### PR TITLE
🐛 Fix authorization bypass in getLinkedTypebots (GHSA-3fr5-999r-84qj)

### DIFF
--- a/apps/builder/src/features/blocks/logic/typebotLink/api/getLinkedTypebots.ts
+++ b/apps/builder/src/features/blocks/logic/typebotLink/api/getLinkedTypebots.ts
@@ -96,40 +96,48 @@ export const getLinkedTypebots = authenticatedProcedure
 
     if (!linkedTypebotIds.length) return { typebots: [] };
 
-    const typebots = (
-      await prisma.typebot.findMany({
-        where: {
-          isArchived: { not: true },
-          id: { in: linkedTypebotIds },
-        },
-        select: {
-          id: true,
-          version: true,
-          groups: true,
-          variables: true,
-          name: true,
-          createdAt: true,
-          workspace: {
-            select: {
-              isSuspended: true,
-              isPastDue: true,
-              members: {
-                select: {
-                  userId: true,
-                },
+    const fetchedTypebots = await prisma.typebot.findMany({
+      where: {
+        isArchived: { not: true },
+        id: { in: linkedTypebotIds },
+      },
+      select: {
+        id: true,
+        version: true,
+        groups: true,
+        variables: true,
+        name: true,
+        createdAt: true,
+        workspace: {
+          select: {
+            isSuspended: true,
+            isPastDue: true,
+            members: {
+              select: {
+                userId: true,
               },
             },
           },
-          collaborators: {
-            select: {
-              type: true,
-              userId: true,
-            },
+        },
+        collaborators: {
+          select: {
+            type: true,
+            userId: true,
           },
         },
-      })
-    )
-      .filter(async (typebot) => !(await isReadTypebotForbidden(typebot, user)))
+      },
+    });
+
+    const accessChecks = await Promise.all(
+      fetchedTypebots.map(async (typebot) => ({
+        typebot,
+        forbidden: await isReadTypebotForbidden(typebot, user),
+      })),
+    );
+
+    const typebots = accessChecks
+      .filter(({ forbidden }) => !forbidden)
+      .map(({ typebot }) => typebot)
       // To avoid the out of sort memory error, we sort the typebots manually
       .sort((a, b) => {
         return b.createdAt.getTime() - a.createdAt.getTime();


### PR DESCRIPTION
## Summary

- Fix broken authorization check in `getLinkedTypebots` where `Array.filter()` received an `async` callback, causing the `isReadTypebotForbidden` predicate to never actually filter out unauthorized typebots (Promise is always truthy)
- Replace with `Promise.all` + synchronous `.filter()` to properly evaluate access checks
- Any authenticated user could previously read full bot definitions (variables, groups, webhooks) from other workspaces via a Typebot Link block reference

## Test plan

- [ ] Verify that linked typebots the user has access to are still returned correctly
- [ ] Verify that linked typebots from other workspaces the user does NOT have access to are no longer returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)