### PR TITLE
🔧 Auto-approve owner PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,14 @@
+name: Auto approve PRs by owner
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  auto-approve:
+    if: github.event.pull_request.user.login == 'baptisteArno' && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v4


### PR DESCRIPTION
Adds a workflow that auto-approves PRs authored by baptisteArno. Runs on PR open/reopen/synchronize and skips drafts.