### PR TITLE
Mention how not to overwrite GSheet results

### DIFF
--- a/apps/docs/editor/blocks/integrations/google-sheets.mdx
+++ b/apps/docs/editor/blocks/integrations/google-sheets.mdx
@@ -12,7 +12,9 @@ With the Google Sheets integration step, you can inject, update or get data from
   />
 </div>
 
-In order to properly work, your spreadsheet must have its first row as a header row. And all header names should be unique. This is how the block knows which columns to update:
+In order to properly work, your spreadsheet must have its first row as a header row. And all header names should be unique. This is how the block knows which columns to update.
+Make sure to have a unique ID as the first column so that the blocks do not to overwrite existing rows. Before the "Insert a row" block, create a new variable resultId and set its value to "Result ID". In the "Insert a row" block set the first column to be an ID and store the resultId there.
+:
 
 <Frame>
   <img

--- a/apps/docs/editor/blocks/integrations/google-sheets.mdx
+++ b/apps/docs/editor/blocks/integrations/google-sheets.mdx
@@ -12,7 +12,7 @@ With the Google Sheets integration step, you can inject, update or get data from
   />
 </div>
 
-In order to properly work, your spreadsheet must have its first row as a header row. And all header name should be unique. This is how the block knows which column to update:
+In order to properly work, your spreadsheet must have its first row as a header row. And all header names should be unique. This is how the block knows which columns to update:
 
 <Frame>
   <img


### PR DESCRIPTION
The GSheet documentation didn't mention how not to overwrite existing rows. By indicating adding a unique ID as the first column, we make sure no rows are overwritten.