### PR TITLE
💅 Make group title hitbox fit text

### DIFF
--- a/apps/builder/src/features/graph/components/nodes/group/GroupNode.tsx
+++ b/apps/builder/src/features/graph/components/nodes/group/GroupNode.tsx
@@ -188,8 +188,9 @@ export const GroupNode = ({ group, groupIndex }: Props) => {
             }}
             preview={{
               className: cx(
-                isEmpty(groupTitle) &&
-                  "absolute block left-4 top-2.5 w-[calc(100%-2rem)]  h-2",
+                isEmpty(groupTitle)
+                  ? "absolute block left-4 top-2.5 w-[calc(100%-2rem)] h-2"
+                  : "w-fit max-w-[calc(100%-2rem)]",
               ),
             }}
             onValueCommit={handleTitleSubmit}


### PR DESCRIPTION
Adjust the group title preview to size to its text while keeping a wide target when empty. This prevents the title area from blocking group drag interactions.