### PR TITLE
Button Dynamic Data to have more advanced possibilities 

### DIFF
--- a/packages/bot-engine/blocks/inputs/buttons/injectVariableValuesInButtonsInputBlock.ts
+++ b/packages/bot-engine/blocks/inputs/buttons/injectVariableValuesInButtonsInputBlock.ts
@@ -38,7 +38,12 @@ export const injectVariableValuesInButtonsInputBlock =
             contentAsJson = false;
           }
 
-          if (contentAsJson)
+          if (contentAsJson
+            &&
+            (contentAsJson.name && contentAsJson.name !== "") 
+            &&
+            (contentAsJson.id && contentAsJson.id != "")
+          )
           {
             result = Object.assign({}, result, {
               content: contentAsJson.name,

--- a/packages/bot-engine/blocks/inputs/buttons/injectVariableValuesInButtonsInputBlock.ts
+++ b/packages/bot-engine/blocks/inputs/buttons/injectVariableValuesInButtonsInputBlock.ts
@@ -23,11 +23,37 @@ export const injectVariableValuesInButtonsInputBlock =
       const value = getVariableValue(state)(variable)
       return {
         ...deepParseVariables(variables)(block),
-        items: value.filter(isDefined).map((item, idx) => ({
-          id: idx.toString(),
-          blockId: block.id,
-          content: item,
-        })),
+        items: value.filter(isDefined).map((item, idx) => {
+          var result = {
+            id: idx.toString(),
+            blockId: block.id,
+          }
+
+          var contentAsJson;
+          try {
+            contentAsJson = JSON.parse(item);
+          }
+          catch
+          {
+            contentAsJson = false;
+          }
+
+          if (contentAsJson)
+          {
+            result = Object.assign({}, result, {
+              content: contentAsJson.name,
+              contentId: contentAsJson.id
+            });
+          }
+          else
+          {
+            result = Object.assign({}, result, {
+              content: item
+            });
+          }
+
+          return result;
+        }),
       }
     }
     return deepParseVariables(variables)(filterChoiceItems(variables)(block))

--- a/packages/bot-engine/blocks/inputs/buttons/parseButtonsReply.ts
+++ b/packages/bot-engine/blocks/inputs/buttons/parseButtonsReply.ts
@@ -75,8 +75,10 @@ export const parseButtonsReply =
           inputValue.toLowerCase().trim() === item.content.toLowerCase().trim())
     )
     if (!matchedItem) return { status: 'fail' }
+
     return {
       status: 'success',
+      replyId: matchedItem.contentId,
       reply: matchedItem.content ?? '',
     }
   }

--- a/packages/bot-engine/continueBotFlow.ts
+++ b/packages/bot-engine/continueBotFlow.ts
@@ -172,7 +172,7 @@ export const continueBotFlow = async (
     formattedReply =
       'reply' in parsedReplyResult ? parsedReplyResult.reply : undefined;
 
-    var formattedReplyId =
+    const formattedReplyId : string | undefined =
       'replyId' in parsedReplyResult ? (parsedReplyResult.replyId ?? formattedReply) : formattedReply;
 
     newSessionState = await processAndSaveAnswer(state, block)(formattedReplyId) 

--- a/packages/bot-engine/continueBotFlow.ts
+++ b/packages/bot-engine/continueBotFlow.ts
@@ -6,7 +6,7 @@ import {
   InputBlock,
   SessionState,
 } from '@typebot.io/schemas'
-import { isInputBlock, byId } from '@typebot.io/lib'
+import { isInputBlock, byId, isChoiceInput } from '@typebot.io/lib'
 import { executeGroup, parseInput } from './executeGroup'
 import { getNextGroup } from './getNextGroup'
 import { validateEmail } from './blocks/inputs/email/validateEmail'
@@ -170,8 +170,12 @@ export const continueBotFlow = async (
       }
 
     formattedReply =
-      'reply' in parsedReplyResult ? parsedReplyResult.reply : undefined
-    newSessionState = await processAndSaveAnswer(state, block)(formattedReply)
+      'reply' in parsedReplyResult ? parsedReplyResult.reply : undefined;
+
+    var formattedReplyId =
+      'replyId' in parsedReplyResult ? (parsedReplyResult.replyId ?? formattedReply) : formattedReply;
+
+    newSessionState = await processAndSaveAnswer(state, block)(formattedReplyId) 
   }
 
   const groupHasMoreBlocks = blockIndex < group.blocks.length - 1

--- a/packages/bot-engine/continueBotFlow.ts
+++ b/packages/bot-engine/continueBotFlow.ts
@@ -6,7 +6,7 @@ import {
   InputBlock,
   SessionState,
 } from '@typebot.io/schemas'
-import { isInputBlock, byId, isChoiceInput } from '@typebot.io/lib'
+import { isInputBlock, byId } from '@typebot.io/lib'
 import { executeGroup, parseInput } from './executeGroup'
 import { getNextGroup } from './getNextGroup'
 import { validateEmail } from './blocks/inputs/email/validateEmail'

--- a/packages/bot-engine/types.ts
+++ b/packages/bot-engine/types.ts
@@ -29,5 +29,6 @@ export type Reply = string | WhatsAppMediaMessage | undefined
 
 export type ParsedReply =
   | { status: 'success'; reply: string }
+  | { status: 'success'; reply: string, replyId: string | undefined }
   | { status: 'fail' }
   | { status: 'skip' }


### PR DESCRIPTION
Button choice dynamic data to allow different display name vs value set in variable

sometimes we want to save key of the choice rather than it's name (due to localization in multiple languages and many other use cases as well)

Normal Usecase:
![image](https://github.com/baptisteArno/typebot.io/assets/38984510/5067b5b1-429b-427c-a694-9ae4a42d8081)

Advanced Usecase:
![image](https://github.com/baptisteArno/typebot.io/assets/38984510/bb751551-29eb-4551-8e47-4d7c8f886927)

I have added a few steps of validation to make sure in case of json data but no id, name we use the whole json array but you can define the standard key which are (id and name) yourself or give option in the button pop.

Changes required:
- Add missing type definitions (required) - will not be able to build docker file without types (currently im bypassing type check on my local workspace)
- Use built in type bot functions to check whether the variable value is string, json (optional)
- Ability to change the variable keys for displaying and variable saving (optional)
- Change how and where the display name and variable id (reply, replyid) are present (optional)

Tested with different data types for every scenario: yes and works as expected.