### PR TITLE
Fix: generate token without refresh by updating CreateTokenModal

### DIFF
--- a/apps/builder/src/features/user/components/CreateTokenModal.tsx
+++ b/apps/builder/src/features/user/components/CreateTokenModal.tsx
@@ -16,7 +16,7 @@ import {
 } from "@chakra-ui/react";
 import { useTranslate } from "@tolgee/react";
 import type { FormEvent } from "react";
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { createApiTokenQuery } from "../queries/createApiTokenQuery";
 import type { ApiTokenFromServer } from "../types";
 
@@ -38,6 +38,14 @@ export const CreateTokenModal = ({
   const [name, setName] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [newTokenValue, setNewTokenValue] = useState<string>();
+
+  useEffect(() => {
+    if (!isOpen) {
+      setName("");
+      setNewTokenValue(undefined);
+      setIsSubmitting(false);
+    }
+  }, [isOpen]);
 
   const createToken = async (e: FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
Problem:
After creating an API token, reopening the `CreateTokenModal` would still display the previously created token instead of the token creation form. This blocked users from generating multiple tokens in one session without refreshing the page.

Cause
The modal's internal state variables (`newTokenValue`, `name`, and `isSubmitting`) were not being reset when the modal was closed or reopened.

 Solution
Added a `useEffect` hook that resets the internal state when the modal is closed. This ensures the modal always shows the token creation form upon reopening, allowing users to create multiple tokens in one session.

Before: 
https://github.com/user-attachments/assets/76f18bdd-71d2-48c3-a598-45b809236f95

After:
https://github.com/user-attachments/assets/8dc2a0ef-0661-41ef-93d4-e521719a56fd


Fixes #2239
