### PR TITLE
🔧 Add iframe titles and enable iframe a11y lint

### DIFF
--- a/apps/builder/src/features/blocks/bubbles/video/components/VideoBubbleContent.tsx
+++ b/apps/builder/src/features/blocks/bubbles/video/components/VideoBubbleContent.tsx
@@ -56,6 +56,7 @@ export const VideoBubbleContent = ({ block }: Props) => {
       return (
         <div className="w-full h-[120px] relative">
           <iframe
+            title="Video preview"
             src={`${baseUrl}/${block.content.id}`}
             style={{
               width: "100%",
@@ -74,6 +75,7 @@ export const VideoBubbleContent = ({ block }: Props) => {
       return (
         <div className="w-full h-[300px] relative">
           <iframe
+            title="TikTok video preview"
             src={`https://www.tiktok.com/embed/v2/${block.content.id}`}
             style={{
               width: "100%",

--- a/apps/builder/src/features/onboarding/components/YoutubeIframe.tsx
+++ b/apps/builder/src/features/onboarding/components/YoutubeIframe.tsx
@@ -40,6 +40,7 @@ export const YoutubeIframe = ({ id }: Props) => {
 
   return (
     <iframe
+      title="Onboarding tutorial video"
       id={id}
       src={`https://www.youtube.com/embed/${id}?autoplay=1&enablejsapi=1`}
       allowFullScreen

--- a/apps/builder/src/features/publish/components/deploy/dialogs/iframe/IframeSnippet.tsx
+++ b/apps/builder/src/features/publish/components/deploy/dialogs/iframe/IframeSnippet.tsx
@@ -20,7 +20,7 @@ export const IframeSnippet = ({
   const { typebot } = useTypebot();
   const src = `${env.NEXT_PUBLIC_VIEWER_URL[0]}/${getPublicId(typebot)}`;
   const code = prettier.format(
-    `<iframe src="${src}" style="border: none; width: ${widthLabel}; height: ${heightLabel}"></iframe>`,
+    `<iframe title="Typebot" src="${src}" style="border: none; width: ${widthLabel}; height: ${heightLabel}"></iframe>`,
     { parser: "html", plugins: [parserHtml] },
   );
 

--- a/apps/docs/editor/blocks/integrations/google-sheets.mdx
+++ b/apps/docs/editor/blocks/integrations/google-sheets.mdx
@@ -6,6 +6,7 @@ With the Google Sheets integration step, you can inject, update or get data from
 
 <div className="relative" style={{ paddingBottom: '64.5933014354067%' }}>
   <iframe
+    title="Google Sheets integration overview video"
     src="https://www.youtube.com/embed/UjlZvlqg6mA"
     allowFullScreen
     className="absolute top-0 left-0 w-full h-full"
@@ -29,6 +30,7 @@ For this, you will need to set a new variable with the value "Now" before the Go
 
 <div className="relative" style={{ paddingBottom: '64.5933014354067%' }}>
   <iframe
+    title="Google Sheets integration advanced tutorial video"
     src="https://www.youtube.com/embed/2E0gK-PwFK4"
     allowFullScreen
     className="absolute top-0 left-0 w-full h-full"

--- a/apps/docs/editor/blocks/integrations/make-com.mdx
+++ b/apps/docs/editor/blocks/integrations/make-com.mdx
@@ -46,6 +46,7 @@ Now you can map this data to variables in Typebot.
 
 <div className="relative" style={{ paddingBottom: "64.5933014354067%" }}>
   <iframe
+    title="Make.com integration tutorial video"
     src="https://www.youtube.com/embed/V-y1Orys_kY"
     allowFullScreen
     className="absolute top-0 left-0 w-full h-full"

--- a/apps/docs/editor/blocks/integrations/zapier.mdx
+++ b/apps/docs/editor/blocks/integrations/zapier.mdx
@@ -18,6 +18,7 @@ The Zapier integration block allows you to trigger a zap at a given moment in yo
 
 <div className="relative" style={{ paddingBottom: '64.5933014354067%' }}>
   <iframe
+    title="Zapier integration tutorial video"
     src="https://www.youtube.com/embed/2ZskGItI_Zo"
     allowFullScreen
     className="absolute top-0 left-0 w-full h-full"

--- a/apps/docs/editor/blocks/logic/condition.mdx
+++ b/apps/docs/editor/blocks/logic/condition.mdx
@@ -13,6 +13,7 @@ A condition can contain different comparisons that are evaluated in order and li
 
 <div className="relative" style={{ paddingBottom: '64.5933014354067%' }}>
   <iframe
+    title="Condition block tutorial video"
     src="https://www.youtube.com/embed/47KyLHzdpnY"
     allowFullScreen
     className="absolute top-0 left-0 w-full h-full"

--- a/apps/docs/editor/variables.mdx
+++ b/apps/docs/editor/variables.mdx
@@ -53,6 +53,7 @@ Here is a quick video that showcases advanced concepts about variables:
 
 <div className="relative" style={{ paddingBottom: '64.5933014354067%' }}>
   <iframe
+    title="Advanced variables concepts video"
     src="https://www.youtube.com/embed/o715Tjv1ijI"
     allowFullScreen
     className="absolute top-0 left-0 w-full h-full"

--- a/apps/docs/get-started/overview.mdx
+++ b/apps/docs/get-started/overview.mdx
@@ -7,6 +7,7 @@ The best way to understand the basic principles of Typebot is by watching this s
 
 <div className="relative" style={{ paddingBottom: '64.5933014354067%' }}>
   <iframe
+    title="Creating a typebot video"
     src="https://www.youtube.com/embed/jp3ggg_42-M"
     allowFullScreen
     className="absolute top-0 left-0 w-full h-full"

--- a/apps/docs/report-abuse.mdx
+++ b/apps/docs/report-abuse.mdx
@@ -25,6 +25,7 @@ Users are responsible for ensuring that the bot they publish, and their conduct 
 If you feel a typebot violates our Terms of Service, please report it to us by filling out the bot below.
 
 <iframe
+  title="Report abuse form"
   src="https://typebot.co/report-abuse"
   style={{ border: 'none', width: '100%', height: 400, borderRadius: '.25rem' }}
 />

--- a/apps/docs/snippets/loom-video.mdx
+++ b/apps/docs/snippets/loom-video.mdx
@@ -7,6 +7,7 @@ export const LoomVideo = ({ id }) => (
     }}
   >
     <iframe
+      title="Loom video"
       src={`https://www.loom.com/embed/${id}`}
       allowFullScreen
       style={{

--- a/apps/docs/snippets/youtube-video.mdx
+++ b/apps/docs/snippets/youtube-video.mdx
@@ -7,6 +7,7 @@ export const YoutubeVideo = ({ id }) => (
     }}
   >
     <iframe
+      title="Youtube video"
       src={`https://www.youtube.com/embed/${id}`}
       allowFullScreen
       style={{

--- a/apps/landing-page/content/blog/appointment-scheduling-chatbot.mdx
+++ b/apps/landing-page/content/blog/appointment-scheduling-chatbot.mdx
@@ -406,7 +406,7 @@ Advanced techniques transform a basic scheduler into a powerful operational tool
 Coordinating several people, locations, and time zones requires clear logic. Avoid guesswork by using variables and integrations to route bookings effectively.
 
 <div data-youtube-video="">
-<iframe width="640" height="480" allowfullscreen="true" autoplay="false" disablekbcontrols="false" enableiframeapi="false" endtime="0" ivloadpolicy="0" loop="false" modestbranding="false" origin="" playlist="" rel="1" src="https://www.youtube-nocookie.com/embed/93iOmzHieCU?start=5&amp;controls=0&amp;rel=1" start="0"></iframe>
+<iframe title="Team scheduling demo video" width="640" height="480" allowfullscreen="true" autoplay="false" disablekbcontrols="false" enableiframeapi="false" endtime="0" ivloadpolicy="0" loop="false" modestbranding="false" origin="" playlist="" rel="1" src="https://www.youtube-nocookie.com/embed/93iOmzHieCU?start=5&amp;controls=0&amp;rel=1" start="0"></iframe>
 </div>
 
 - Find the “next available” or least-booked teammate using Google Sheets or Cal.com.

--- a/apps/landing-page/content/blog/best-no-code-website-builder.mdx
+++ b/apps/landing-page/content/blog/best-no-code-website-builder.mdx
@@ -90,7 +90,7 @@ Wix is ideal for small businesses, portfolios, online stores, blogs, restaurants
 #### Best Use Cases
 
 <div data-youtube-video="">
-<iframe width="640" height="480" allowfullscreen="true" autoplay="false" disablekbcontrols="false" enableiframeapi="false" endtime="0" ivloadpolicy="0" loop="false" modestbranding="false" origin="" playlist="" rel="1" src="https://www.youtube-nocookie.com/embed/T2pr8Dn2YuU?controls=0" start="0"></iframe>
+<iframe title="Notion Sites demo video" width="640" height="480" allowfullscreen="true" autoplay="false" disablekbcontrols="false" enableiframeapi="false" endtime="0" ivloadpolicy="0" loop="false" modestbranding="false" origin="" playlist="" rel="1" src="https://www.youtube-nocookie.com/embed/T2pr8Dn2YuU?controls=0" start="0"></iframe>
 </div>
 
 Notion Sites work well for simple websites, portfolios, blogs, documentation hubs, and event sites. If you or your team already use Notion for content management, converting that content into a website can be particularly efficient and relevant.
@@ -177,7 +177,7 @@ Squarespace suits small businesses, creatives showcasing portfolios, bloggers, s
 Carrd excels for simple websites, portfolios, landing pages, mobile-ready design, and budget-conscious users.
 
 <div data-youtube-video="">
-<iframe width="640" height="480" allowfullscreen="true" autoplay="false" disablekbcontrols="false" enableiframeapi="false" endtime="0" ivloadpolicy="0" loop="false" modestbranding="false" origin="" playlist="" rel="1" src="https://www.youtube-nocookie.com/embed/nXcxVtxIxd4?controls=0" start="0"></iframe>
+<iframe title="Carrd demo video" width="640" height="480" allowfullscreen="true" autoplay="false" disablekbcontrols="false" enableiframeapi="false" endtime="0" ivloadpolicy="0" loop="false" modestbranding="false" origin="" playlist="" rel="1" src="https://www.youtube-nocookie.com/embed/nXcxVtxIxd4?controls=0" start="0"></iframe>
 </div>
 
 ### 6. Unbounce

--- a/apps/landing-page/content/blog/best-whatsapp-chatbot.mdx
+++ b/apps/landing-page/content/blog/best-whatsapp-chatbot.mdx
@@ -106,6 +106,7 @@ Typebot shines in its flexibility and customizability, allowing you to create un
 While Typebot's free plan is generous, it does lack some advanced features like priority support and in-depth analytics. And if you choose to self-host, you'll need to manage the infrastructure and maintenance yourself.
 
 <iframe
+  title="Product Hunt reviews"
   src="https://cards.producthunt.com/cards/reviews/627368?v="
   width="500"
   height="405"

--- a/apps/landing-page/content/blog/chatbot-marketing-examples.mdx
+++ b/apps/landing-page/content/blog/chatbot-marketing-examples.mdx
@@ -43,7 +43,7 @@ In the beauty industry, Sephora's Virtual Artist has redefined how customers dis
 It delivers remarkably accurate previews that mirror in-store testing. Sephora integrated this across their mobile app, website, and even in-store kiosks, creating a seamless omnichannel experience.
 
 <div data-youtube-video="">
-<iframe width="640" height="480" allowfullscreen="true" autoplay="false" disablekbcontrols="false" enableiframeapi="false" endtime="0" ivloadpolicy="0" loop="false" modestbranding="false" origin="" playlist="" rel="1" src="https://www.youtube-nocookie.com/embed/_ynN9eZHe30?controls=0&amp;rel=1" start="0"></iframe>
+<iframe title="Sephora virtual artist video" width="640" height="480" allowfullscreen="true" autoplay="false" disablekbcontrols="false" enableiframeapi="false" endtime="0" ivloadpolicy="0" loop="false" modestbranding="false" origin="" playlist="" rel="1" src="https://www.youtube-nocookie.com/embed/_ynN9eZHe30?controls=0&amp;rel=1" start="0"></iframe>
 </div>
 
 The Virtual Artist increased [add-to-basket rates by 25%](https://cosmeticsinsights.com/ar-cosmetics-ecommerce) and boosted makeup conversion rates by 35%. More importantly, it extended average app sessions from 3 minutes to 12 minutes. Users engaging 10 times more with virtual try-ons year-over-year.

--- a/biome.json
+++ b/biome.json
@@ -35,7 +35,6 @@
       "a11y": {
         "noSvgWithoutTitle": "off",
         "useMediaCaption": "off",
-        "useIframeTitle": "off",
         "useKeyWithClickEvents": "off",
         "useButtonType": "off",
         "noRedundantAlt": "off",

--- a/packages/embeds/js/src/features/blocks/bubbles/embed/components/EmbedBubble.tsx
+++ b/packages/embeds/js/src/features/blocks/bubbles/embed/components/EmbedBubble.tsx
@@ -92,6 +92,7 @@ export const EmbedBubble = (props: Props) => {
             }}
           >
             <iframe
+              title="Embedded content"
               id="embed-bubble-content"
               src={props.content?.url}
               class="w-full h-full"

--- a/packages/embeds/js/src/features/blocks/bubbles/video/components/VideoBubble.tsx
+++ b/packages/embeds/js/src/features/blocks/bubbles/video/components/VideoBubble.tsx
@@ -125,6 +125,7 @@ export const VideoBubble = (props: Props) => {
                 }}
               >
                 <iframe
+                  title="Video content"
                   src={`${
                     embedBaseUrls[
                       props.content?.type as EmbeddableVideoBubbleContentType

--- a/packages/embeds/stories/src/iframe.stories.tsx
+++ b/packages/embeds/stories/src/iframe.stories.tsx
@@ -1,7 +1,10 @@
 export const Default = () => {
   return (
     <div style={{ height: "1000px", width: "1000px" }}>
-      <iframe src="http://localhost:3001/lead-generation-4kkypp4" />
+      <iframe
+        title="Lead generation typebot preview"
+        src="http://localhost:3001/lead-generation-4kkypp4"
+      />
     </div>
   );
 };


### PR DESCRIPTION
This PR removes the Biome `useIframeTitle` override and adds explicit `title` attributes to iframe usages across builder, embeds, docs, and landing-page blog content. It also updates the generated embed iframe snippet to include a title by default. Validation: `bun check` passes on this branch.