### PR TITLE
fix(auth): 🐛explicitly set linkAccount user values

### DIFF
--- a/apps/builder/pages/api/auth/adapter.ts
+++ b/apps/builder/pages/api/auth/adapter.ts
@@ -42,7 +42,22 @@ export function CustomAdapter(p: PrismaClient): Adapter {
     },
     updateUser: (data) => p.user.update({ where: { id: data.id }, data }),
     deleteUser: (id) => p.user.delete({ where: { id } }),
-    linkAccount: (data) => p.account.create({ data }) as any,
+    linkAccount: (data) => {
+      return p.account.create({
+        data: {
+          provider: data.provider,
+          type: data.type,
+          providerAccountId: data.providerAccountId,
+          access_token: data.access_token,
+          token_type: data.token_type,
+          expires_at: data.expires_at,
+          refresh_token: data.refresh_token,
+          scope: data.scope,
+          id_token: data.id_token,
+          userId: data.userId,
+        }
+      }) as any
+    },
     unlinkAccount: (provider_providerAccountId) =>
       p.account.delete({ where: { provider_providerAccountId } }) as any,
     async getSessionAndUser(sessionToken) {

--- a/apps/builder/pages/api/auth/adapter.ts
+++ b/apps/builder/pages/api/auth/adapter.ts
@@ -45,16 +45,20 @@ export function CustomAdapter(p: PrismaClient): Adapter {
     linkAccount: (data) => {
       return p.account.create({
         data: {
-          provider: data.provider,
+          userId: data.userId,
           type: data.type,
+          provider: data.provider,
           providerAccountId: data.providerAccountId,
-          access_token: data.access_token,
-          token_type: data.token_type,
-          expires_at: data.expires_at,
           refresh_token: data.refresh_token,
+          access_token: data.access_token,
+          expires_at: data.expires_at,
+          token_type: data.token_type,
           scope: data.scope,
           id_token: data.id_token,
-          userId: data.userId,
+          session_state: data.session_state,
+          oauth_token_secret: data.oauth_token_secret as string,
+          oauth_token: data.oauth_token as string,
+          refresh_token_expires_in: data.refresh_token_expires_in as number,
         }
       }) as any
     },


### PR DESCRIPTION
Only set the expected values of the user in the linkAccount method. This is necessary because GitLab includes values in the token response that are not expected.

Mentioned in [#10](https://github.com/baptisteArno/typebot.io/issues/10#issuecomment-1088907597)