### PR TITLE
Support specifying custom OAuth scope

### DIFF
--- a/apps/builder/src/pages/api/auth/[...nextauth].ts
+++ b/apps/builder/src/pages/api/auth/[...nextauth].ts
@@ -119,6 +119,11 @@ if (isNotEmpty(process.env.CUSTOM_OAUTH_WELL_KNOWN_URL)) {
     id: 'custom-oauth',
     name: process.env.CUSTOM_OAUTH_NAME ?? 'Custom OAuth',
     type: 'oauth',
+    authorization: {
+      params: {
+        scope: process.env.CUSTOM_OAUTH_SCOPE ?? 'openid profile email'
+      }
+    },
     clientId: process.env.CUSTOM_OAUTH_CLIENT_ID,
     clientSecret: process.env.CUSTOM_OAUTH_CLIENT_SECRET,
     wellKnown: process.env.CUSTOM_OAUTH_WELL_KNOWN_URL,

--- a/apps/docs/docs/self-hosting/configuration/builder.mdx
+++ b/apps/docs/docs/self-hosting/configuration/builder.mdx
@@ -123,6 +123,7 @@ The Authorization callback URL should be `$NEXTAUTH_URL/api/auth/callback/azure-
 | CUSTOM_OAUTH_USER_NAME_PATH  | name         | Used to map the name from the user info object                                          |
 | CUSTOM_OAUTH_USER_EMAIL_PATH | email        | Used to map the email from the user info object                                         |
 | CUSTOM_OAUTH_USER_IMAGE_PATH | image        | Used to map the image from the user info object                                         |
+| CUSTOM_OAUTH_SCOPE | openid profile email | OAuth scope                                        |
 
 For `*_PATH` parameters, you can use dot notation to access nested properties (i.e. `account.name`).
 


### PR DESCRIPTION
For OpenID connect over OAuth, at least `openid profile` need to be set there, but since the email is also used, the `email` scope will instruct the OpenID provider to also deliver that.