### PR TITLE
fix(gitlab-auth): patch profile parsing for next-auth@v5 compatibility

### DIFF
--- a/apps/builder/src/features/auth/lib/providers.ts
+++ b/apps/builder/src/features/auth/lib/providers.ts
@@ -95,9 +95,7 @@ if (
     MicrosoftEntraID({
       clientId: env.AZURE_AD_CLIENT_ID,
       clientSecret: env.AZURE_AD_CLIENT_SECRET,
-      issuer: `https://login.microsoftonline.com/${
-        env.AZURE_AD_TENANT_ID || "common"
-      }/v2.0`,
+      issuer: `https://login.microsoftonline.com/${env.AZURE_AD_TENANT_ID || "common"}/v2.0`,
     }),
   );
 }


### PR DESCRIPTION
## 🚑 fix(gitlab-auth): patch profile parsing for next-auth@v5 compatibility

### Description

Fixes a compatibility issue with **GitLab authentication** after upgrading to `next-auth@v5.0.0-beta.28`.

Starting from [this commit](https://github.com/nextauthjs/next-auth/commit/2da115c6649e1d98aee33b364efa2c412608898b), NextAuth started relying on `profile.sub` instead of `profile.id`, which **breaks GitLab OAuth authentication** since `sub` is only defined in OIDC flows — not OAuth.

### Root Cause

The breaking change was introduced in:
- PR: https://github.com/nextauthjs/next-auth/pull/11176
- Commit: https://github.com/nextauthjs/next-auth/commit/2da115c6649e1d98aee33b364efa2c412608898b

> `sub` is not present in GitLab's OAuth profile response, leading to missing or broken user ID resolution.

### Solution

We override the `profile()` function in the GitLab provider to safely fallback to:

```ts
id: profile.sub?.toString() || profile.id.toString()
```

Additionally, we retain essential fields:

- name: fallback to username if not present.
- email, image: copied as-is.

### Validation
✅ Tested manually – authentication works as expected with GitLab after the patch.

