### PR TITLE
Update local-installation documentation for landing page

### DIFF
--- a/apps/docs/contribute/guides/local-installation.mdx
+++ b/apps/docs/contribute/guides/local-installation.mdx
@@ -46,8 +46,6 @@ icon: 'laptop'
 
 6. (Optional) Start the landing page
 
-   <!--- Copy `apps/landing-page/.env.local.example` to `apps/landing-page/.env.local` --->
-
    ```sh
    cd ee/apps/landing-page
    pnpm dev

--- a/apps/docs/contribute/guides/local-installation.mdx
+++ b/apps/docs/contribute/guides/local-installation.mdx
@@ -46,10 +46,10 @@ icon: 'laptop'
 
 6. (Optional) Start the landing page
 
-   Copy `apps/landing-page/.env.local.example` to `apps/landing-page/.env.local`
+   <!--- Copy `apps/landing-page/.env.local.example` to `apps/landing-page/.env.local` --->
 
    ```sh
-   cd apps/landing-page
+   cd ee/apps/landing-page
    pnpm dev
    ```
 


### PR DESCRIPTION
This section of the local-installation documentation required to be modified because the `/landing-page` directory has already been moved from the `/apps` directory to the `/ee/apps` directory.


Thanks!