### PR TITLE
fix: whole page overflowing on the x axis and displaying a horizontal scrollbar

### DIFF
--- a/apps/landing-page/components/Homepage/RealTimeResults.tsx
+++ b/apps/landing-page/components/Homepage/RealTimeResults.tsx
@@ -85,6 +85,7 @@ export const RealTimeResults = () => {
           w="full"
           direction={['column', 'row']}
           spacing="4"
+          pos="relative"
           data-aos="fade"
         >
           {typebot && (


### PR DESCRIPTION
this PR fixes issue https://github.com/baptisteArno/typebot.io/issues/1008 by making the position of `HandDrawnArrow`'s parent relative, which confines the absolute position of its children to be within the bounds of the parent, causing layout not shift due to `right -30px`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the layout behavior of the `RealTimeResults` component on the landing page for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->