### PR TITLE
Made bubble height width configurable through props.

### DIFF
--- a/apps/builder/src/features/blocks/integrations/webhook/helpers/getDeepKeys.ts
+++ b/apps/builder/src/features/blocks/integrations/webhook/helpers/getDeepKeys.ts
@@ -42,7 +42,9 @@ export const getDeepKeys = (obj: any): string[] => {
 
 const parseKey = (key: string) => {
   if (
-    (key.includes(' ') || key.includes('-')) &&
+    (key.includes(' ') ||
+      key.includes('-') ||
+      !isNaN(key as unknown as number)) &&
     !key.includes('.flatMap(item => item') &&
     !key.includes("['") &&
     !key.includes("']")

--- a/packages/embeds/js/src/features/bubble/components/Bubble.tsx
+++ b/packages/embeds/js/src/features/bubble/components/Bubble.tsx
@@ -152,7 +152,6 @@ export const Bubble = (props: BubbleProps) => {
         style={{
           height: props.height ?? 'calc(100% - 80px)',
           width: props.width ?? '100%!important',
-          'max-height': 'calc(100% - 80px)',
           transition:
             'transform 200ms cubic-bezier(0, 1.2, 1, 1), opacity 150ms ease-out',
           'transform-origin':

--- a/packages/embeds/js/src/features/bubble/components/Bubble.tsx
+++ b/packages/embeds/js/src/features/bubble/components/Bubble.tsx
@@ -20,6 +20,8 @@ export type BubbleProps = BotProps &
     onOpen?: () => void
     onClose?: () => void
     onPreviewMessageClick?: () => void
+    height?: string
+    width?: string
   }
 
 export const Bubble = (props: BubbleProps) => {
@@ -148,7 +150,9 @@ export const Bubble = (props: BubbleProps) => {
       <div
         part="bot"
         style={{
-          height: 'calc(100% - 80px)',
+          height: props.height ?? 'calc(100% - 80px)',
+          width: props.width ?? '100%!important',
+          'max-height': 'calc(100% - 80px)',
           transition:
             'transform 200ms cubic-bezier(0, 1.2, 1, 1), opacity 150ms ease-out',
           'transform-origin':
@@ -159,7 +163,7 @@ export const Bubble = (props: BubbleProps) => {
           'z-index': 42424242,
         }}
         class={
-          'fixed rounded-lg w-full sm:w-[400px] max-h-[704px]' +
+          'fixed rounded-lg sm:w-[400px] max-h-[704px]' +
           (isBotOpened() ? ' opacity-1' : ' opacity-0 pointer-events-none') +
           (props.theme?.button?.size === 'large'
             ? ' bottom-24'

--- a/packages/embeds/js/src/features/bubble/types.ts
+++ b/packages/embeds/js/src/features/bubble/types.ts
@@ -8,7 +8,9 @@ export type BubbleTheme = {
   chatWindow?: ChatWindowTheme
   button?: ButtonTheme
   previewMessage?: PreviewMessageTheme
-  placement?: 'left' | 'right'
+  placement?: 'left' | 'right',
+  height?: string
+  width?: string
 }
 
 export type ChatWindowTheme = {


### PR DESCRIPTION
/claim #458
Made bubble height width configurable through props.

Please find default height width screenshot below.

<img width="960" alt="image" src="https://github.com/baptisteArno/typebot.io/assets/29385192/82f3b9a5-d616-40db-bd64-45da24c0d9bc">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: Introduced customizable dimensions for chat bubbles. Users can now specify the height and width of the chat bubbles, providing greater flexibility in adapting the chat interface to different layouts and designs. If no dimensions are specified, the system will use default values, ensuring a consistent user experience. This update enhances the visual adaptability of our chat feature, making it more user-friendly and versatile for various display settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->