### PR TITLE
Fixed pinch zooming mouse issue(with ctrl key)

### DIFF
--- a/apps/builder/src/features/graph/components/Graph.tsx
+++ b/apps/builder/src/features/graph/components/Graph.tsx
@@ -171,7 +171,12 @@ export const Graph = ({
   }) => {
     const { x: mouseX, y } = mousePosition ?? getCenterOfGraph()
     const mouseY = y - headerHeight
-    let newScale = scale ?? graphPosition.scale + (delta ?? 0)
+    let newScale = graphPosition.scale + (delta ?? 0)
+    if (scale) {
+      const scaleDiff = scale - graphPosition.scale;
+      newScale += Math.min(zoomButtonsScaleBlock, Math.abs(scaleDiff)) * Math.sign(scaleDiff);
+    }
+
     if (
       (newScale >= maxScale && graphPosition.scale === maxScale) ||
       (newScale <= minScale && graphPosition.scale === minScale)

--- a/apps/builder/src/features/graph/components/Graph.tsx
+++ b/apps/builder/src/features/graph/components/Graph.tsx
@@ -173,8 +173,8 @@ export const Graph = ({
     const mouseY = y - headerHeight
     let newScale = graphPosition.scale + (delta ?? 0)
     if (scale) {
-      const scaleDiff = scale - graphPosition.scale;
-      newScale += Math.min(zoomButtonsScaleBlock, Math.abs(scaleDiff)) * Math.sign(scaleDiff);
+      const scaleDiff = scale - graphPosition.scale
+      newScale += Math.min(zoomButtonsScaleBlock, Math.abs(scaleDiff)) * Math.sign(scaleDiff)
     }
 
     if (


### PR DESCRIPTION
**Fixed the drastic zoom increase decrease on ctrl + mouse scroll.**

The issue was occuring due to the "scale" property in the pinch gesture. The scale was getting bigger values, leading to more zooming.
What I did was, made sure that maximum scale difference between current and last value cannot be more than the scaling factor used in zoomin/zoomout buttons. That is. 0.2
Also, the pinch zoom would work as expected.

/claim #567