### PR TITLE
Fix editable overflowing in the variables drawer

### DIFF
--- a/apps/builder/src/features/preview/components/VariablesDrawer.tsx
+++ b/apps/builder/src/features/preview/components/VariablesDrawer.tsx
@@ -181,6 +181,7 @@ const VariableItem = ({
       <Editable
         defaultValue={variable.name}
         onSubmit={(name) => onChange({ name })}
+        minWidth={0}
       >
         <EditablePreview
           px="2"


### PR DESCRIPTION
In the `VariablesDrawer`, long variables overflow their parent container by pushing away action buttons as can be seen in the following screenshot: 

<img width="503" alt="image" src="https://github.com/user-attachments/assets/c51afef9-8290-4178-a119-83c2d50af48d">

Since we are in a flex context, the default value for `min-width` is `auto` which causes the container to grow automatically based on its content.

To make sure the `text-overflow` / `overflow` pair work correctly, and display an ellipsis, the parent container must have a fixed size. This can be solved by setting the `min-width` of the overflowing container to `0` (the default outside a flex context).

After applying `min-width: 0` to the editable component: 

<img width="428" alt="image" src="https://github.com/user-attachments/assets/0a4f39b2-613b-4b36-8e13-634e4f5feaef">

