### PR TITLE
bubble chat height and width

### DIFF
--- a/packages/embeds/js/src/features/bubble/components/Bubble.tsx
+++ b/packages/embeds/js/src/features/bubble/components/Bubble.tsx
@@ -20,6 +20,8 @@ export type BubbleProps = BotProps &
     onOpen?: () => void
     onClose?: () => void
     onPreviewMessageClick?: () => void
+    height?: string; 
+    width?: string;
   }
 
 export const Bubble = (props: BubbleProps) => {
@@ -148,7 +150,8 @@ export const Bubble = (props: BubbleProps) => {
       <div
         part="bot"
         style={{
-          height: 'calc(100% - 80px)',
+          height: props.height ?? 'calc(100% - 80px)',
+          width: props.width ?? '100%',
           transition:
             'transform 200ms cubic-bezier(0, 1.2, 1, 1), opacity 150ms ease-out',
           'transform-origin':

--- a/packages/embeds/js/src/features/bubble/types.ts
+++ b/packages/embeds/js/src/features/bubble/types.ts
@@ -9,6 +9,8 @@ export type BubbleTheme = {
   button?: ButtonTheme
   previewMessage?: PreviewMessageTheme
   placement?: 'left' | 'right'
+  height?: string;
+  width?: string;
 }
 
 export type ChatWindowTheme = {


### PR DESCRIPTION
/fixes #458 
/claim #458
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced customization options for chat bubble dimensions in our chat interface. Users can now specify the height and width of the chat bubbles, providing a more personalized user experience. If no dimensions are provided, the system will use default values, ensuring a consistent look and feel. This enhancement offers a more flexible and visually appealing chat environment, contributing to improved user engagement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->