### PR TITLE
:pencil: (docs): fix typo in Unsplash description

### DIFF
--- a/apps/docs/docs/self-hosting/configuration.md
+++ b/apps/docs/docs/self-hosting/configuration.md
@@ -159,7 +159,7 @@ Used to search for GIF. You can create a Giphy app [here](https://developers.gip
 
 ## Unsplash (image picker)
 
-Used to search for images. You can create a Giphy app [here](https://unsplash.com/developers)
+Used to search for images. You can create an Unsplash app [here](https://unsplash.com/developers)
 
 | Parameter                       | Default | Description       |
 | ------------------------------- | ------- | ----------------- |


### PR DESCRIPTION
Documentation

This PR updates the documentation to fix an incorrect description for the Unsplash configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a hyperlink and associated text in the self-hosting configuration guide, changing "Giphy" to "Unsplash" for image search references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->