### PR TITLE
:passport_control: (billing) Add isPastDue field in workspace

### DIFF
--- a/apps/builder/src/features/blocks/logic/typebotLink/api/getLinkedTypebots.ts
+++ b/apps/builder/src/features/blocks/logic/typebotLink/api/getLinkedTypebots.ts
@@ -56,7 +56,17 @@ export const getLinkedTypebots = authenticatedProcedure
         variables: true,
         name: true,
         createdAt: true,
-        workspaceId: true,
+        workspace: {
+          select: {
+            isQuarantined: true,
+            isPastDue: true,
+            members: {
+              select: {
+                userId: true,
+              },
+            },
+          },
+        },
         collaborators: {
           select: {
             type: true,
@@ -97,7 +107,17 @@ export const getLinkedTypebots = authenticatedProcedure
           variables: true,
           name: true,
           createdAt: true,
-          workspaceId: true,
+          workspace: {
+            select: {
+              isQuarantined: true,
+              isPastDue: true,
+              members: {
+                select: {
+                  userId: true,
+                },
+              },
+            },
+          },
           collaborators: {
             select: {
               type: true,

--- a/apps/builder/src/features/collaboration/api/getCollaborators.ts
+++ b/apps/builder/src/features/collaboration/api/getCollaborators.ts
@@ -32,6 +32,17 @@ export const getCollaborators = authenticatedProcedure
       },
       include: {
         collaborators: true,
+        workspace: {
+          select: {
+            isQuarantined: true,
+            isPastDue: true,
+            members: {
+              select: {
+                userId: true,
+              },
+            },
+          },
+        },
       },
     })
     if (

--- a/apps/builder/src/features/results/api/deleteResults.ts
+++ b/apps/builder/src/features/results/api/deleteResults.ts
@@ -36,8 +36,19 @@ export const deleteResults = authenticatedProcedure
         id: typebotId,
       },
       select: {
-        workspaceId: true,
         groups: true,
+        workspace: {
+          select: {
+            isQuarantined: true,
+            isPastDue: true,
+            members: {
+              select: {
+                userId: true,
+                role: true,
+              },
+            },
+          },
+        },
         collaborators: {
           select: {
             userId: true,

--- a/apps/builder/src/features/results/api/getResult.ts
+++ b/apps/builder/src/features/results/api/getResult.ts
@@ -33,8 +33,18 @@ export const getResult = authenticatedProcedure
       },
       select: {
         id: true,
-        workspaceId: true,
         groups: true,
+        workspace: {
+          select: {
+            isQuarantined: true,
+            isPastDue: true,
+            members: {
+              select: {
+                userId: true,
+              },
+            },
+          },
+        },
         collaborators: {
           select: {
             userId: true,

--- a/apps/builder/src/features/results/api/getResultLogs.ts
+++ b/apps/builder/src/features/results/api/getResultLogs.ts
@@ -28,8 +28,18 @@ export const getResultLogs = authenticatedProcedure
       },
       select: {
         id: true,
-        workspaceId: true,
         groups: true,
+        workspace: {
+          select: {
+            isQuarantined: true,
+            isPastDue: true,
+            members: {
+              select: {
+                userId: true,
+              },
+            },
+          },
+        },
         collaborators: {
           select: {
             userId: true,

--- a/apps/builder/src/features/results/api/getResults.ts
+++ b/apps/builder/src/features/results/api/getResults.ts
@@ -44,12 +44,22 @@ export const getResults = authenticatedProcedure
       },
       select: {
         id: true,
-        workspaceId: true,
         groups: true,
         collaborators: {
           select: {
             userId: true,
             type: true,
+          },
+        },
+        workspace: {
+          select: {
+            isQuarantined: true,
+            isPastDue: true,
+            members: {
+              select: {
+                userId: true,
+              },
+            },
           },
         },
       },

--- a/apps/builder/src/features/telemetry/api/processTelemetryEvent.ts
+++ b/apps/builder/src/features/telemetry/api/processTelemetryEvent.ts
@@ -81,7 +81,7 @@ export const processTelemetryEvent = authenticatedProcedure
       client.capture({
         distinctId: event.userId,
         event: event.name,
-        properties: event.data,
+        properties: 'data' in event ? event.data : undefined,
         groups,
       })
     })

--- a/apps/builder/src/features/typebot/api/deleteTypebot.ts
+++ b/apps/builder/src/features/typebot/api/deleteTypebot.ts
@@ -33,8 +33,19 @@ export const deleteTypebot = authenticatedProcedure
       },
       select: {
         id: true,
-        workspaceId: true,
         groups: true,
+        workspace: {
+          select: {
+            isQuarantined: true,
+            isPastDue: true,
+            members: {
+              select: {
+                userId: true,
+                role: true,
+              },
+            },
+          },
+        },
         collaborators: {
           select: {
             userId: true,

--- a/apps/builder/src/features/typebot/api/getPublishedTypebot.ts
+++ b/apps/builder/src/features/typebot/api/getPublishedTypebot.ts
@@ -52,6 +52,17 @@ export const getPublishedTypebot = authenticatedProcedure
         include: {
           collaborators: true,
           publishedTypebot: true,
+          workspace: {
+            select: {
+              isQuarantined: true,
+              isPastDue: true,
+              members: {
+                select: {
+                  userId: true,
+                },
+              },
+            },
+          },
         },
       })
       if (

--- a/apps/builder/src/features/typebot/api/getTypebot.ts
+++ b/apps/builder/src/features/typebot/api/getTypebot.ts
@@ -41,6 +41,17 @@ export const getTypebot = authenticatedProcedure
         },
         include: {
           collaborators: true,
+          workspace: {
+            select: {
+              isQuarantined: true,
+              isPastDue: true,
+              members: {
+                select: {
+                  userId: true,
+                },
+              },
+            },
+          },
         },
       })
       if (

--- a/apps/builder/src/features/typebot/api/publishTypebot.ts
+++ b/apps/builder/src/features/typebot/api/publishTypebot.ts
@@ -46,6 +46,14 @@ export const publishTypebot = authenticatedProcedure
         workspace: {
           select: {
             plan: true,
+            isQuarantined: true,
+            isPastDue: true,
+            members: {
+              select: {
+                userId: true,
+                role: true,
+              },
+            },
           },
         },
       },

--- a/apps/builder/src/features/typebot/api/unpublishTypebot.ts
+++ b/apps/builder/src/features/typebot/api/unpublishTypebot.ts
@@ -32,6 +32,18 @@ export const unpublishTypebot = authenticatedProcedure
       include: {
         collaborators: true,
         publishedTypebot: true,
+        workspace: {
+          select: {
+            isQuarantined: true,
+            isPastDue: true,
+            members: {
+              select: {
+                userId: true,
+                role: true,
+              },
+            },
+          },
+        },
       },
     })
     if (!existingTypebot?.publishedTypebot)

--- a/apps/builder/src/features/typebot/api/updateTypebot.ts
+++ b/apps/builder/src/features/typebot/api/updateTypebot.ts
@@ -79,7 +79,6 @@ export const updateTypebot = authenticatedProcedure
           id: true,
           customDomain: true,
           publicId: true,
-          workspaceId: true,
           collaborators: {
             select: {
               userId: true,
@@ -88,7 +87,16 @@ export const updateTypebot = authenticatedProcedure
           },
           workspace: {
             select: {
+              id: true,
               plan: true,
+              isQuarantined: true,
+              isPastDue: true,
+              members: {
+                select: {
+                  userId: true,
+                  role: true,
+                },
+              },
             },
           },
           updatedAt: true,
@@ -160,7 +168,7 @@ export const updateTypebot = authenticatedProcedure
           selectedThemeTemplateId: typebot.selectedThemeTemplateId,
           events: typebot.events ?? undefined,
           groups: typebot.groups
-            ? await sanitizeGroups(existingTypebot.workspaceId)(typebot.groups)
+            ? await sanitizeGroups(existingTypebot.workspace.id)(typebot.groups)
             : undefined,
           theme: typebot.theme ? typebot.theme : undefined,
           settings: typebot.settings

--- a/apps/builder/src/features/upload/api/generateUploadUrl.ts
+++ b/apps/builder/src/features/upload/api/generateUploadUrl.ts
@@ -147,7 +147,19 @@ const parseFilePath = async ({
       id: input.typebotId,
     },
     select: {
-      workspaceId: true,
+      workspace: {
+        select: {
+          plan: true,
+          isQuarantined: true,
+          isPastDue: true,
+          members: {
+            select: {
+              userId: true,
+              role: true,
+            },
+          },
+        },
+      },
       collaborators: {
         select: {
           userId: true,

--- a/apps/builder/src/features/whatsapp/startWhatsAppPreview.ts
+++ b/apps/builder/src/features/whatsapp/startWhatsAppPreview.ts
@@ -57,7 +57,17 @@ export const startWhatsAppPreview = authenticatedProcedure
       },
       select: {
         id: true,
-        workspaceId: true,
+        workspace: {
+          select: {
+            isQuarantined: true,
+            isPastDue: true,
+            members: {
+              select: {
+                userId: true,
+              },
+            },
+          },
+        },
         collaborators: {
           select: {
             userId: true,

--- a/apps/builder/src/features/workspace/WorkspaceProvider.tsx
+++ b/apps/builder/src/features/workspace/WorkspaceProvider.tsx
@@ -6,7 +6,7 @@ import {
   useMemo,
   useState,
 } from 'react'
-import { byId, isNotDefined } from '@typebot.io/lib'
+import { byId } from '@typebot.io/lib'
 import { WorkspaceRole } from '@typebot.io/prisma'
 import { useRouter } from 'next/router'
 import { trpc } from '@/lib/trpc'
@@ -136,16 +136,20 @@ export const WorkspaceProvider = ({
   ])
 
   useEffect(() => {
-    if (isNotDefined(workspace?.isSuspended)) return
-    if (workspace?.isSuspended && pathname !== '/suspended') push('/suspended')
-  }, [pathname, push, workspace?.isSuspended])
+    if (workspace?.isSuspended) {
+      if (pathname === '/suspended') return
+      push('/suspended')
+      return
+    }
+    if (workspace?.isPastDue) {
+      if (pathname === '/past-due') return
+      push('/past-due')
+      return
+    }
+  }, [pathname, push, workspace?.isPastDue, workspace?.isSuspended])
 
   const switchWorkspace = (workspaceId: string) => {
     setWorkspaceIdInLocalStorage(workspaceId)
-    if (pathname === '/suspended') {
-      window.location.href = '/typebots'
-      return
-    }
     setWorkspaceId(workspaceId)
   }
 

--- a/apps/builder/src/pages/past-due.tsx
+++ b/apps/builder/src/pages/past-due.tsx
@@ -1,7 +1,8 @@
-import { TextLink } from '@/components/TextLink'
+import { AlertIcon } from '@/components/icons'
+import { BillingPortalButton } from '@/features/billing/components/BillingPortalButton'
 import { DashboardHeader } from '@/features/dashboard/components/DashboardHeader'
 import { useWorkspace } from '@/features/workspace/WorkspaceProvider'
-import { Heading, Text, VStack } from '@chakra-ui/react'
+import { Heading, VStack, Text } from '@chakra-ui/react'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 
@@ -10,7 +11,7 @@ export default function Page() {
   const { workspace } = useWorkspace()
 
   useEffect(() => {
-    if (!workspace || workspace.isSuspended) return
+    if (!workspace || workspace.isPastDue) return
     replace('/typebots')
   }, [replace, workspace])
 
@@ -23,16 +24,12 @@ export default function Page() {
         justifyContent="center"
         spacing={4}
       >
-        <Heading>Your workspace has been suspended.</Heading>
-        <Text>
-          We detected that one of your typebots does not comply with our{' '}
-          <TextLink
-            href="https://typebot.io/terms-of-service#scam-typebots"
-            isExternal
-          >
-            terms of service
-          </TextLink>
-        </Text>
+        <AlertIcon fontSize="4xl" />
+        <Heading fontSize="2xl">Your workspace has unpaid invoice(s).</Heading>
+        <Text>Head over to the billing portal to pay it.</Text>
+        {workspace?.id && (
+          <BillingPortalButton workspaceId={workspace?.id} colorScheme="blue" />
+        )}
       </VStack>
     </>
   )

--- a/apps/docs/openapi/builder/_spec_.json
+++ b/apps/docs/openapi/builder/_spec_.json
@@ -415,6 +415,52 @@
                             "data"
                           ],
                           "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "userId": {
+                              "type": "string"
+                            },
+                            "workspaceId": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string",
+                              "enum": [
+                                "Workspace past due"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "userId",
+                            "workspaceId",
+                            "name"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "userId": {
+                              "type": "string"
+                            },
+                            "workspaceId": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string",
+                              "enum": [
+                                "Workspace past due status removed"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "userId",
+                            "workspaceId",
+                            "name"
+                          ],
+                          "additionalProperties": false
                         }
                       ]
                     }
@@ -7487,6 +7533,9 @@
                         },
                         "isSuspended": {
                           "type": "boolean"
+                        },
+                        "isPastDue": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -7507,7 +7556,8 @@
                         "customStorageLimit",
                         "customSeatsLimit",
                         "isQuarantined",
-                        "isSuspended"
+                        "isSuspended",
+                        "isPastDue"
                       ],
                       "additionalProperties": false
                     }
@@ -7636,6 +7686,9 @@
                         },
                         "isSuspended": {
                           "type": "boolean"
+                        },
+                        "isPastDue": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -7656,7 +7709,8 @@
                         "customStorageLimit",
                         "customSeatsLimit",
                         "isQuarantined",
-                        "isSuspended"
+                        "isSuspended",
+                        "isPastDue"
                       ],
                       "additionalProperties": false
                     }
@@ -7802,6 +7856,9 @@
                         },
                         "isSuspended": {
                           "type": "boolean"
+                        },
+                        "isPastDue": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -7822,7 +7879,8 @@
                         "customStorageLimit",
                         "customSeatsLimit",
                         "isQuarantined",
-                        "isSuspended"
+                        "isSuspended",
+                        "isPastDue"
                       ],
                       "additionalProperties": false
                     }
@@ -54515,6 +54573,9 @@
                         },
                         "isSuspended": {
                           "type": "boolean"
+                        },
+                        "isPastDue": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -54535,7 +54596,8 @@
                         "customStorageLimit",
                         "customSeatsLimit",
                         "isQuarantined",
-                        "isSuspended"
+                        "isSuspended",
+                        "isPastDue"
                       ],
                       "additionalProperties": false,
                       "nullable": true

--- a/packages/prisma/mysql/schema.prisma
+++ b/packages/prisma/mysql/schema.prisma
@@ -97,6 +97,7 @@ model Workspace {
   customSeatsLimit              Int?
   isQuarantined                 Boolean               @default(false)
   isSuspended                   Boolean               @default(false)
+  isPastDue                     Boolean               @default(false)
   themeTemplates                ThemeTemplate[]
 }
 

--- a/packages/prisma/postgresql/migrations/20231121154057_add_is_past_due_field/migration.sql
+++ b/packages/prisma/postgresql/migrations/20231121154057_add_is_past_due_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Workspace" ADD COLUMN     "isPastDue" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/postgresql/schema.prisma
+++ b/packages/prisma/postgresql/schema.prisma
@@ -91,6 +91,7 @@ model Workspace {
   customSeatsLimit              Int?
   isQuarantined                 Boolean               @default(false)
   isSuspended                   Boolean               @default(false)
+  isPastDue                     Boolean               @default(false)
   themeTemplates                ThemeTemplate[]
 }
 

--- a/packages/schemas/features/telemetry.ts
+++ b/packages/schemas/features/telemetry.ts
@@ -105,6 +105,18 @@ const workspaceAutoQuarantinedEventSchema = workspaceEvent.merge(
   })
 )
 
+export const workspacePastDueEventSchema = workspaceEvent.merge(
+  z.object({
+    name: z.literal('Workspace past due'),
+  })
+)
+
+export const workspaceNotPastDueEventSchema = workspaceEvent.merge(
+  z.object({
+    name: z.literal('Workspace past due status removed'),
+  })
+)
+
 export const eventSchema = z.discriminatedUnion('name', [
   workspaceCreatedEventSchema,
   userCreatedEventSchema,
@@ -115,6 +127,8 @@ export const eventSchema = z.discriminatedUnion('name', [
   workspaceLimitReachedEventSchema,
   workspaceAutoQuarantinedEventSchema,
   subscriptionAutoUpdatedEventSchema,
+  workspacePastDueEventSchema,
+  workspaceNotPastDueEventSchema,
 ])
 
 export type TelemetryEvent = z.infer<typeof eventSchema>

--- a/packages/schemas/features/workspace.ts
+++ b/packages/schemas/features/workspace.ts
@@ -50,6 +50,7 @@ export const workspaceSchema = z.object({
   customSeatsLimit: z.number().nullable(),
   isQuarantined: z.boolean(),
   isSuspended: z.boolean(),
+  isPastDue: z.boolean(),
 }) satisfies z.ZodType<WorkspacePrisma>
 
 export type Workspace = z.infer<typeof workspaceSchema>


### PR DESCRIPTION
Closes #1039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspaces now include additional status indicator: `isPastDue`.
  - New pages for handling workspaces that are past due. Meaning, an invoice is unpaid.

- **Bug Fixes**
  - Fixed issues with workspace status checks and redirections for suspended workspaces.

- **Refactor**
  - Refactored workspace-related API functions to accommodate new status fields.
  - Improved permission checks for reading and writing typebots based on workspace status.

- **Chores**
  - Database schema updated to include `isPastDue` field for workspaces.
  - Implemented new webhook event handling for subscription and invoice updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->