### PR TITLE
Fixed: Default phone country resetted when emptying the input

### DIFF
--- a/packages/embeds/js/package.json
+++ b/packages/embeds/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/js",
-  "version": "0.3.47",
+  "version": "0.3.48",
   "description": "Javascript library to display typebots on your website",
   "license": "FSL-1.1-ALv2",
   "type": "module",

--- a/packages/embeds/js/src/features/blocks/inputs/phone/components/PhoneInput.tsx
+++ b/packages/embeds/js/src/features/blocks/inputs/phone/components/PhoneInput.tsx
@@ -27,14 +27,9 @@ export const PhoneInput = (props: PhoneInputProps) => {
 
   const handleInput = (inputValue: string | undefined) => {
     setInputValue(inputValue as string);
-    if (
-      (inputValue === "" || inputValue === "+") &&
-      selectedCountryCode() !== "INT"
-    )
-      setSelectedCountryCode("INT");
-    const matchedCountry =
-      inputValue?.startsWith("+") &&
-      inputValue.length > 2 &&
+
+    if (inputValue?.startsWith("+") && inputValue.length > 2) {
+      const matchedCountry =
       phoneCountries.reduce<(typeof phoneCountries)[number] | null>(
         (matchedCountry, country) => {
           if (
@@ -53,7 +48,8 @@ export const PhoneInput = (props: PhoneInputProps) => {
         },
         null,
       );
-    if (matchedCountry) setSelectedCountryCode(matchedCountry.code);
+      if (matchedCountry) setSelectedCountryCode(matchedCountry.code);
+    }
   };
 
   const checkIfInputIsValid = () =>

--- a/packages/embeds/js/src/features/blocks/inputs/phone/components/PhoneInput.tsx
+++ b/packages/embeds/js/src/features/blocks/inputs/phone/components/PhoneInput.tsx
@@ -29,25 +29,23 @@ export const PhoneInput = (props: PhoneInputProps) => {
     setInputValue(inputValue as string);
 
     if (inputValue?.startsWith("+") && inputValue.length > 2) {
-      const matchedCountry =
-      phoneCountries.reduce<(typeof phoneCountries)[number] | null>(
-        (matchedCountry, country) => {
-          if (
-            !country?.dial_code ||
-            (matchedCountry !== null && !matchedCountry.dial_code)
-          ) {
-            return matchedCountry;
-          }
-          if (
-            inputValue?.startsWith(country.dial_code) &&
-            country.dial_code.length > (matchedCountry?.dial_code.length ?? 0)
-          ) {
-            return country;
-          }
+      const matchedCountry = phoneCountries.reduce<
+        (typeof phoneCountries)[number] | null
+      >((matchedCountry, country) => {
+        if (
+          !country?.dial_code ||
+          (matchedCountry !== null && !matchedCountry.dial_code)
+        ) {
           return matchedCountry;
-        },
-        null,
-      );
+        }
+        if (
+          inputValue?.startsWith(country.dial_code) &&
+          country.dial_code.length > (matchedCountry?.dial_code.length ?? 0)
+        ) {
+          return country;
+        }
+        return matchedCountry;
+      }, null);
       if (matchedCountry) setSelectedCountryCode(matchedCountry.code);
     }
   };

--- a/packages/embeds/nextjs/package.json
+++ b/packages/embeds/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/nextjs",
-  "version": "0.3.47",
+  "version": "0.3.48",
   "license": "FSL-1.1-ALv2",
   "description": "Convenient library to display typebots on your Next.js website",
   "type": "module",

--- a/packages/embeds/react/package.json
+++ b/packages/embeds/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/react",
-  "version": "0.3.47",
+  "version": "0.3.48",
   "description": "Convenient library to display typebots on your React app",
   "license": "FSL-1.1-ALv2",
   "type": "module",


### PR DESCRIPTION
Fixed #1999  Prevent selected country code from resetting to INT when input is cleared

- Removed the block that reset **selectedCountryCode** to **INT** when the input field was cleared.

- This ensures that if a country is selected, clearing the input does not revert it to **INT**.