### PR TITLE
Fixing PHP deprecation warning

### DIFF
--- a/packages/embeds/wordpress/trunk/includes/class-typebot-loader.php
+++ b/packages/embeds/wordpress/trunk/includes/class-typebot-loader.php
@@ -4,6 +4,7 @@ class Typebot_Loader
 {
 	protected $actions;
 	protected $filters;
+    	protected $shortcodes;
 
 	public function __construct()
 	{


### PR DESCRIPTION
In PHP 8.2+, creating properties on an object that are not declared in the class definition is deprecated. The fix is to explicitly declare the property in the class definition.