### PR TITLE
Added option to save file upload with file name

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
-  "i18n-ally.localesPaths": ["apps/builder/public/locales"],
+  "i18n-ally.localesPaths": [
+    "apps/builder/public/locales"
+  ],
   "i18n-ally.keystyle": "flat",
   "i18n-ally.displayLanguage": "en",
   "i18n-ally.enabledFrameworks": ["custom"],

--- a/apps/builder/src/components/ImageUploadContent/UploadButton.tsx
+++ b/apps/builder/src/components/ImageUploadContent/UploadButton.tsx
@@ -27,6 +27,7 @@ export const UploadButton = ({
     },
     onSuccess: async (data) => {
       if (!file) return
+
       const formData = new FormData()
       Object.entries(data.formData).forEach(([key, value]) => {
         formData.append(key, value)
@@ -54,7 +55,10 @@ export const UploadButton = ({
       return showToast({ description: 'Could not read file.', status: 'error' })
     setFile(await compressFile(file))
     mutate({
-      filePathProps,
+      filePathProps: {
+        ...filePathProps,
+        fileName: file.name,
+      },
       fileType: file.type,
     })
   }

--- a/apps/builder/src/features/upload/api/generateUploadUrl.ts
+++ b/apps/builder/src/features/upload/api/generateUploadUrl.ts
@@ -14,6 +14,7 @@ const inputSchema = z.object({
       typebotId: z.string(),
       blockId: z.string(),
       itemId: z.string().optional(),
+      fileName: z.string().optional(),
     })
     .or(
       z.object({
@@ -180,6 +181,14 @@ const parseFilePath = async ({
     })
   if (!('blockId' in input)) {
     return `public/workspaces/${input.workspaceId}/typebots/${input.typebotId}/${input.fileName}`
+  }
+
+  if (env.S3_FILENAME_IN_URL && env.S3_FILENAME_IN_URL === 'true') {
+    return `public/workspaces/${input.workspaceId}/typebots/${
+      input.typebotId
+    }/blocks/${input.blockId}${
+      input.itemId ? `/items/${input.itemId}` : ''
+    }${`/${input.fileName}`}`
   }
   return `public/workspaces/${input.workspaceId}/typebots/${
     input.typebotId

--- a/apps/docs/docs/self-hosting/configuration.md
+++ b/apps/docs/docs/self-hosting/configuration.md
@@ -144,6 +144,7 @@ Used for uploading images, videos, etc... It can be any S3 compatible object sto
 | S3_SSL                  | true    | Use SSL when establishing the connection.                                          |
 | S3_REGION               |         | S3 region.                                                                         |
 | S3_PUBLIC_CUSTOM_DOMAIN |         | If the final URL that is used to read public files is different from `S3_ENDPOINT` |
+| S3_FILENAME_IN_URL      | false   | If true, it will generate the media url with the file name                         |
 
 Note that for AWS S3, your endpoint is usually: `s3.<S3_REGION>.amazonaws.com`
 

--- a/packages/env/env.ts
+++ b/packages/env/env.ts
@@ -214,6 +214,7 @@ const s3Env = {
     S3_SSL: boolean.optional().default('true'),
     S3_REGION: z.string().min(1).optional(),
     S3_PUBLIC_CUSTOM_DOMAIN: z.string().url().optional(),
+    S3_FILENAME_IN_URL: z.string().min(1).optional().default('true'),
   },
 }
 

--- a/packages/env/env.ts
+++ b/packages/env/env.ts
@@ -214,7 +214,7 @@ const s3Env = {
     S3_SSL: boolean.optional().default('true'),
     S3_REGION: z.string().min(1).optional(),
     S3_PUBLIC_CUSTOM_DOMAIN: z.string().url().optional(),
-    S3_FILENAME_IN_URL: z.string().min(1).optional().default('true'),
+    S3_FILENAME_IN_URL: z.string().min(1).optional().default('false'),
   },
 }
 


### PR DESCRIPTION
Created the option to be able to upload a file to s3 with the file name and extension.

With this implementation, the variable S3_FILENAME_IN_URL, if set to true it sends the file name along with the url.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Search bar introduced to enhance user navigation and accessibility.
  - Media URLs can now optionally include the file name for better clarity.

- **Bug Fixes**
  - Improved error handling in the image upload process to prevent issues when files are not present.

- **Documentation**
  - Updated self-hosting documentation to include the new `S3_FILENAME_IN_URL` configuration option.

- **Refactor**
  - Streamlined search functionality with backend improvements for more efficient operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->