### PR TITLE
fix(entrypoint): allow IPv6 binding via HOSTNAME env var

### DIFF
--- a/scripts/builder-entrypoint.sh
+++ b/scripts/builder-entrypoint.sh
@@ -6,4 +6,4 @@ cd ../..;
 
 ./node_modules/.bin/prisma migrate deploy --schema=packages/prisma/postgresql/schema.prisma;
 
-NODE_OPTIONS=--no-node-snapshot HOSTNAME=0.0.0.0 PORT=3000 node apps/builder/server.js;
+NODE_OPTIONS=--no-node-snapshot HOSTNAME=${HOSTNAME:-0.0.0.0} PORT=${PORT:-3000} node apps/builder/server.js;

--- a/scripts/viewer-entrypoint.sh
+++ b/scripts/viewer-entrypoint.sh
@@ -4,4 +4,4 @@ cd apps/viewer;
 node  -e "const { configureRuntimeEnv } = require('next-runtime-env/build/configure'); configureRuntimeEnv();"
 cd ../..;
 
-NODE_OPTIONS=--no-node-snapshot HOSTNAME=0.0.0.0 PORT=3000 node apps/viewer/server.js;
+NODE_OPTIONS=--no-node-snapshot HOSTNAME=${HOSTNAME:-0.0.0.0} PORT=${PORT:-3000} node apps/viewer/server.js;


### PR DESCRIPTION
This PR addresses [issue #2133](https://github.com/baptisteArno/typebot.io/issues/2133) by allowing the Typebot builder and viewer to bind to IPv6 addresses when `HOSTNAME=::` is provided via environment variable.

✅ Changes made:
- Updated `scripts/builder-entrypoint.sh` and `scripts/viewer-entrypoint.sh`
- Respect `HOSTNAME` and `PORT` environment variables if set
- Default to `0.0.0.0` and `3000` if not defined

🧪 Tested:
- Successfully deployed on Amazon EKS IPv6-only cluster
- Server binds correctly on `[::]:3000`

🧑‍💻 Contributors:
- [@silvadavitor](https://github.com/silvadavitor)
- [@RanielHaendchen](https://github.com/RanielHaendchen) (assisted with cluster testing and validation)

![test](https://github.com/user-attachments/assets/640e2eca-e201-4254-a747-d7259f2d25cc)

