### PR TITLE
🔧 enforce assignment-safe linting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,69 +7,13 @@ Typebot is a chatbot platform that provides a visual builder for composing conve
 - `apps/builder/` - Visual flow editor
 - `apps/viewer/` - Runtime that executes bots
 - `apps/landing-page/` - Commercial website landing page
+- `apps/workflows/` - Durable workflows server
 - `apps/docs/` - Documentation
 - `packages/` - All feature-driven modules, shared libs, schemas, UI package.
 
-## Default Workflow
-
-Follow this workflow unless explicitly instructed otherwise.
-
-1. **Explore the current state**
-
-   - Inspect the existing implementation.
-   - Identify relevant files, patterns, and constraints.
-
-2. **Research** (Never skip this step)
-
-   - Never check node_modules. You have access to any package, CLI and Github repo source code and documentation using `opensrc` skill. Always prefer using `opensrc` instead of web search if possible.
-   - If we are working with some Effect code, make sure to run `bunx effect-solutions list` and read the relevant best practices guide.
-   - Use web searches when you want to look for blog posts or Github issues for example.
-   - Never rely on assumptions or prior knowledge. Verify behavior directly in the source.
-
-3. **Clarify uncertainties** (IMPORTANT: Before editting anything, never skip this step)
-
-   - Explain what you found from opensrc or web searches
-   - Ask questions about unclear requirements, edge cases, or technical decisions.
-   - Report what you are planning on doing
-   - If I mention "IMPLEMENT" or "GO", it means you can move to step 4.
-
-4. **Implement**
-
-   - Follow established project conventions.
-   - Prefer the smallest change that keeps the design coherent.
-   - If the smallest change would introduce or extend inconsistency/tech debt, propose a refactor plan first:
-     - What is incoherent today and why the small fix worsens it
-     - The refactor scope (files/modules impacted)
-     - Migration strategy (incremental steps if possible)
-     - Test plan and verification steps
-   - After the plan is agreed, implement the refactor.
-   - Add or update unit tests when relevant.
-   - Unit tests must use the `*.test.ts` suffix.
-
-5. **Verify** (IMPORTANT: never skip this step)
-
-   - Run `bun run check`. It runs typechecking, lint and unit tests.
-
-6. **Review**
-
-   - Re-read the implementation as a reviewer, not the author.
-   - Look for:
-     - Bugs, edge cases, or incorrect assumptions
-     - Type-safety issues or unsound casts
-     - Inconsistencies with existing patterns
-     - Unnecessary complexity or missed simplifications
-   - If issues are found, fix them and re-run verification.
-
-7. **Report**
-
-   - Summarize key decisions made during implementation.
-   - Call out any tradeoffs, assumptions, or rejected alternatives.
-   - Explicitly mention if:
-     - A refactor was chosen over a local fix (and why)
-     - Existing behavior was preserved intentionally
-     - Open questions or follow-ups remain
-
 ## opensrc
+
+Never check node_modules. You have access to any package, CLI and Github repo source code and documentation using `opensrc` skill. Always prefer using `opensrc` instead of web search if possible.
 
 To fetch source code for a package or repository you need to understand, run:
 
@@ -84,7 +28,6 @@ Source code for dependencies is then available in `opensrc/`.
 
 ## Coding guidelines
 
-- Never use `any` type. Always use proper TypeScript types, interfaces, or union types instead.
 - Whenever possible, never use `as`. Instead, use `satisfies` as a last resort to make sure we keep strong type-safety.
 - Only add a comment if a piece of logic is hard to grasp.
 - Prefer inferring types instead of declaring it.
@@ -92,14 +35,3 @@ Source code for dependencies is then available in `opensrc/`.
 - Functions used only locally should stay in the same file at the bottom of it. Only export helpers if used elsewhere then the helper file should have the same name as the function.
 - No brackets on `if` blocks if it's just 1 line.
 - Outside of Effect code, prefer using `env` from `@typebot.io/env` instead of `process.env` directly. This package provides type-safe, validated environment variables.
-
-## Refactors
-
-Deep refactors are allowed when they reduce long-term complexity or restore architectural coherence.
-
-Rules:
-
-- Propose before implementing if the change is cross-cutting or touches core abstractions.
-- Keep the refactor goal-oriented (no “cleanup while here”).
-- Preserve behavior unless a behavior change is explicitly required.
-- Prefer incremental refactors when feasible; otherwise ensure the change remains reviewable.

--- a/apps/builder/src/features/editor/providers/typebotActions/edges.ts
+++ b/apps/builder/src/features/editor/providers/typebotActions/edges.ts
@@ -123,7 +123,9 @@ const addEdgeIdToEvent = (
   typebot: Draft<TypebotV6>,
   edgeId: string,
   { eventIndex }: { eventIndex: number },
-) => (typebot.events[eventIndex].outgoingEdgeId = edgeId);
+) => {
+  typebot.events[eventIndex].outgoingEdgeId = edgeId;
+};
 
 const addEdgeIdToBlock = (
   typebot: Draft<Typebot>,
@@ -137,21 +139,23 @@ const addEdgeIdToItem = (
   typebot: Draft<Typebot>,
   edgeId: string,
   { groupIndex, blockIndex, itemIndex }: ItemIndices,
-) =>
-  ((typebot.groups[groupIndex].blocks[blockIndex] as BlockWithItems).items[
+) => {
+  (typebot.groups[groupIndex].blocks[blockIndex] as BlockWithItems).items[
     itemIndex
-  ].outgoingEdgeId = edgeId);
+  ].outgoingEdgeId = edgeId;
+};
 
 const addEdgeIdToPath = (
   typebot: Draft<Typebot>,
   edgeId: string,
   { groupIndex, blockIndex, itemIndex, pathIndex }: PathIndices,
-) =>
-  ((
+) => {
+  (
     (typebot.groups[groupIndex].blocks[blockIndex] as BlockWithItems).items[
       itemIndex
     ] as ItemWithPaths
-  ).paths[pathIndex].outgoingEdgeId = edgeId);
+  ).paths[pathIndex].outgoingEdgeId = edgeId;
+};
 
 export const deleteEdgeDraft = ({
   typebot,

--- a/apps/builder/src/features/editor/providers/typebotActions/events.ts
+++ b/apps/builder/src/features/editor/providers/typebotActions/events.ts
@@ -77,9 +77,9 @@ const eventsActions = (setTypebot: SetTypebot): EventsActions => ({
   updateEventsCoordinates: (newCoord) =>
     setTypebot((typebot) =>
       produce(typebot, (typebot) => {
-        typebot.events.forEach(
-          (event) => (event.graphCoordinates = newCoord[event.id]),
-        );
+        typebot.events.forEach((event) => {
+          event.graphCoordinates = newCoord[event.id];
+        });
       }),
     ),
   pasteEvents: (clipboard, { oldToNewIdsMapping, updateCoordinates }) => {

--- a/apps/builder/src/features/editor/providers/typebotActions/items.ts
+++ b/apps/builder/src/features/editor/providers/typebotActions/items.ts
@@ -58,12 +58,14 @@ export const itemsAction = (setTypebot: SetTypebot): ItemsActions => ({
 
         if (item.outgoingEdgeId) {
           const edgeIndex = typebot.edges.findIndex(byId(item.outgoingEdgeId));
-          edgeIndex !== -1
-            ? (typebot.edges[edgeIndex].from = {
-                blockId: block.id,
-                itemId: newItem.id,
-              })
-            : (newItem.outgoingEdgeId = undefined);
+          if (edgeIndex !== -1) {
+            typebot.edges[edgeIndex].from = {
+              blockId: block.id,
+              itemId: newItem.id,
+            };
+          } else {
+            newItem.outgoingEdgeId = undefined;
+          }
         }
 
         newItemId = newItem.id;

--- a/apps/builder/src/features/graph/components/nodes/block/BlockNodesList.tsx
+++ b/apps/builder/src/features/graph/components/nodes/block/BlockNodesList.tsx
@@ -69,7 +69,7 @@ export const BlockNodesList = ({ blocks, groupIndex, groupRef }: Props) => {
 
   const handlePushElementRef =
     (idx: number) => (elem: HTMLDivElement | null) => {
-      elem && (placeholderRefs.current[idx] = elem);
+      if (elem) placeholderRefs.current[idx] = elem;
     };
 
   const onGroupMouseMove = useCallback(

--- a/apps/builder/src/features/graph/components/nodes/item/ItemNodesList.tsx
+++ b/apps/builder/src/features/graph/components/nodes/item/ItemNodesList.tsx
@@ -125,7 +125,7 @@ export const ItemNodesList = ({
 
   const handlePushElementRef =
     (idx: number) => (elem: HTMLDivElement | null) => {
-      elem && (placeholderRefs.current[idx] = elem);
+      if (elem) placeholderRefs.current[idx] = elem;
     };
 
   const groupId = typebot?.groups.at(groupIndex)?.id;

--- a/biome.json
+++ b/biome.json
@@ -82,7 +82,6 @@
       },
       "suspicious": {
         "noArrayIndexKey": "off",
-        "noAssignInExpressions": "off",
         "noImplicitAnyLet": "off",
         "noExplicitAny": "off",
         "noExportsInTest": "off",

--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,14 @@
     "": {
       "name": "root",
       "devDependencies": {
-        "@biomejs/biome": "^2.3.7",
+        "@biomejs/biome": "^2.3.13",
         "@effect/language-service": "^0.65.0",
         "@tolgee/cli": "^2.14.0",
         "effect-solutions": "^0.4.13",
         "husky": "^9.1.7",
         "rimraf": "^6.1.2",
-        "sherif": "^1.9.0",
-        "turbo": "^2.6.1",
+        "sherif": "^1.10.0",
+        "turbo": "^2.7.6",
         "typescript": "^5.9.3",
       },
     },
@@ -1671,23 +1671,23 @@
 
     "@base-ui-components/utils": ["@base-ui-components/utils@0.1.2", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-aEitDGpMsYO2qnSpYOwZNykn9Rzn2ioyEVk2fyDRH7t+TIHVKpp9CeV7SPTq43M9mMSDxQ+7UeZJVkrj2dCVIQ=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.3.7", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.7", "@biomejs/cli-darwin-x64": "2.3.7", "@biomejs/cli-linux-arm64": "2.3.7", "@biomejs/cli-linux-arm64-musl": "2.3.7", "@biomejs/cli-linux-x64": "2.3.7", "@biomejs/cli-linux-x64-musl": "2.3.7", "@biomejs/cli-win32-arm64": "2.3.7", "@biomejs/cli-win32-x64": "2.3.7" }, "bin": { "biome": "bin/biome" } }, "sha512-CTbAS/jNAiUc6rcq94BrTB8z83O9+BsgWj2sBCQg9rD6Wkh2gjfR87usjx0Ncx0zGXP1NKgT7JNglay5Zfs9jw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.3.13", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.13", "@biomejs/cli-darwin-x64": "2.3.13", "@biomejs/cli-linux-arm64": "2.3.13", "@biomejs/cli-linux-arm64-musl": "2.3.13", "@biomejs/cli-linux-x64": "2.3.13", "@biomejs/cli-linux-x64-musl": "2.3.13", "@biomejs/cli-win32-arm64": "2.3.13", "@biomejs/cli-win32-x64": "2.3.13" }, "bin": { "biome": "bin/biome" } }, "sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LirkamEwzIUULhXcf2D5b+NatXKeqhOwilM+5eRkbrnr6daKz9rsBL0kNZ16Hcy4b8RFq22SG4tcLwM+yx/wFA=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-Q4TO633kvrMQkKIV7wmf8HXwF0dhdTD9S458LGE24TYgBjSRbuhvio4D5eOQzirEYg6eqxfs53ga/rbdd8nBKg=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-inHOTdlstUBzgjDcx0ge71U4SVTbwAljmkfi3MC5WzsYCRhancqfeL+sa4Ke6v2ND53WIwCFD5hGsYExoI3EZQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-/afy8lto4CB8scWfMdt+NoCZtatBUF62Tk3ilWH2w8ENd5spLhM77zKlFZEvsKJv9AFNHknMl03zO67CiklL2Q=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.7", "", { "os": "linux", "cpu": "x64" }, "sha512-fJMc3ZEuo/NaMYo5rvoWjdSS5/uVSW+HPRQujucpZqm2ZCq71b8MKJ9U4th9yrv2L5+5NjPF0nqqILCl8HY/fg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.13", "", { "os": "linux", "cpu": "x64" }, "sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.7", "", { "os": "linux", "cpu": "x64" }, "sha512-CQUtgH1tIN6e5wiYSJqzSwJumHYolNtaj1dwZGCnZXm2PZU1jOJof9TsyiP3bXNDb+VOR7oo7ZvY01If0W3iFQ=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.13", "", { "os": "linux", "cpu": "x64" }, "sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJAE8eCNyRpcfx2JJAtsPtISnELJ0H4xVVSwnxm13bzI8RwbXMyVtxy2r5DV1xT3WiSP+7LxORcApWw0LM8HiA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.7", "", { "os": "win32", "cpu": "x64" }, "sha512-pulzUshqv9Ed//MiE8MOUeeEkbkSHVDVY5Cz5wVAnH1DUqliCQG3j6s1POaITTFqFfo7AVIx2sWdKpx/GS+Nqw=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.13", "", { "os": "win32", "cpu": "x64" }, "sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.0.1", "", {}, "sha512-URg8UM6lfC9ZYqFipItRSxYJdgpU5d2Z4KnjsJ+rj6tgAmGme7E+PQNCiud8g0HDaZKMovu2qjfa0f5Ge0Vlsg=="],
 
@@ -5331,23 +5331,23 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "sherif": ["sherif@1.9.0", "", { "optionalDependencies": { "sherif-darwin-arm64": "1.9.0", "sherif-darwin-x64": "1.9.0", "sherif-linux-arm64": "1.9.0", "sherif-linux-arm64-musl": "1.9.0", "sherif-linux-x64": "1.9.0", "sherif-linux-x64-musl": "1.9.0", "sherif-windows-arm64": "1.9.0", "sherif-windows-x64": "1.9.0" }, "bin": { "sherif": "index.js" } }, "sha512-5n7zqPAjL+RzR7n09NPKpWBXmDCtuRpQzIL+ycj8pe6MayV7cDuFmceoyPQJ0c95oFj6feY7SZvhX/+S0i1ukg=="],
+    "sherif": ["sherif@1.10.0", "", { "optionalDependencies": { "sherif-darwin-arm64": "1.10.0", "sherif-darwin-x64": "1.10.0", "sherif-linux-arm64": "1.10.0", "sherif-linux-arm64-musl": "1.10.0", "sherif-linux-x64": "1.10.0", "sherif-linux-x64-musl": "1.10.0", "sherif-windows-arm64": "1.10.0", "sherif-windows-x64": "1.10.0" }, "bin": { "sherif": "index.js" } }, "sha512-DHg6+Pj7ORhYyC+CaSAr8DeRxqf9GXB90yqLmUILPtY7WhZuJatMir3id2MNjuF5I/1313SbrTTItIDu//G4jg=="],
 
-    "sherif-darwin-arm64": ["sherif-darwin-arm64@1.9.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-R+RpKSzlqZgBHean04CqHrdlmBBKu6Dhd/9BcdCpjx/KpqsalZsh9LzBVxTWLTtT9IBb/ccr23PNqFzWQTuh6A=="],
+    "sherif-darwin-arm64": ["sherif-darwin-arm64@1.10.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fHRg/fgyxHebCH9vuGEhImyGqmwlBq67BVyI8Ugda8GM+W+Ofj1cQnzDX82cYuCHU+KJ7hQFq8iPHkRizXWOrA=="],
 
-    "sherif-darwin-x64": ["sherif-darwin-x64@1.9.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-b/KX9MczzkzmyEjngGxYuBq/rOdM6CbGcDLFdQ0H990Dmn9foj4C/UpLlyqSxXcsJhy586ATMEVN68aM2hFQdQ=="],
+    "sherif-darwin-x64": ["sherif-darwin-x64@1.10.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-7rhayQ+jlIj3SscnHMi6JVCYR9od/HiqIGIBgOQeux31YRzc/XvfKjE9X+FrCRU+72qz7sqw5ZY7jl7bRxbOUg=="],
 
-    "sherif-linux-arm64": ["sherif-linux-arm64@1.9.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-TyuGhaD/efCxGIk4scx09n6NsTr3qfKvH5qHYdyxtelv1mHRgbzVHwJ+Jj98jVktuzOZoexHpxr/hz7RUjd/nw=="],
+    "sherif-linux-arm64": ["sherif-linux-arm64@1.10.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-QtEju3eLPpEb7hv9QRVdsi2J3bhIFEBbRk0vjdnAEKyRb3q9MjyqEhps69JgaCv8olEiBjGcU1hGP7vl5QVG4A=="],
 
-    "sherif-linux-arm64-musl": ["sherif-linux-arm64-musl@1.9.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-OZ4cKcCXTJTl8zaTxKnP8z0wu05nDeGtttxRQjaXHSKK+fjBwGkH/1qqFEVDcRANUxtLRLLdwmDyxvqQrCzhPQ=="],
+    "sherif-linux-arm64-musl": ["sherif-linux-arm64-musl@1.10.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-TsaQSefkaIJ+oFGGaaPm5BzrjVRnvcquh4q3/e5LB6JdhPTveNPo3o2Pzmq6sKry9dzk3p7sKtzJpLz4q5V/+Q=="],
 
-    "sherif-linux-x64": ["sherif-linux-x64@1.9.0", "", { "os": "linux", "cpu": "x64" }, "sha512-iO+hTxndO36r0hgmipBRjntWFqFHKrrYFRODz0WnmDquVek88LInSzAY1xpS18/Thbff8IVc6ssefYNVFQQPWw=="],
+    "sherif-linux-x64": ["sherif-linux-x64@1.10.0", "", { "os": "linux", "cpu": "x64" }, "sha512-/1ydjgJxXbqnGWViAENHxlX9lEDhATO99qtFcMseUFkPpEAxQ9qFctWf3OB2rciPlHLuPzhphkJAt7ZkX1R5eA=="],
 
-    "sherif-linux-x64-musl": ["sherif-linux-x64-musl@1.9.0", "", { "os": "linux", "cpu": "x64" }, "sha512-JSbA6DN0HkWSabYU858BUkS4cMmkTsAamDZEYuUVDW+XvW9IjaI6o0HNatUr7oCjrITIfcjzqlqy7uizmNlr/A=="],
+    "sherif-linux-x64-musl": ["sherif-linux-x64-musl@1.10.0", "", { "os": "linux", "cpu": "x64" }, "sha512-iSYRYEFE0xfOJVwPjsUN4o8CoNSEyxJHsSliBDxfEZQubN0rmE9f1hs83HPPAkEozGestI7PxKFKcyTgTxEoXg=="],
 
-    "sherif-windows-arm64": ["sherif-windows-arm64@1.9.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-lPqQXDB/95SJodtIbGAJc90O/KyxcunvKTycZqo+6RGjkOSYZB/XnRzm/tJ7If/6kz0/wcDP4uvkJmJxrxcj3A=="],
+    "sherif-windows-arm64": ["sherif-windows-arm64@1.10.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-CBNys+m7TsWD/1/5WQRJCNjfm08VhmBP9JSmecoHCsfDF+o0vt52NDrzVOOeai/c/yYunCBvAAx9EIFXBmgpHw=="],
 
-    "sherif-windows-x64": ["sherif-windows-x64@1.9.0", "", { "os": "win32", "cpu": "x64" }, "sha512-3cL+XVGLpmyLC3UOZYiPr4vY2OFBQqPZnCoCwoRKN+ONm8VfGMirO9iqI0OckgFBUtJoG4AQY/MWxoPhNmzD8A=="],
+    "sherif-windows-x64": ["sherif-windows-x64@1.10.0", "", { "os": "win32", "cpu": "x64" }, "sha512-XRN4SuZQud0X4UKZZxLe4IyVkbo9qa8rvmFhgCoULaRScucNdJJ4r6hnjZ7DR0spl7zSPJNZUNcgnnJmxWfs1Q=="],
 
     "shiki": ["shiki@1.29.2", "", { "dependencies": { "@shikijs/core": "1.29.2", "@shikijs/engine-javascript": "1.29.2", "@shikijs/engine-oniguruma": "1.29.2", "@shikijs/langs": "1.29.2", "@shikijs/themes": "1.29.2", "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1", "@types/hast": "^3.0.4" } }, "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg=="],
 
@@ -5607,19 +5607,19 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
-    "turbo": ["turbo@2.6.1", "", { "optionalDependencies": { "turbo-darwin-64": "2.6.1", "turbo-darwin-arm64": "2.6.1", "turbo-linux-64": "2.6.1", "turbo-linux-arm64": "2.6.1", "turbo-windows-64": "2.6.1", "turbo-windows-arm64": "2.6.1" }, "bin": { "turbo": "bin/turbo" } }, "sha512-qBwXXuDT3rA53kbNafGbT5r++BrhRgx3sAo0cHoDAeG9g1ItTmUMgltz3Hy7Hazy1ODqNpR+C7QwqL6DYB52yA=="],
+    "turbo": ["turbo@2.7.6", "", { "optionalDependencies": { "turbo-darwin-64": "2.7.6", "turbo-darwin-arm64": "2.7.6", "turbo-linux-64": "2.7.6", "turbo-linux-arm64": "2.7.6", "turbo-windows-64": "2.7.6", "turbo-windows-arm64": "2.7.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-PO9AvJLEsNLO+EYhF4zB+v10hOjsJe5kJW+S6tTbRv+TW7gf1Qer4mfjP9h3/y9h8ZiPvOrenxnEgDtFgaM5zw=="],
 
-    "turbo-darwin-64": ["turbo-darwin-64@2.6.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Dm0HwhyZF4J0uLqkhUyCVJvKM9Rw7M03v3J9A7drHDQW0qAbIGBrUijQ8g4Q9Cciw/BXRRd8Uzkc3oue+qn+ZQ=="],
+    "turbo-darwin-64": ["turbo-darwin-64@2.7.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-bYu0qnWju2Ha3EbIkPCk1SMLT3sltKh1P/Jy5FER6BmH++H5z+T5MHh3W1Xoers9rk4N1VdKvog9FO1pxQyjhw=="],
 
-    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.6.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-U0PIPTPyxdLsrC3jN7jaJUwgzX5sVUBsKLO7+6AL+OASaa1NbT1pPdiZoTkblBAALLP76FM0LlnsVQOnmjYhyw=="],
+    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.7.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-KCxTf3Y1hgNLYIWRLw8bwH8Zie9RyCGoxAlXYsCBI/YNqBSR+ZZK9KYzFxAqDaVaNvTwLFv3rJRGsXOFWg4+Uw=="],
 
-    "turbo-linux-64": ["turbo-linux-64@2.6.1", "", { "os": "linux", "cpu": "x64" }, "sha512-eM1uLWgzv89bxlK29qwQEr9xYWBhmO/EGiH22UGfq+uXr+QW1OvNKKMogSN65Ry8lElMH4LZh0aX2DEc7eC0Mw=="],
+    "turbo-linux-64": ["turbo-linux-64@2.7.6", "", { "os": "linux", "cpu": "x64" }, "sha512-vjoU8zIfNgvJR3cMitgw7inEoi6bmuVuFawDl5yKtxjAEhDktFdRBpGS3WojD4l3BklBbIK689ssXcGf21LxRA=="],
 
-    "turbo-linux-arm64": ["turbo-linux-arm64@2.6.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-MFFh7AxAQAycXKuZDrbeutfWM5Ep0CEZ9u7zs4Hn2FvOViTCzIfEhmuJou3/a5+q5VX1zTxQrKGy+4Lf5cdpsA=="],
+    "turbo-linux-arm64": ["turbo-linux-arm64@2.7.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-TcMpBvTqZf+1DptrVYLbZls7WY1UVNDTGaf0bo7/GCgWYv5eZHCVo4Td7kCJeDU4glbXg67REX0md0S0V6ghMg=="],
 
-    "turbo-windows-64": ["turbo-windows-64@2.6.1", "", { "os": "win32", "cpu": "x64" }, "sha512-buq7/VAN7KOjMYi4tSZT5m+jpqyhbRU2EUTTvp6V0Ii8dAkY2tAAjQN1q5q2ByflYWKecbQNTqxmVploE0LVwQ=="],
+    "turbo-windows-64": ["turbo-windows-64@2.7.6", "", { "os": "win32", "cpu": "x64" }, "sha512-1/MhkYldiihjneY8QnnDMbAkHXn/udTWSVYS94EMlkE9AShozsLTTOT1gDOpX06EfEW5njP09suhMvxbvwuwpQ=="],
 
-    "turbo-windows-arm64": ["turbo-windows-arm64@2.6.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-7w+AD5vJp3R+FB0YOj1YJcNcOOvBior7bcHTodqp90S3x3bLgpr7tE6xOea1e8JkP7GK6ciKVUpQvV7psiwU5Q=="],
+    "turbo-windows-arm64": ["turbo-windows-arm64@2.7.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-0wDVnUJLFAWm4ZzOQFDkbyyUqaszorTGf3Rdc22IRIyJTTLd6ajqdb+cWD89UZ1RKr953+PZR1gqgWQY4PDuhA=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "sync-agents-config": "bunx @iannuttall/dotagents"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.7",
+    "@biomejs/biome": "^2.3.13",
     "@tolgee/cli": "^2.14.0",
     "husky": "^9.1.7",
-    "sherif": "^1.9.0",
-    "turbo": "^2.6.1",
+    "sherif": "^1.10.0",
+    "turbo": "^2.7.6",
     "typescript": "^5.9.3",
     "rimraf": "^6.1.2",
     "@effect/language-service": "^0.65.0",

--- a/packages/embeds/js/src/features/blocks/inputs/textInput/components/VoiceRecorder.tsx
+++ b/packages/embeds/js/src/features/blocks/inputs/textInput/components/VoiceRecorder.tsx
@@ -95,7 +95,7 @@ export const VoiceRecorder = (props: Props) => {
     if (!ctx) ctx = canvasElement.getContext("2d") ?? undefined;
 
     recordTimeInterval = setInterval(() => {
-      setRecordingTime((prev) => (prev += 1));
+      setRecordingTime((prev) => prev + 1);
     }, 1000);
 
     audioContext = new AudioContext();

--- a/packages/forge/core/src/types.ts
+++ b/packages/forge/core/src/types.ts
@@ -259,13 +259,10 @@ export type BlockDefinition<
   actions: ActionDefinition<Auth, BaseOptions, z.ZodObject<z.ZodRawShape>>[];
 };
 
-export type FetchItemsParams<T> = T extends ActionDefinition<
-  infer A,
-  infer BaseOptions,
-  infer Options
->
-  ? {
-      credentials: CredentialsFromAuthDef<A>;
-      options: BaseOptions & Options;
-    }
-  : never;
+export type FetchItemsParams<T> =
+  T extends ActionDefinition<infer A, infer BaseOptions, infer Options>
+    ? {
+        credentials: CredentialsFromAuthDef<A>;
+        options: BaseOptions & Options;
+      }
+    : never;

--- a/packages/prisma/scripts/db-generate.ts
+++ b/packages/prisma/scripts/db-generate.ts
@@ -2,7 +2,7 @@ import { executePrismaCommand } from "./executeCommand";
 import { patchEffectClient } from "./patchEffectClient";
 
 const run = async () => {
-  await executePrismaCommand("prisma generate", { force: true });
+  await executePrismaCommand("prisma generate --no-hints", { force: true });
   await patchEffectClient();
 };
 

--- a/packages/whatsapp/src/resumeWhatsAppFlow.ts
+++ b/packages/whatsapp/src/resumeWhatsAppFlow.ts
@@ -190,7 +190,9 @@ const convertWhatsAppMessageToTypebotMessage = async ({
   block?: Block;
 }): Promise<Message | undefined> => {
   let text = "";
-  const append = (s: string) => (text = text !== "" ? `${text}\n\n${s}` : s);
+  const append = (s: string) => {
+    text = text !== "" ? `${text}\n\n${s}` : s;
+  };
   let replyId: string | undefined;
   const attachedFileUrls: string[] = [];
   for (const message of messages) {

--- a/turbo.json
+++ b/turbo.json
@@ -2,24 +2,26 @@
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [".env"],
   "globalEnv": ["DATABASE_URL", "SKIP_ENV_CHECK", "DATABASE_URL_REPLICA"],
-  "globalPassThroughEnv": ["ENCRYPTION_SECRET"],
   "envMode": "loose",
   "tasks": {
     "typecheck": {
-      "cache": false,
-      "dependsOn": ["@typebot.io/react#build"]
+      "dependsOn": ["@typebot.io/react#build", "^typecheck"],
+      "outputLogs": "new-only"
     },
     "landing-page#typecheck": {
       "dependsOn": [
         "@typebot.io/react#build",
         "landing-page#content-collections:build"
-      ]
+      ],
+      "outputLogs": "new-only"
     },
     "content-collections:build": {
-      "outputs": [".content-collections/generated/**"]
+      "outputs": [".content-collections/generated/**"],
+      "outputLogs": "new-only"
     },
     "@typebot.io/react#build": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "outputLogs": "new-only"
     },
     "dev": {
       "cache": false,
@@ -78,7 +80,7 @@
     },
     "test": {
       "dependsOn": ["^test"],
-      "cache": false
+      "outputLogs": "new-only"
     },
     "//#lint-repo": {
       "cache": false


### PR DESCRIPTION
This enforces Biome's no-assign-in-expressions rule and rewrites offending spots. Turbo typecheck/test now participate in caching with clearer output logs. Tooling versions and Prisma generate flags were updated, plus minor doc/format tweaks.