### PR TITLE
🔧 Enforce noDangerouslySetInnerHtml in templates

### DIFF
--- a/apps/landing-page/src/routes/_layout/templates/$slug.tsx
+++ b/apps/landing-page/src/routes/_layout/templates/$slug.tsx
@@ -4,7 +4,7 @@ import { templates } from "@typebot.io/templates";
 import { Badge } from "@typebot.io/ui/components/Badge";
 import { ContentPageWrapper } from "@/components/ContentPageWrapper";
 import { ButtonLink, CtaButtonLink } from "@/components/link";
-import { currentBaseUrl, dashboardUrl } from "@/constants";
+import { dashboardUrl } from "@/constants";
 import { TemplateCard } from "@/features/templates/TemplateCard";
 import { createMetaTags } from "@/lib/createMetaTags";
 
@@ -41,22 +41,9 @@ function RouteComponent() {
   const { template, relatedTemplates } = Route.useLoaderData();
   const slug = template.slug;
   const templateTitle = getTemplateTitle(template);
-  const structuredData = createTemplateStructuredData(template, slug);
 
   return (
     <ContentPageWrapper className="md:pt-12">
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(structuredData.template),
-        }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(structuredData.breadcrumbs),
-        }}
-      />
       <div className="flex flex-col gap-12 max-w-5xl mx-auto w-full">
         <ButtonLink
           to="/templates"
@@ -159,59 +146,6 @@ function RouteComponent() {
     </ContentPageWrapper>
   );
 }
-
-const createTemplateStructuredData = (template: Template, slug: string) => {
-  const url = `${currentBaseUrl}/templates/${slug}`;
-  const keywords = ["chatbot template", template.useCase, ...template.features]
-    .filter((keyword) => keyword.length > 0)
-    .join(", ");
-
-  const templateJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "CreativeWork",
-    name: getTemplateTitle(template),
-    description: template.summary,
-    url,
-    inLanguage: "en",
-    publisher: {
-      "@type": "Organization",
-      name: "Typebot",
-      url: currentBaseUrl,
-    },
-    about: template.useCase,
-    keywords,
-  } satisfies Record<string, unknown>;
-
-  const breadcrumbsJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      {
-        "@type": "ListItem",
-        position: 1,
-        name: "Home",
-        item: currentBaseUrl,
-      },
-      {
-        "@type": "ListItem",
-        position: 2,
-        name: "Templates",
-        item: `${currentBaseUrl}/templates`,
-      },
-      {
-        "@type": "ListItem",
-        position: 3,
-        name: getTemplateTitle(template),
-        item: url,
-      },
-    ],
-  } satisfies Record<string, unknown>;
-
-  return {
-    template: templateJsonLd,
-    breadcrumbs: breadcrumbsJsonLd,
-  };
-};
 
 const getTemplateTitle = (template: Template) =>
   `${template.name} Chatbot Template`;

--- a/apps/landing-page/src/routes/_layout/templates/index.tsx
+++ b/apps/landing-page/src/routes/_layout/templates/index.tsx
@@ -79,14 +79,8 @@ function RouteComponent() {
     return matchesSearch && matchesUseCase && matchesFeatures;
   });
 
-  const jsonLd = createTemplatesItemListJsonLd();
-
   return (
     <ContentPageWrapper>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
       <div className="flex flex-col w-full gap-8">
         <TemplatesHero />
         <div className="flex gap-8 w-full">
@@ -116,23 +110,6 @@ function RouteComponent() {
     </ContentPageWrapper>
   );
 }
-
-const createTemplatesItemListJsonLd = () => {
-  const itemListElement = templates.map((template, index) => ({
-    "@type": "ListItem",
-    position: index + 1,
-    name: getTemplateTitle(template),
-    url: `${currentBaseUrl}/templates/${template.slug}`,
-    description: template.summary,
-  }));
-
-  return {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    name: "Typebot Chatbot Templates",
-    itemListElement,
-  } satisfies Record<string, unknown>;
-};
 
 const getTemplateTitle = (template: (typeof templates)[number]) =>
   `${template.name} Chatbot Template`;

--- a/biome.json
+++ b/biome.json
@@ -32,7 +32,6 @@
     "rules": {
       "recommended": true,
       "security": {
-        "noDangerouslySetInnerHtml": "off",
         "noGlobalEval": "off"
       },
       "a11y": {


### PR DESCRIPTION
This removes all JSON-LD <script type="application/ld+json"> blocks from the landing-page templates routes and deletes now-unused helper code. It also removes the biome override that disabled security/noDangerouslySetInnerHtml so the rule is enforced again. Validation: bun format-and-lint:fix passes; bun check currently fails in apps/landing-page due existing @typebot.io/react resolution errors unrelated to this change.