### PR TITLE
:zap: (setVariable) Add "Environment name" value in Set variable block

### DIFF
--- a/apps/builder/src/features/blocks/logic/setVariable/components/SetVariableContent.tsx
+++ b/apps/builder/src/features/blocks/logic/setVariable/components/SetVariableContent.tsx
@@ -62,6 +62,7 @@ const Expression = ({
     case 'Tomorrow':
     case 'User ID':
     case 'Moment of the day':
+    case 'Environment name':
     case 'Yesterday': {
       return (
         <Text as="span">

--- a/apps/builder/src/features/blocks/logic/setVariable/components/SetVariableSettings.tsx
+++ b/apps/builder/src/features/blocks/logic/setVariable/components/SetVariableSettings.tsx
@@ -158,6 +158,17 @@ const SetVariableValue = ({
         </Alert>
       )
     }
+    case 'Environment name': {
+      return (
+        <Alert fontSize="sm">
+          <AlertIcon />
+          <Text>
+            Will return either <Tag size="sm">web</Tag> or{' '}
+            <Tag size="sm">whatsapp</Tag>.
+          </Text>
+        </Alert>
+      )
+    }
     case 'Contact name':
     case 'Phone number':
     case 'Random ID':

--- a/apps/docs/openapi/builder/_spec_.json
+++ b/apps/docs/openapi/builder/_spec_.json
@@ -1979,6 +1979,7 @@
                                                 "enum": [
                                                   "Custom",
                                                   "Empty",
+                                                  "Environment name",
                                                   "User ID",
                                                   "Now",
                                                   "Today",
@@ -6367,6 +6368,7 @@
                                             "enum": [
                                               "Custom",
                                               "Empty",
+                                              "Environment name",
                                               "User ID",
                                               "Now",
                                               "Today",
@@ -10396,6 +10398,7 @@
                                               "enum": [
                                                 "Custom",
                                                 "Empty",
+                                                "Environment name",
                                                 "User ID",
                                                 "Now",
                                                 "Today",
@@ -14565,6 +14568,7 @@
                                             "enum": [
                                               "Custom",
                                               "Empty",
+                                              "Environment name",
                                               "User ID",
                                               "Now",
                                               "Today",
@@ -18614,6 +18618,7 @@
                                               "enum": [
                                                 "Custom",
                                                 "Empty",
+                                                "Environment name",
                                                 "User ID",
                                                 "Now",
                                                 "Today",
@@ -22718,6 +22723,7 @@
                                               "enum": [
                                                 "Custom",
                                                 "Empty",
+                                                "Environment name",
                                                 "User ID",
                                                 "Now",
                                                 "Today",
@@ -26885,6 +26891,7 @@
                                               "enum": [
                                                 "Custom",
                                                 "Empty",
+                                                "Environment name",
                                                 "User ID",
                                                 "Now",
                                                 "Today",

--- a/apps/docs/openapi/chat/_spec_.json
+++ b/apps/docs/openapi/chat/_spec_.json
@@ -1574,6 +1574,7 @@
                                                     "enum": [
                                                       "Custom",
                                                       "Empty",
+                                                      "Environment name",
                                                       "User ID",
                                                       "Now",
                                                       "Today",

--- a/packages/bot-engine/blocks/logic/setVariable/executeSetVariable.ts
+++ b/packages/bot-engine/blocks/logic/setVariable/executeSetVariable.ts
@@ -77,9 +77,11 @@ const getExpressionToEvaluate =
   (options: SetVariableBlock['options']): string | null => {
     switch (options.type) {
       case 'Contact name':
-        return state.whatsApp?.contact.name ?? ''
-      case 'Phone number':
-        return `"${state.whatsApp?.contact.phoneNumber}"` ?? ''
+        return state.whatsApp?.contact.name ?? null
+      case 'Phone number': {
+        const phoneNumber = state.whatsApp?.contact.phoneNumber
+        return phoneNumber ? `"${state.whatsApp?.contact.phoneNumber}"` : null
+      }
       case 'Now':
       case 'Today':
         return 'new Date().toISOString()'
@@ -111,6 +113,9 @@ const getExpressionToEvaluate =
         if(now.getHours() >= 12 && now.getHours() < 18) return 'afternoon'
         if(now.getHours() >= 18) return 'evening'
         if(now.getHours() >= 22 || now.getHours() < 6) return 'night'`
+      }
+      case 'Environment name': {
+        return state.whatsApp?.contact.name ? 'whatsapp' : 'web'
       }
       case 'Custom':
       case undefined: {

--- a/packages/bot-engine/blocks/logic/setVariable/executeSetVariable.ts
+++ b/packages/bot-engine/blocks/logic/setVariable/executeSetVariable.ts
@@ -115,7 +115,7 @@ const getExpressionToEvaluate =
         if(now.getHours() >= 22 || now.getHours() < 6) return 'night'`
       }
       case 'Environment name': {
-        return state.whatsApp?.contact.name ? 'whatsapp' : 'web'
+        return state.whatsApp ? 'whatsapp' : 'web'
       }
       case 'Custom':
       case undefined: {

--- a/packages/bot-engine/startSession.ts
+++ b/packages/bot-engine/startSession.ts
@@ -30,11 +30,13 @@ import { injectVariablesFromExistingResult } from './variables/injectVariablesFr
 type Props = {
   startParams: StartParams
   userId: string | undefined
+  initialSessionState?: Pick<SessionState, 'whatsApp' | 'expiryTimeout'>
 }
 
 export const startSession = async ({
   startParams,
   userId,
+  initialSessionState,
 }: Props): Promise<ChatReply & { newSessionState: SessionState }> => {
   if (!startParams)
     throw new TRPCError({
@@ -108,6 +110,7 @@ export const startSession = async ({
     dynamicTheme: parseDynamicThemeInState(typebot.theme),
     isStreamEnabled: startParams.isStreamEnabled,
     typingEmulation: typebot.settings.typingEmulation,
+    ...initialSessionState,
   }
 
   if (startParams.isOnlyRegistering) {

--- a/packages/bot-engine/whatsapp/resumeWhatsAppFlow.ts
+++ b/packages/bot-engine/whatsapp/resumeWhatsAppFlow.ts
@@ -46,16 +46,6 @@ export const resumeWhatsAppFlow = async ({
     typebotId: typebot?.id,
   })
 
-  const sessionState =
-    isPreview && session?.state
-      ? ({
-          ...session?.state,
-          whatsApp: {
-            contact,
-          },
-        } satisfies SessionState)
-      : session?.state
-
   const credentials = await getCredentials({ credentialsId, isPreview })
 
   if (!credentials) {
@@ -71,8 +61,8 @@ export const resumeWhatsAppFlow = async ({
     session?.updatedAt.getTime() + session.state.expiryTimeout < Date.now()
 
   const resumeResponse =
-    sessionState && !isSessionExpired
-      ? await continueBotFlow(sessionState)(messageContent)
+    session && !isSessionExpired
+      ? await continueBotFlow(session.state)(messageContent)
       : workspaceId
       ? await startWhatsAppSession({
           incomingMessage: messageContent,

--- a/packages/schemas/features/blocks/logic/setVariable.ts
+++ b/packages/schemas/features/blocks/logic/setVariable.ts
@@ -5,6 +5,7 @@ import { LogicBlockType } from './enums'
 export const valueTypes = [
   'Custom',
   'Empty',
+  'Environment name',
   'User ID',
   'Now',
   'Today',


### PR DESCRIPTION
Closes #848
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added "Environment name" as a new value type in the SetVariable function, allowing users to distinguish between 'web' and 'whatsapp' environments.
- Refactor: Simplified session state handling in `resumeWhatsAppFlow.ts` for improved code clarity.
- Refactor: Updated `startWhatsAppSession.ts` to include an initial session state with WhatsApp contact and expiry timeout, enhancing session management.
- Bug Fix: Improved null handling in `executeSetVariable.ts` for 'Contact name' and 'Phone number', preventing potential issues with falsy values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->