### PR TITLE
🔧 add rpc retries and email divider

### DIFF
--- a/packages/config/src/workflowsRpcProtocol.ts
+++ b/packages/config/src/workflowsRpcProtocol.ts
@@ -4,9 +4,13 @@ import {
   HttpClientRequest,
 } from "@effect/platform";
 import { RpcClient, RpcSerialization } from "@effect/rpc";
-import { Effect, Layer, Option, Redacted } from "effect";
+import { Effect, Layer, Option, Redacted, Schedule } from "effect";
 import { RPC_SECRET_HEADER_KEY } from "./constants";
 import { WorkflowsRpcClientConfig } from "./index";
+
+const workflowsRpcRetrySchedule = Schedule.exponential("200 millis").pipe(
+  Schedule.jittered,
+);
 
 export const WorkflowsRpcClientProtocolLayer = Effect.gen(function* () {
   const { rpcSecret, rpcUrl } = yield* WorkflowsRpcClientConfig;
@@ -16,13 +20,19 @@ export const WorkflowsRpcClientProtocolLayer = Effect.gen(function* () {
       () => new URL("http://localhost:3007/rpc"),
     ).toString(),
     transformClient: (client) =>
-      HttpClient.mapRequest(client, (request) =>
-        request.pipe(
-          HttpClientRequest.setHeader(
-            RPC_SECRET_HEADER_KEY,
-            Redacted.value(rpcSecret),
+      client.pipe(
+        HttpClient.mapRequest((request) =>
+          request.pipe(
+            HttpClientRequest.setHeader(
+              RPC_SECRET_HEADER_KEY,
+              Redacted.value(rpcSecret),
+            ),
           ),
         ),
+        HttpClient.retry({
+          schedule: workflowsRpcRetrySchedule,
+          times: 2,
+        }),
       ),
   });
 }).pipe(

--- a/packages/emails/transactional/UserOnboardingEmail.tsx
+++ b/packages/emails/transactional/UserOnboardingEmail.tsx
@@ -2,6 +2,7 @@ import {
   Body,
   Container,
   Head,
+  Hr,
   Html,
   Link,
   Preview,
@@ -67,6 +68,7 @@ export const UserOnboardingEmail = ({ unsubscribeUrl }: Props) => (
           <br />
           Baptiste.
         </Text>
+        <Hr />
         {unsubscribeUrl ? (
           <Text style={{ ...footerText, marginTop: "24px" }}>
             <Link href={unsubscribeUrl}>Click here to unsubscribe</Link>


### PR DESCRIPTION
Add a retry policy for workflows RPC HTTP calls to make onboarding best-effort on transient failures. Include a small onboarding email divider for readability.