### PR TITLE
🔧 Centralize telemetry layer and trim export logs

### DIFF
--- a/apps/builder/src/features/results/api/handleStreamExportJob.ts
+++ b/apps/builder/src/features/results/api/handleStreamExportJob.ts
@@ -4,11 +4,11 @@ import { createId } from "@typebot.io/lib/createId";
 import prisma from "@typebot.io/prisma";
 import type { ExportResultsWorkflowStatusChunk } from "@typebot.io/results/workflows/rpc";
 import { ResultsWorkflowsRpcClient } from "@typebot.io/results/workflows/rpc";
+import { TelemetryLayer } from "@typebot.io/telemetry/telemetryLayer";
 import { isReadTypebotForbidden } from "@typebot.io/typebot/helpers/isReadTypebotForbidden";
 import type { User } from "@typebot.io/user/schemas";
 import { Cause, Effect, Layer, Queue, Stream } from "effect";
 import { z } from "zod";
-import { TelemetryLayer } from "@/lib/telemetry";
 
 const MainLayer = Layer.provideMerge(
   Layer.provide(

--- a/apps/builder/src/features/results/api/handleTriggerSendExportResultsToEmail.ts
+++ b/apps/builder/src/features/results/api/handleTriggerSendExportResultsToEmail.ts
@@ -2,11 +2,11 @@ import { ORPCError } from "@orpc/server";
 import { WorkflowsRpcClientConfig } from "@typebot.io/config";
 import prisma from "@typebot.io/prisma";
 import { ResultsWorkflowsRpcClient } from "@typebot.io/results/workflows/rpc";
+import { TelemetryLayer } from "@typebot.io/telemetry/telemetryLayer";
 import { isReadTypebotForbidden } from "@typebot.io/typebot/helpers/isReadTypebotForbidden";
 import type { User } from "@typebot.io/user/schemas";
 import { Effect, Layer } from "effect";
 import { z } from "zod";
-import { TelemetryLayer } from "@/lib/telemetry";
 
 const MainLayer = Layer.provideMerge(
   Layer.provide(

--- a/packages/results/src/streamAllResultsToCsvV2.ts
+++ b/packages/results/src/streamAllResultsToCsvV2.ts
@@ -99,10 +99,6 @@ export const streamResultsToCsvV2 = (
       },
     });
 
-    yield* Effect.logInfo("Starting CSV generation stream").pipe(
-      Effect.annotateLogs({ totalResultsToExport }),
-    );
-
     const totalRowsExportedRef = yield* Ref.make(0);
 
     // Create a stream of CSV chunks

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -7,12 +7,16 @@
     "./*": "./src/*.ts"
   },
   "dependencies": {
+    "@effect/opentelemetry": "^0.60.0",
     "@typebot.io/env": "workspace:*",
-    "@typebot.io/prisma": "workspace:*",
-    "posthog-node": "^5.8.2",
-    "ky": "^1.2.4",
-    "cookie": "^1.0.2",
     "@typebot.io/lib": "workspace:*",
+    "@typebot.io/prisma": "workspace:*",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.209.0",
+    "@opentelemetry/sdk-trace-base": "^2.3.0",
+    "cookie": "^1.0.2",
+    "effect": "^3.19.14",
+    "ky": "^1.2.4",
+    "posthog-node": "^5.8.2",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/packages/telemetry/src/telemetryLayer.ts
+++ b/packages/telemetry/src/telemetryLayer.ts
@@ -1,14 +1,15 @@
 import { NodeSdk } from "@effect/opentelemetry";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { env } from "@typebot.io/env";
 import { Effect, Layer } from "effect";
 
 export const TelemetryLayer = Layer.unwrapEffect(
   Effect.sync(() => {
-    const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    const endpoint = env.OTEL_EXPORTER_OTLP_ENDPOINT;
     if (!endpoint) return Layer.empty;
 
-    const headers = parseOtlpHeaders(process.env.OTEL_EXPORTER_OTLP_HEADERS);
+    const headers = parseOtlpHeaders(env.OTEL_EXPORTER_OTLP_HEADERS);
 
     return NodeSdk.layer(() => ({
       resource: { serviceName: "builder" },


### PR DESCRIPTION
Move the OTEL TelemetryLayer into @typebot.io/telemetry and reuse it for builder export triggers and auth onboarding RPC so root spans are exported. Remove the local builder telemetry helper. Trim noisy export CSV workflow logging.