### PR TITLE
docs(docker): add section on migration issues

### DIFF
--- a/apps/docs/self-hosting/deploy/docker.mdx
+++ b/apps/docs/self-hosting/deploy/docker.mdx
@@ -353,6 +353,36 @@ To build your own viewer Docker image
 docker build -t typebot-viewer --build-arg SCOPE=viewer .
 ```
 
+## Troubleshooting
+
+### Avoiding network issues when migrating in Portainer
+
+If you migrate a Typebot stack between Portainer instances, hostname resolution may fail, causing `typebot-viewer` to be unable to connect to `typebot-db`.
+
+Before deploying the stack in Portainer, ensure the network is **explicitly defined as attachable** in `docker-compose.yml`:
+
+```yml
+networks:
+  typebot_network:
+    driver: bridge
+    attachable: true
+
+services:
+  typebot-db:
+    ...
+    networks:
+      - typebot_network
+  typebot-builder:
+    ...
+    networks:
+      - typebot_network
+  typebot-viewer:
+    ...
+    networks:
+      - typebot_network
+```
+When deploying the stack, Portainer will automatically create the network with the correct settings. This prevents hostname resolution issues after migration.
+
 <Note>
   If you're self-hosting Typebot, [sponsoring
   me](https://github.com/sponsors/baptisteArno) is a great way to give back to


### PR DESCRIPTION
This PR adds a new **Troubleshooting** section to the documentation, specifically addressing network issues when migrating a Typebot stack in Portainer. 

It provides guidance on ensuring hostname resolution by explicitly defining an **attachable network** in `docker-compose.yml`.
