### PR TITLE
Update InstallNextjsPackageSnippet to install @typebot.io/react inste…

### DIFF
--- a/apps/builder/src/features/publish/components/embeds/modals/Nextjs/InstallNextjsPackageSnippet.tsx
+++ b/apps/builder/src/features/publish/components/embeds/modals/Nextjs/InstallNextjsPackageSnippet.tsx
@@ -3,7 +3,7 @@ import { CodeEditor } from "@/components/inputs/CodeEditor";
 export const InstallNextjsPackageSnippet = () => {
   return (
     <CodeEditor
-      value={`npm install @typebot.io/nextjs`}
+      value={`npm install @typebot.io/react`}
       isReadOnly
       lang="shell"
     />


### PR DESCRIPTION
Issue: [2195](https://github.com/baptisteArno/typebot.io/issues/2195)

## TLDR
This MR corrects the npm install command in the **_InstallNextjsPackageSnippet_** to specify _@typebot.io/react_ instead of the incorrect _@typebot.io/nextjs_.

## Insight
The _@typebot.io/nextjs_ package is deprecated and the _@typebot.io/react_ package should now be used for both standard React applications and Next.js applications.
The React code snippet/installation instructions were providing an incorrect package name _(@typebot.io/nextjs)_ for installation via npm. This would lead to users installing a deprecated (or incorrect for pure React) library. This change ensures users are guided to install the correct, current package _(@typebot.io/react)_ for their React projects.

![Screenshot from 2025-06-03 10-33-22](https://github.com/user-attachments/assets/42e4eb9e-569c-4928-865e-45d21f336c64)


## Solution
The value text providing the npm install command has been updated to specify the correct React package.

The command has been changed from (or similar representation):
`value={'npm install @typebot.io/nextjs'}`

To (or similar representation):
`value={'npm install @typebot.io/react'}
`