### PR TITLE
[Solve Issue #724] | Feature - Add an optional Comment about a Group

### DIFF
--- a/apps/builder/src/components/icons.tsx
+++ b/apps/builder/src/components/icons.tsx
@@ -643,3 +643,10 @@ export const XCircleIcon = (props: IconProps) => (
     <path d="m9 9 6 6" />
   </Icon>
 )
+
+export const NoteIcon = (props: IconProps) => (
+	<Icon viewBox="0 0 256 256" {...featherIconsBaseProps} {...props}>
+		<path d="M88,96a8,8,0,0,1,8-8h64a8,8,0,0,1,0,16H96A8,8,0,0,1,88,96Zm8,40h64a8,8,0,0,0,0-16H96a8,8,0,0,0,0,16Zm32,16H96a8,8,0,0,0,0,16h32a8,8,0,0,0,0-16ZM224,48V156.69A15.86,15.86,0,0,1,219.31,168L168,219.31A15.86,15.86,0,0,1,156.69,224H48a16,16,0,0,1-16-16V48A16,16,0,0,1,48,32H208A16,16,0,0,1,224,48ZM48,208H152V160a8,8,0,0,1,8-8h48V48H48Zm120-40v28.7L196.69,168Z">
+		</path>
+	</Icon>
+)

--- a/apps/builder/src/features/graph/components/nodes/group/GroupComment.tsx
+++ b/apps/builder/src/features/graph/components/nodes/group/GroupComment.tsx
@@ -3,12 +3,13 @@ import { useTypebot } from '@/features/editor/providers/TypebotProvider'
 import { groupWidth } from '@/features/graph/constants'
 import { useOutsideClick } from '@/hooks/useOutsideClick'
 import { chakra, Stack, useColorModeValue } from '@chakra-ui/react'
+import { TElement } from '@udecode/plate-common'
 import { Dispatch, SetStateAction, useRef } from 'react'
 
 type Props = {
   groupId: string
   groupIndex: number
-  comment: string | null | undefined
+  initialValue?: TElement[]
   currentCoordinates: Record<'x' | 'y', number>
   setIsCommentActive: Dispatch<SetStateAction<boolean>>
 }
@@ -16,7 +17,7 @@ type Props = {
 export const GroupComment = ({
   groupId,
   groupIndex,
-  comment = "",
+  initialValue,
   currentCoordinates,
   setIsCommentActive,
 }: Props) => {
@@ -60,10 +61,13 @@ export const GroupComment = ({
       {typebot && (
         <TextBubbleEditor
           id={`text-comment-${groupId}`}
-          initialValue={[{ type: "p", children: [{ text: comment ?? "" }] }]}
+          initialValue={
+						initialValue?.length
+							? initialValue
+							: [{ type: "p", children: [{ text: "" }] }]
+					}
           onClose={(newContent) => {
-						const newComment = newContent.map(({ children: [comment] }) => comment.text).join("\n")
-            updateGroup(groupIndex, { comment: newComment })
+            updateGroup(groupIndex, { comment: newContent })
           }}
         />
       )}

--- a/apps/builder/src/features/graph/components/nodes/group/GroupComment.tsx
+++ b/apps/builder/src/features/graph/components/nodes/group/GroupComment.tsx
@@ -1,34 +1,42 @@
-import { TextBubbleEditor } from "@/features/blocks/bubbles/textBubble/components/TextBubbleEditor"
-import { useTypebot } from "@/features/editor/providers/TypebotProvider"
-import { groupWidth } from "@/features/graph/constants"
+import { TextBubbleEditor } from '@/features/blocks/bubbles/textBubble/components/TextBubbleEditor'
+import { useTypebot } from '@/features/editor/providers/TypebotProvider'
+import { groupWidth } from '@/features/graph/constants'
 import { useOutsideClick } from '@/hooks/useOutsideClick'
-import { chakra, Stack, useColorModeValue } from "@chakra-ui/react"
+import { chakra, Stack, useColorModeValue } from '@chakra-ui/react'
 import { Dispatch, SetStateAction, useRef } from 'react'
 
 type Props = {
   groupId: string
-  currentCoordinates: Record<"x" | "y", number>
-	setIsCommentActive: Dispatch<SetStateAction<boolean>>
+  groupIndex: number
+  comment: string | null | undefined
+  currentCoordinates: Record<'x' | 'y', number>
+  setIsCommentActive: Dispatch<SetStateAction<boolean>>
 }
 
-export const GroupComment = ({ groupId, currentCoordinates, setIsCommentActive }: Props) => {
-	const stackRef = useRef(null)
-  const { typebot } = useTypebot()
-  const bg = useColorModeValue("white", "gray.900")
-	
-	function handleCommentClose() {
-		setIsCommentActive(false)
-	}
+export const GroupComment = ({
+  groupId,
+  groupIndex,
+  comment = "",
+  currentCoordinates,
+  setIsCommentActive,
+}: Props) => {
+  const stackRef = useRef(null)
+  const { typebot, updateGroup } = useTypebot()
+  const bg = useColorModeValue('white', 'gray.900')
 
-	useOutsideClick({
-		ref: stackRef,
-		handler: handleCommentClose
-	})
+  const handleCommentClose = () => {
+    setIsCommentActive(false)
+  }
+
+  useOutsideClick({
+    ref: stackRef,
+    handler: handleCommentClose,
+  })
 	
   return (
     <Stack
       id={`comment-${groupId}`}
-			ref={stackRef}
+      ref={stackRef}
       p="4"
       pb="5"
       rounded="xl"
@@ -41,19 +49,22 @@ export const GroupComment = ({ groupId, currentCoordinates, setIsCommentActive }
         transform: `translate(${
           currentCoordinates?.x + groupWidth + 12 ?? 0
         }px, ${currentCoordinates?.y ?? 0}px)`,
-        touchAction: "none",
+        touchAction: 'none',
       }}
-      cursor={"auto"}
+      cursor={'auto'}
       shadow="md"
     >
       <chakra.h3 fontWeight="semibold" pl="1" py="2">
-        Note
+        Observation Note
       </chakra.h3>
       {typebot && (
         <TextBubbleEditor
           id={`text-comment-${groupId}`}
-          initialValue={[{ type: "p", children: [{ text: "" }] }]}
-          onClose={() => {}}
+          initialValue={[{ type: "p", children: [{ text: comment ?? "" }] }]}
+          onClose={(newContent) => {
+						const newComment = newContent.map(({ children: [comment] }) => comment.text).join("\n")
+            updateGroup(groupIndex, { comment: newComment })
+          }}
         />
       )}
     </Stack>

--- a/apps/builder/src/features/graph/components/nodes/group/GroupComment.tsx
+++ b/apps/builder/src/features/graph/components/nodes/group/GroupComment.tsx
@@ -1,0 +1,61 @@
+import { TextBubbleEditor } from "@/features/blocks/bubbles/textBubble/components/TextBubbleEditor"
+import { useTypebot } from "@/features/editor/providers/TypebotProvider"
+import { groupWidth } from "@/features/graph/constants"
+import { useOutsideClick } from '@/hooks/useOutsideClick'
+import { chakra, Stack, useColorModeValue } from "@chakra-ui/react"
+import { Dispatch, SetStateAction, useRef } from 'react'
+
+type Props = {
+  groupId: string
+  currentCoordinates: Record<"x" | "y", number>
+	setIsCommentActive: Dispatch<SetStateAction<boolean>>
+}
+
+export const GroupComment = ({ groupId, currentCoordinates, setIsCommentActive }: Props) => {
+	const stackRef = useRef(null)
+  const { typebot } = useTypebot()
+  const bg = useColorModeValue("white", "gray.900")
+	
+	function handleCommentClose() {
+		setIsCommentActive(false)
+	}
+
+	useOutsideClick({
+		ref: stackRef,
+		handler: handleCommentClose
+	})
+	
+  return (
+    <Stack
+      id={`comment-${groupId}`}
+			ref={stackRef}
+      p="4"
+      pb="5"
+      rounded="xl"
+      bg={bg}
+      borderWidth="1px"
+      w={groupWidth}
+      transition="border 300ms, box-shadow 200ms"
+      pos="absolute"
+      style={{
+        transform: `translate(${
+          currentCoordinates?.x + groupWidth + 12 ?? 0
+        }px, ${currentCoordinates?.y ?? 0}px)`,
+        touchAction: "none",
+      }}
+      cursor={"auto"}
+      shadow="md"
+    >
+      <chakra.h3 fontWeight="semibold" pl="1" py="2">
+        Note
+      </chakra.h3>
+      {typebot && (
+        <TextBubbleEditor
+          id={`text-comment-${groupId}`}
+          initialValue={[{ type: "p", children: [{ text: "" }] }]}
+          onClose={() => {}}
+        />
+      )}
+    </Stack>
+  )
+}

--- a/apps/builder/src/features/graph/components/nodes/group/GroupFocusToolbar.tsx
+++ b/apps/builder/src/features/graph/components/nodes/group/GroupFocusToolbar.tsx
@@ -1,4 +1,4 @@
-import { ChatIcon, CopyIcon, InfoIcon, PlayIcon, TrashIcon } from '@/components/icons'
+import { CopyIcon, InfoIcon, NoteIcon, PlayIcon, TrashIcon } from '@/components/icons'
 import {
   HStack,
   IconButton,
@@ -69,7 +69,7 @@ export const GroupFocusToolbar = ({
         />
       </Tooltip>
 			<IconButton
-				icon={<ChatIcon/>}
+				icon={<NoteIcon fill="#000000"/>}
 				aria-label="Insert a comment"
 				size="sm"
 				variant="ghost"

--- a/apps/builder/src/features/graph/components/nodes/group/GroupFocusToolbar.tsx
+++ b/apps/builder/src/features/graph/components/nodes/group/GroupFocusToolbar.tsx
@@ -11,6 +11,7 @@ type Props = {
   groupId: string
   onPlayClick: () => void
   onDuplicateClick: () => void
+  onCommentClick: () => void
   onDeleteClick: () => void
 }
 
@@ -18,6 +19,7 @@ export const GroupFocusToolbar = ({
   groupId,
   onPlayClick,
   onDuplicateClick,
+	onCommentClick,
   onDeleteClick,
 }: Props) => {
   const { hasCopied, onCopy } = useClipboard(groupId)
@@ -70,6 +72,7 @@ export const GroupFocusToolbar = ({
       </Tooltip>
 			<IconButton
 				icon={<NoteIcon fill="#000000"/>}
+        onClick={onCommentClick}
 				aria-label="Insert a comment"
 				size="sm"
 				variant="ghost"

--- a/apps/builder/src/features/graph/components/nodes/group/GroupFocusToolbar.tsx
+++ b/apps/builder/src/features/graph/components/nodes/group/GroupFocusToolbar.tsx
@@ -1,4 +1,4 @@
-import { CopyIcon, InfoIcon, PlayIcon, TrashIcon } from '@/components/icons'
+import { ChatIcon, CopyIcon, InfoIcon, PlayIcon, TrashIcon } from '@/components/icons'
 import {
   HStack,
   IconButton,
@@ -68,6 +68,15 @@ export const GroupFocusToolbar = ({
           onClick={onCopy}
         />
       </Tooltip>
+			<IconButton
+				icon={<ChatIcon/>}
+				aria-label="Insert a comment"
+				size="sm"
+				variant="ghost"
+				borderLeftRadius="none"
+				borderRightRadius="none"
+				borderRightWidth="1px"
+			/>
       <IconButton
         aria-label="Delete"
         borderLeftRadius="none"

--- a/apps/builder/src/features/graph/components/nodes/group/GroupNode.tsx
+++ b/apps/builder/src/features/graph/components/nodes/group/GroupNode.tsx
@@ -27,6 +27,7 @@ import { useGroupsCoordinates } from '@/features/graph/providers/GroupsCoordinat
 import { setMultipleRefs } from '@/helpers/setMultipleRefs'
 import { Coordinates } from '@/features/graph/types'
 import { groupWidth } from '@/features/graph/constants'
+import { GroupComment } from './GroupComment'
 
 type Props = {
   group: GroupV6
@@ -79,6 +80,7 @@ const NonMemoizedDraggableGroupNode = ({
     group.graphCoordinates
   )
   const [groupTitle, setGroupTitle] = useState(group.title)
+	const [isCommentActive, setIsCommentActive] = useState(false)
 
   const isPreviewing =
     previewingBlock?.groupId === group.id ||
@@ -192,91 +194,102 @@ const NonMemoizedDraggableGroupNode = ({
       isDisabled={isReadOnly}
     >
       {(ref, isContextMenuOpened) => (
-        <Stack
-          ref={setMultipleRefs([ref, groupRef])}
-          id={`group-${group.id}`}
-          data-testid="group"
-          p="4"
-          rounded="xl"
-          bg={bg}
-          borderWidth="1px"
-          borderColor={
-            isConnecting || isContextMenuOpened || isPreviewing || isFocused
-              ? previewingBorderColor
-              : borderColor
-          }
-          w={groupWidth}
-          transition="border 300ms, box-shadow 200ms"
-          pos="absolute"
-          style={{
-            transform: `translate(${currentCoordinates?.x ?? 0}px, ${
-              currentCoordinates?.y ?? 0
-            }px)`,
-            touchAction: 'none',
-          }}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-          cursor={isMouseDown ? 'grabbing' : 'pointer'}
-          shadow="md"
-          _hover={{ shadow: 'lg' }}
-          zIndex={isFocused ? 10 : 1}
-          spacing={isEmpty(group.title) ? '0' : '2'}
-        >
-          <Editable
-            value={groupTitle}
-            onChange={setGroupTitle}
-            onSubmit={handleTitleSubmit}
-            fontWeight="semibold"
-            pr="8"
+        <>
+          <Stack
+            ref={setMultipleRefs([ref, groupRef])}
+            id={`group-${group.id}`}
+            data-testid="group"
+            p="4"
+            rounded="xl"
+            bg={bg}
+            borderWidth="1px"
+            borderColor={
+              isConnecting || isContextMenuOpened || isPreviewing || isFocused
+                ? previewingBorderColor
+                : borderColor
+            }
+            w={groupWidth}
+            transition="border 300ms, box-shadow 200ms"
+            pos="absolute"
+            style={{
+              transform: `translate(${currentCoordinates?.x ?? 0}px, ${
+                currentCoordinates?.y ?? 0
+              }px)`,
+              touchAction: 'none',
+            }}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+            cursor={isMouseDown ? 'grabbing' : 'pointer'}
+            shadow="md"
+            _hover={{ shadow: 'lg' }}
+            zIndex={isFocused ? 10 : 1}
+            spacing={isEmpty(group.title) ? '0' : '2'}
           >
-            <EditablePreview
-              _hover={{
-                bg: editableHoverBg,
-              }}
-              px="1"
-              userSelect={'none'}
-              style={
-                isEmpty(groupTitle)
-                  ? {
-                      display: 'block',
-                      position: 'absolute',
-                      top: '10px',
-                      width: '50px',
-                    }
-                  : undefined
-              }
-            />
-            <EditableInput minW="0" px="1" className="prevent-group-drag" />
-          </Editable>
-          {typebot && (
-            <BlockNodesList
-              blocks={group.blocks}
-              groupIndex={groupIndex}
-              groupRef={ref}
-            />
-          )}
-          {!isReadOnly && (
-            <SlideFade
-              in={isFocused}
-              style={{
-                position: 'absolute',
-                top: '-50px',
-                right: 0,
-              }}
-              unmountOnExit
+            <Editable
+              value={groupTitle}
+              onChange={setGroupTitle}
+              onSubmit={handleTitleSubmit}
+              fontWeight="semibold"
+              pr="8"
             >
-              <GroupFocusToolbar
-                groupId={group.id}
-                onPlayClick={startPreviewAtThisGroup}
-                onDuplicateClick={() => {
-                  setIsFocused(false)
-                  duplicateGroup(groupIndex)
+              <EditablePreview
+                _hover={{
+                  bg: editableHoverBg,
                 }}
-                onDeleteClick={() => deleteGroup(groupIndex)}
+                px="1"
+                userSelect={'none'}
+                style={
+                  isEmpty(groupTitle)
+                    ? {
+                        display: 'block',
+                        position: 'absolute',
+                        top: '10px',
+                        width: '50px',
+                      }
+                    : undefined
+                }
               />
-            </SlideFade>
-          )}
-        </Stack>
+              <EditableInput minW="0" px="1" className="prevent-group-drag" />
+            </Editable>
+            {typebot && (
+              <BlockNodesList
+                blocks={group.blocks}
+                groupIndex={groupIndex}
+                groupRef={ref}
+              />
+            )}
+            {!isReadOnly && (
+              <SlideFade
+                in={isFocused}
+                style={{
+                  position: 'absolute',
+                  top: '-50px',
+                  right: 0,
+                }}
+                unmountOnExit
+              >
+                <GroupFocusToolbar
+                  groupId={group.id}
+                  onPlayClick={startPreviewAtThisGroup}
+                  onDuplicateClick={() => {
+                    setIsFocused(false)
+                    duplicateGroup(groupIndex)
+                  }}
+                  onCommentClick={() => { setIsCommentActive((prev) => !prev) }}
+                  onDeleteClick={() => deleteGroup(groupIndex)}
+                />
+              </SlideFade>
+            )}
+          </Stack>
+
+					{isCommentActive && (
+						<GroupComment
+							groupId={group.id}
+							currentCoordinates={currentCoordinates}
+							setIsCommentActive={setIsCommentActive}
+						/>
+					)}
+        </>
       )}
     </ContextMenu>
   )

--- a/apps/builder/src/features/graph/components/nodes/group/GroupNode.tsx
+++ b/apps/builder/src/features/graph/components/nodes/group/GroupNode.tsx
@@ -285,6 +285,8 @@ const NonMemoizedDraggableGroupNode = ({
 					{isCommentActive && (
 						<GroupComment
 							groupId={group.id}
+							groupIndex={groupIndex}
+							comment={group.comment}
 							currentCoordinates={currentCoordinates}
 							setIsCommentActive={setIsCommentActive}
 						/>

--- a/apps/builder/src/features/graph/components/nodes/group/GroupNode.tsx
+++ b/apps/builder/src/features/graph/components/nodes/group/GroupNode.tsx
@@ -286,7 +286,7 @@ const NonMemoizedDraggableGroupNode = ({
 						<GroupComment
 							groupId={group.id}
 							groupIndex={groupIndex}
-							comment={group.comment}
+							initialValue={group.comment}
 							currentCoordinates={currentCoordinates}
 							setIsCommentActive={setIsCommentActive}
 						/>

--- a/packages/schemas/features/typebot/group.ts
+++ b/packages/schemas/features/typebot/group.ts
@@ -14,7 +14,7 @@ type GroupV5 = z.infer<typeof groupV5Schema>
 
 export const groupV6Schema = groupV5Schema.extend({
   blocks: z.array(blockSchemaV6),
-	comment: z.string().nullish(),
+	comment: z.array(z.any()).optional(),
 })
 export type GroupV6 = z.infer<typeof groupV6Schema>
 

--- a/packages/schemas/features/typebot/group.ts
+++ b/packages/schemas/features/typebot/group.ts
@@ -14,6 +14,7 @@ type GroupV5 = z.infer<typeof groupV5Schema>
 
 export const groupV6Schema = groupV5Schema.extend({
   blocks: z.array(blockSchemaV6),
+	comment: z.string().nullish(),
 })
 export type GroupV6 = z.infer<typeof groupV6Schema>
 


### PR DESCRIPTION
### FEATURE
In order to address issue #724, which was opened by @JulianHafermann, I created a feature that allows the user to add some comments or observations relevant to a specific group.

This feature isn't a new Block, but rather an additional field in the Group schema.

Furthermore, I also implemented the [suggestion](https://github.com/baptisteArno/typebot.io/issues/724#issuecomment-1795509435) made by @Lanhild, where this feature should be added to the group toolbar.

### PREVIEW
https://github.com/baptisteArno/typebot.io/assets/110189424/421aecc3-b9bb-4141-ab8f-67c76dc6f234


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `NoteIcon` component for better visual representation of notes.
  - Added a `GroupComment` component to allow users to add comments to groups.
  - Implemented a new comment button in the `GroupFocusToolbar` for user interaction.
  - Enhanced `GroupNode` with the ability to toggle comments on and off.

- **Enhancements**
  - Updated the `GroupV6` schema to include an optional `comment` field, allowing for richer data representation.

- **Documentation**
  - No visible changes to end-user documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->