### PR TITLE
fix openapi document filepaths

### DIFF
--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -2,8 +2,8 @@
   "$schema": "https://mintlify.com/schema.json",
   "name": "Typebot Docs",
   "openapi": [
-    "/openapi-reference/builder.json",
-    "/openapi-reference/viewer.json"
+    "/openapi/builder.json",
+    "/openapi/viewer.json"
   ],
   "feedback": {
     "suggestEdit": true


### PR DESCRIPTION
👋 Hi! Engineer from mintlify here

This updates the `openapi` field in `mint.json` to point to the correct files in the repo. This bug seems to have been introduced [during the migration](https://github.com/baptisteArno/typebot.io/pull/1115/files#diff-f9f0cfdf7078569b552a4f90df1b3d7982ef914aebf74ea7d291604e91fdc1a3)