### PR TITLE
Fix MinIO bucket creation script for newer `mc` versions

### DIFF
--- a/apps/docs/self-hosting/deploy/docker.mdx
+++ b/apps/docs/self-hosting/deploy/docker.mdx
@@ -194,7 +194,7 @@ services:
     image: minio/minio
     command: server /data
     ports:
-      - '9000:9000'
+      - "9000:9000"
     environment:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: minio123
@@ -208,8 +208,8 @@ services:
     entrypoint: >
       /bin/sh -c "
       sleep 10;
-      /usr/bin/mc config host add minio http://minio:9000 minio minio123;
-      /usr/bin/mc mb minio/typebot;
+      /usr/bin/mc alias set minio http://minio:9000 minio minio123;
+      /usr/bin/mc mb --ignore-existing minio/typebot;
       /usr/bin/mc anonymous set public minio/typebot/public;
       exit 0;
       "
@@ -322,8 +322,8 @@ services:
     entrypoint: >
       /bin/sh -c "
       sleep 10;
-      /usr/bin/mc config host add minio http://minio:9000 minio minio123;
-      /usr/bin/mc mb minio/typebot;
+      /usr/bin/mc alias set minio http://minio:9000 minio minio123;
+      /usr/bin/mc mb --ignore-existing minio/typebot;
       /usr/bin/mc anonymous set public minio/typebot/public;
       exit 0;
       "
@@ -375,6 +375,7 @@ services:
     networks:
       - typebot_network
 ```
+
 When deploying the stack, Portainer will automatically create the network with the correct settings. This prevents hostname resolution issues after migration.
 
 <Note>

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,21 +1,21 @@
-version: '3.3'
+version: "3.3"
 services:
   typebot-db:
     image: postgres:16
     ports:
-      - '5432:5432'
+      - "5432:5432"
     restart: always
     volumes:
       - db_data:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: 'typebot'
-      POSTGRES_PASSWORD: 'typebot'
+      POSTGRES_DB: "typebot"
+      POSTGRES_PASSWORD: "typebot"
   minio:
     image: minio/minio
     command: server /data --console-address ":9001"
     ports:
-      - '9000:9000'
-      - '9001:9001'
+      - "9000:9000"
+      - "9001:9001"
     environment:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: minio123
@@ -29,8 +29,8 @@ services:
     entrypoint: >
       /bin/sh -c "
       sleep 10;
-      /usr/bin/mc config host add minio http://minio:9000 minio minio123;
-      /usr/bin/mc mb minio/typebot;
+      /usr/bin/mc alias set minio http://minio:9000 minio minio123;
+      /usr/bin/mc mb --ignore-existing minio/typebot;
       /usr/bin/mc anonymous set public minio/typebot/public;
       exit 0;
       "


### PR DESCRIPTION
Replace deprecated `mc config host add` with `mc alias set`.

## Context

Running the current **createbuckets** service logs errors similar to:

```
mc: <ERROR> `config` is not a recognized command. Get help using `--help` flag.
mc: <ERROR> Unable to set anonymous `public` for `minio/typebot/public`. Requested path `/minio/typebot/public` not found.
```

These arise because the command `mc config host` add was removed in recent releases in favor of `mc alias set`. Without a valid alias, subsequent commands reference a non‑existent path and fail.

`--ignore-existing` – makes bucket creation idempotent so the service can run multiple times without failing.