### PR TITLE
fix(blocks, number): reapply default value to number input

### DIFF
--- a/packages/embeds/js/src/features/blocks/inputs/number/components/NumberInput.tsx
+++ b/packages/embeds/js/src/features/blocks/inputs/number/components/NumberInput.tsx
@@ -22,6 +22,7 @@ type NumberInputProps = {
 
 export const NumberInput = (props: NumberInputProps) => {
   const numberInput = useNumberInput({
+    defaultValue: props.defaultValue,
     locale: props.block.options?.locale,
     formatOptions: parseFormatOptions(props.block.options),
     min: safeParseFloat(props.block.options?.min),


### PR DESCRIPTION
Fixes the regression on number input, not taking into account the default value prop