### PR TITLE
🐛 Fix example

### DIFF
--- a/packages/embeds/react/README.md
+++ b/packages/embeds/react/README.md
@@ -85,13 +85,13 @@ This code will show the bubble and let a preview message appear after 5 seconds.
 You can use these commands:
 
 ```js
-import * as Typebot from '@typebot.io/js'
+import { showPreviewMessage } from '@typebot.io/js'
 
 Typebot.showPreviewMessage()
 ```
 
 ```js
-import * as Typebot from '@typebot.io/js'
+import { hidePreviewMessage } from '@typebot.io/js'
 
 Typebot.hidePreviewMessage()
 ```

--- a/packages/embeds/react/README.md
+++ b/packages/embeds/react/README.md
@@ -38,19 +38,19 @@ This code will automatically trigger the popup window after 3 seconds.
 You can use these commands:
 
 ```js
-import { open } from '@typebot.io/react'
+import { open } from '@typebot.io/js'
 
 open()
 ```
 
 ```js
-import { close } from '@typebot.io/react'
+import { close } from '@typebot.io/js'
 
 close()
 ```
 
 ```js
-import { toggle } from '@typebot.io/react'
+import { toggle } from '@typebot.io/js'
 
 toggle()
 ```
@@ -85,13 +85,13 @@ This code will show the bubble and let a preview message appear after 5 seconds.
 You can use these commands:
 
 ```js
-import { showPreviewMessage } from '@typebot.io/react'
+import * as Typebot from '@typebot.io/js'
 
 Typebot.showPreviewMessage()
 ```
 
 ```js
-import { hidePreviewMessage } from '@typebot.io/react'
+import * as Typebot from '@typebot.io/js'
 
 Typebot.hidePreviewMessage()
 ```
@@ -101,19 +101,19 @@ Typebot.hidePreviewMessage()
 You can use these commands:
 
 ```js
-import { open } from '@typebot.io/react'
+import { open } from '@typebot.io/js'
 
 open()
 ```
 
 ```js
-import { close } from '@typebot.io/react'
+import { close } from '@typebot.io/js'
 
 close()
 ```
 
 ```js
-import { toggle } from '@typebot.io/react'
+import { toggle } from '@typebot.io/js'
 
 toggle()
 ```


### PR DESCRIPTION
open, close and toggle are apparently exported from @typebot.io/js package or at least that's what worked for me, I was getting unknown function error when trying to import them from @typebot/react

aslo in order for Typebot.showPreviewMessage() and Typebot.hidePreviewMessage() to work, I need to import all exports as Typebot, otherwise it didn't seem to have the named exports "showPreviewMessage" nor "hidePreviewMessage", since I was also getting an error when trying to import them.

this is my first PR here, I apologise for mistakes upfront.

It's ok if it is not meged, I just wanted to catch your attention on this potential update required in the documentation of react embed