### PR TITLE
🐛 Fix file upload in builder preview mode

### DIFF
--- a/packages/blocks/fileInput/src/api/router.ts
+++ b/packages/blocks/fileInput/src/api/router.ts
@@ -1,4 +1,7 @@
-import { authenticatedProcedure } from "@typebot.io/config/orpc/builder/middlewares";
+import {
+  authenticatedProcedure,
+  publicProcedure as builderPublicProcedure,
+} from "@typebot.io/config/orpc/builder/middlewares";
 import { publicProcedure } from "@typebot.io/config/orpc/viewer/middlewares";
 import { z } from "zod";
 import {
@@ -39,6 +42,23 @@ export const fileUploadBuilderRouter = {
     )
     .input(getPrivateFileInputSchema)
     .handler(handleGetPrivateFile),
+  generateUploadUrlProcedure: builderPublicProcedure
+    .route({
+      method: "POST",
+      path: "/v3/generate-upload-url",
+      summary: "Generate upload URL",
+      description: "Used to upload anything from the client to S3 bucket",
+      tags: ["File upload"],
+    })
+    .input(generateUploadUrlInputSchema)
+    .output(
+      z.object({
+        presignedUrl: z.string(),
+        formData: z.record(z.string(), z.any()),
+        fileUrl: z.string(),
+      }),
+    )
+    .handler(handleGenerateUploadUrl),
 };
 
 export const fileUploadViewerRouter = {


### PR DESCRIPTION
## Summary

- Add `generateUploadUrlProcedure` to the `fileUploadBuilderRouter` so the builder's API exposes the `/v3/generate-upload-url` endpoint
- Since `apiHost` now points to the builder origin, file upload requests from the bot preview were hitting a missing endpoint (previously routed to the viewer)

## Verification

- Test a bot in the builder preview that has a file upload block
- Confirm the upload request to `/api/v3/generate-upload-url` succeeds and file uploads work