### PR TITLE
fix(builder): Calculate the completion rate

### DIFF
--- a/apps/builder/src/features/analytics/components/StatsCards.tsx
+++ b/apps/builder/src/features/analytics/components/StatsCards.tsx
@@ -10,6 +10,14 @@ import {
 import { Stats } from 'models'
 import React from 'react'
 
+const computeCompletionRate  = (
+  totalCompleted: number,
+  totalStarts: number
+): string => {
+  if (totalStarts === 0) return 'Not available'
+  return `${Math.round((totalCompleted / totalStarts) * 100)}%`
+}
+
 export const StatsCards = ({
   stats,
   ...props
@@ -38,7 +46,7 @@ export const StatsCards = ({
         <StatLabel>Completion rate</StatLabel>
         {stats ? (
           <StatNumber>
-            {Math.round((stats.totalCompleted / stats.totalStarts) * 100)}%
+            {computeCompletionRate(stats.totalCompleted, stats.totalStarts)}
           </StatNumber>
         ) : (
           <Skeleton w="50%" h="10px" mt="2" />


### PR DESCRIPTION
Calculate the completion rate if both totalCompleted and totalStarts are defined and are not zero

![image](https://user-images.githubusercontent.com/581672/212729033-3c1e8adb-961f-49d0-be1f-859640ab93ff.png)

Closes #244
