### PR TITLE
feat(blocks, ai): add prompt and completion tokens to the save dropdown

### DIFF
--- a/packages/ai/src/constants.ts
+++ b/packages/ai/src/constants.ts
@@ -3,4 +3,6 @@ export const maxSteps = 6;
 export const chatCompletionResponseValues = [
   "Message content",
   "Total tokens",
+  "Prompt tokens",
+  "Completion tokens",
 ] as const;

--- a/packages/ai/src/parseChatCompletionOptions.ts
+++ b/packages/ai/src/parseChatCompletionOptions.ts
@@ -81,7 +81,12 @@ export const parseChatCompletionOptions = ({ models }: Props) =>
       defaultValue: 1,
     }),
     responseMapping: option
-      .saveResponseArray(["Message content", "Total tokens"] as const)
+      .saveResponseArray([
+        "Message content",
+        "Total tokens",
+        "Prompt tokens",
+        "Completion tokens",
+      ] as const)
       .layout({
         accordion: "Save response",
       }),

--- a/packages/ai/src/runChatCompletion.ts
+++ b/packages/ai/src/runChatCompletion.ts
@@ -52,6 +52,12 @@ export const runChatCompletion = async ({
         variables.set([{ id: mapping.variableId, value: text }]);
       if (mapping.item === "Total tokens")
         variables.set([{ id: mapping.variableId, value: usage.totalTokens }]);
+      if (mapping.item === "Prompt tokens")
+        variables.set([{ id: mapping.variableId, value: usage.promptTokens }]);
+      if (mapping.item === "Completion tokens")
+        variables.set([
+          { id: mapping.variableId, value: usage.completionTokens },
+        ]);
     });
   } catch (err) {
     logs.add(

--- a/packages/ai/src/runChatCompletionStream.ts
+++ b/packages/ai/src/runChatCompletionStream.ts
@@ -52,6 +52,17 @@ export const runChatCompletionStream = async ({
             variables.set([
               { id: mapping.variableId, value: response.usage.totalTokens },
             ]);
+          if (mapping.item === "Prompt tokens")
+            variables.set([
+              { id: mapping.variableId, value: response.usage.promptTokens },
+            ]);
+          if (mapping.item === "Completion tokens")
+            variables.set([
+              {
+                id: mapping.variableId,
+                value: response.usage.completionTokens,
+              },
+            ]);
         });
       },
     });

--- a/packages/blocks/integrations/src/openai/constants.ts
+++ b/packages/blocks/integrations/src/openai/constants.ts
@@ -20,6 +20,8 @@ export const deprecatedRoles = ["Messages sequence ✨"] as const;
 export const chatCompletionResponseValues = [
   "Message content",
   "Total tokens",
+  "Prompt tokens",
+  "Completion tokens",
 ] as const;
 
 export const defaultOpenAIOptions = {

--- a/packages/bot-engine/src/blocks/integrations/legacy/openai/createChatCompletionOpenAI.ts
+++ b/packages/bot-engine/src/blocks/integrations/legacy/openai/createChatCompletionOpenAI.ts
@@ -128,7 +128,11 @@ export const createChatCompletionOpenAI = async (
       logs,
     };
   const messageContent = chatCompletion.choices.at(0)?.message?.content;
-  const totalTokens = chatCompletion.usage?.total_tokens;
+  const tokens = {
+    totalTokens: chatCompletion.usage?.total_tokens,
+    promptTokens: chatCompletion.usage?.prompt_tokens,
+    completionTokens: chatCompletion.usage?.completion_tokens,
+  };
   if (isEmpty(messageContent)) {
     console.error(
       "OpenAI block returned empty message",
@@ -141,7 +145,7 @@ export const createChatCompletionOpenAI = async (
       options,
       outgoingEdgeId,
       logs,
-    })(messageContent, totalTokens)),
+    })(messageContent, tokens)),
     startTimeShouldBeUpdated: true,
   };
 };

--- a/packages/bot-engine/src/blocks/integrations/legacy/openai/resumeChatCompletion.ts
+++ b/packages/bot-engine/src/blocks/integrations/legacy/openai/resumeChatCompletion.ts
@@ -5,6 +5,12 @@ import type { VariableWithUnknowValue } from "@typebot.io/variables/schemas";
 import type { ContinueChatResponse } from "../../../../schemas/api";
 import { updateVariablesInSession } from "../../../../updateVariablesInSession";
 
+interface ResumeChatCompletionTokens {
+  totalTokens?: number;
+  promptTokens?: number;
+  completionTokens?: number;
+}
+
 export const resumeChatCompletion =
   (
     state: SessionState,
@@ -18,7 +24,7 @@ export const resumeChatCompletion =
       logs?: ContinueChatResponse["logs"];
     },
   ) =>
-  async (message: string, totalTokens?: number) => {
+  async (message: string, tokens?: ResumeChatCompletionTokens) => {
     let newSessionState = state;
     const newVariables = options.responseMapping?.reduce<
       VariableWithUnknowValue[]
@@ -34,10 +40,31 @@ export const resumeChatCompletion =
             : message,
         });
       }
-      if (mapping.valueToExtract === "Total tokens" && isDefined(totalTokens)) {
+      if (
+        mapping.valueToExtract === "Total tokens" &&
+        isDefined(tokens?.totalTokens)
+      ) {
         newVariables.push({
           ...existingVariable,
-          value: totalTokens,
+          value: tokens.totalTokens,
+        });
+      }
+      if (
+        mapping.valueToExtract === "Prompt tokens" &&
+        isDefined(tokens?.promptTokens)
+      ) {
+        newVariables.push({
+          ...existingVariable,
+          value: tokens.promptTokens,
+        });
+      }
+      if (
+        mapping.valueToExtract === "Completion tokens" &&
+        isDefined(tokens?.completionTokens)
+      ) {
+        newVariables.push({
+          ...existingVariable,
+          value: tokens.completionTokens,
         });
       }
       return newVariables;


### PR DESCRIPTION
This adds **Prompt tokens** and **Completion tokens** options to the save dropdown for AI blocks, based on the available token counts of the CompletionUsage response.


<img width="322" alt="Capture d’écran 2025-03-14 à 16 37 55" src="https://github.com/user-attachments/assets/e5cce02d-7f61-4cfa-8f84-a50f718335ed" />
