### PR TITLE
Add aria-label to improve button accessibility

### DIFF
--- a/packages/embeds/js/src/features/bubble/components/PreviewMessage.tsx
+++ b/packages/embeds/js/src/features/bubble/components/PreviewMessage.tsx
@@ -67,6 +67,7 @@ const CloseButton = (props: {
 }) => (
   <button
     part="preview-message-close-button"
+    aria-label="Close"
     class={
       `absolute -top-2 -right-2 rounded-full w-6 h-6 p-1 hover:brightness-95 active:brightness-90 transition-all border ` +
       (props.isHovered ? 'opacity-100' : 'opacity-0')


### PR DESCRIPTION
Fix Issue [#1321](https://github.com/baptisteArno/typebot.io/issues/1321) Preview Message button's accessibility issue