### PR TITLE
docs: warn about escaping $ in SMTP_PASSWORD

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -19,4 +19,14 @@ NODE_OPTIONS=--no-node-snapshot
 
 NEXT_PUBLIC_PARTYKIT_HOST=localhost:1999
 
+# SMTP Configuration (Email Auth & Notifications)
+# Note: If your SMTP_PASSWORD contains a $ character, escape it as \$ (e.g., abc&\$defghij)
+# The dotenv CLI treats $ as shell variable interpolation, which silently corrupts passwords.
+# Only $ needs escaping — do NOT escape other special characters like &
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_HOST=
+SMTP_PORT=25
+NEXT_PUBLIC_SMTP_FROM=
+
 # For more configuration options check out: https://docs.typebot.io/self-hosting/configuration

--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,13 @@ NEXT_PUBLIC_VIEWER_URL=
 
 ADMIN_EMAIL=
 # For more configuration options check out: https://docs.typebot.io/self-hosting/configuration
+
+# SMTP Configuration (Email Authentication & Notifications)
+# Note: If your SMTP_PASSWORD contains a $ character, escape it as \$ (e.g-, abc\$$defghij)
+# The dotenv CLI treats $ as shell variable which silently corrupts the password value.
+# Only $ needs escaping - DO NOT escape other special characters like &
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_HOST=
+SMTP_PORT=25
+NEXT_PUBLIC_SMTP_FROM=

--- a/apps/docs/self-hosting/configuration.mdx
+++ b/apps/docs/self-hosting/configuration.mdx
@@ -44,6 +44,15 @@ Used for sending email notifications and authentication
 | SMTP_IGNORE_TLS       | undefined | If true and SMTP_SECURE is false then TLS is not used while connecting to server even if server supports STARTTLS extension.                                                                                                                               |
 | SMTP_AUTH_DISABLED    | false     | To disable the authentication by email but still use the provided config for notifications                                                                                                                                                                 |
 
+<Note>
+  If your `SMTP_PASSWORD` contains a `$` character, you must escape it as `\$` in the `.env` file.
+  The dotenv CLI passes values through shell interpolation, where `$` is treaded as a variable refrence and silently corrupts the password, causing `535 Incorrect authentication data` errors.
+
+  - `SMPT_PASSWORD=abc$defghij` - `$def` is expanded by shell and lost
+  - `SMPT_PASSWORD=abc\&\$defghij` - `&` must NOT be escaped
+  - `SMPT_PASSWORD=abc&\$defghij` - only `$` is escaped, password is correct
+</Note>
+
 ## Google Auth
 
 <Accordion title="Requirements">


### PR DESCRIPTION
## What does this PR do?

Adds documentation warning about the `$` character in `SMTP_PASSWORD` values.

## Problem

When `SMTP_PASSWORD` contains a `$` character, the dotenv CLI (used to start the app) passes values through shell interpolation. The `$` is treated as the start of a variable name, silently corrupting the password and causing `535 Incorrect authentication data` errors.

For example, `abc$defghij` silently becomes `abc` at runtime.

## Changes

- `.env.example`: Added SMTP configuration block with warning about `$` escaping
- `.env.dev.example`: Same SMTP block and warning added
- `apps/docs/self-hosting/configuration.mdx`: Added a `<Note>` with correct/incorrect examples after the SMTP table

## Related Issue

Fixes the issue reported by @alehostert regarding SMTP_PASSWORD dollar sign escaping.