### PR TITLE
fix(bot-engine): fallback to iframeReferrerOrigin in continueChat origin check (issue #2263)

### DIFF
--- a/packages/bot-engine/src/apiHandlers/continueChat.ts
+++ b/packages/bot-engine/src/apiHandlers/continueChat.ts
@@ -37,7 +37,7 @@ export const continueChat = async ({
     });
   }
 
-  assertOriginIsAllowed(origin, {
+  assertOriginIsAllowed(origin ?? iframeReferrerOrigin, {
     allowedOrigins: session.state.allowedOrigins,
     iframeReferrerOrigin,
   });


### PR DESCRIPTION
Closes #2263

Follow-up requests to /sessions/:id/continueChat from iframe embeds can send an unexpected or missing Origin (e.g., switching to typebot.co), causing "FORBIDDEN: Origin not allowed" despite the initial request being valid.

Use iframeReferrerOrigin as a fallback when Origin is undefined, while still validating against session.state.allowedOrigins. This mirrors the first-request preprocessing behavior (startChat) and preserves existing security boundaries.