### PR TITLE
feat(builder): Enable ctrl+z to undo changes in editor

### DIFF
--- a/apps/builder/src/features/editor/components/TypebotHeader/TypebotHeader.tsx
+++ b/apps/builder/src/features/editor/components/TypebotHeader/TypebotHeader.tsx
@@ -27,6 +27,8 @@ import { headerHeight } from '../../constants'
 import { EditableEmojiOrImageIcon } from '@/components/EditableEmojiOrImageIcon'
 import { PublishButton } from '@/features/publish'
 import { CollaborationMenuButton } from '@/features/collaboration'
+import { useUndoShortcut } from '@/hooks/useUndoShortcut'
+
 
 export const TypebotHeader = () => {
   const router = useRouter()
@@ -51,6 +53,8 @@ export const TypebotHeader = () => {
     save().then()
     setRightPanel(RightPanel.PREVIEW)
   }
+
+  useUndoShortcut(canUndo, undo);
 
   const handleHelpClick = () => {
     isCloudProdInstance

--- a/apps/builder/src/hooks/useUndoShortcut.ts
+++ b/apps/builder/src/hooks/useUndoShortcut.ts
@@ -1,11 +1,17 @@
 import { useEventListener } from '@chakra-ui/react'
 
-export const useUndoShortcut = (canUndo: boolean, undo: () => void) => {
+export const useUndoShortcut = (undo: () => void) => {
   const isUndoShortcut = (event: KeyboardEvent) =>
     (event.metaKey || event.ctrlKey) && event.key === 'z'
 
   useEventListener('keydown', (event: KeyboardEvent) => {
-    if (isUndoShortcut(event) && canUndo) {
+    const target = event.target as HTMLElement | null
+    const isTyping =
+      target?.role === 'textbox' ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLInputElement
+    if (isTyping) return
+    if (isUndoShortcut(event)) {
       undo()
     }
   })

--- a/apps/builder/src/hooks/useUndoShortcut.ts
+++ b/apps/builder/src/hooks/useUndoShortcut.ts
@@ -1,0 +1,12 @@
+import { useEventListener } from '@chakra-ui/react'
+
+export const useUndoShortcut = (canUndo: boolean, undo: () => void) => {
+  const isUndoShortcut = (event: KeyboardEvent) =>
+    (event.metaKey || event.ctrlKey) && event.key === 'z'
+
+  useEventListener('keydown', (event: KeyboardEvent) => {
+    if (isUndoShortcut(event) && canUndo) {
+      undo()
+    }
+  })
+}


### PR DESCRIPTION
Added shortcut Ctrl + z requested in task #[217](https://github.com/users/baptisteArno/projects/4/views/1?pane=issue&itemId=17517993)

Closes https://github.com/baptisteArno/typebot.io/issues/217