### PR TITLE
🐛 Fix cross-typebot result data access (GHSA-f475-7m4x-m6mx)

### DIFF
--- a/packages/bot-engine/src/queries/findResult.ts
+++ b/packages/bot-engine/src/queries/findResult.ts
@@ -2,11 +2,12 @@ import prisma from "@typebot.io/prisma";
 
 type Props = {
   id: string;
+  typebotId: string;
 };
-export const findResult = async ({ id }: Props) => {
+export const findResult = async ({ id, typebotId }: Props) => {
   const { answers, answersV2, ...result } =
     (await prisma.result.findFirst({
-      where: { id, isArchived: { not: true } },
+      where: { id, typebotId, isArchived: { not: true } },
       select: {
         id: true,
         variables: true,

--- a/packages/bot-engine/src/startSession.ts
+++ b/packages/bot-engine/src/startSession.ts
@@ -101,6 +101,7 @@ export const startSession = async ({
 
   const result = await getOrInitResult({
     resultId: startParams.type === "live" ? startParams.resultId : undefined,
+    typebotId: typebot.id,
     isPreview: startParams.type === "preview",
     isRememberUserEnabled:
       typebot.settings.general?.rememberUser?.isEnabled ??
@@ -401,16 +402,18 @@ const getTypebot = async (startParams: StartParams) => {
 const getOrInitResult = async ({
   isPreview,
   resultId,
+  typebotId,
   isRememberUserEnabled,
 }: {
   resultId: string | undefined;
+  typebotId: string;
   isPreview: boolean;
   isRememberUserEnabled: boolean;
 }) => {
   if (isPreview) return;
   const existingResult =
     resultId && isRememberUserEnabled
-      ? await findResult({ id: resultId })
+      ? await findResult({ id: resultId, typebotId })
       : undefined;
 
   return {


### PR DESCRIPTION
## Summary
- Adds a `typebotId` filter to the `findResult` Prisma query, preventing a user from loading result data (answers, variables) belonging to a different typebot via a foreign `resultId` in the `startChat` endpoint.
- Addresses security advisory GHSA-f475-7m4x-m6mx.

## Test plan
- [x] Typecheck passes (`bunx nx typecheck bot-engine`)
- [x] All affected tests pass (bot-engine, results, builder, etc.)
- [ ] Verify that `startChat` with a `resultId` from another typebot no longer returns that result's data

🤖 Generated with [Claude Code](https://claude.com/claude-code)