### PR TITLE
fix: add credentials include option for HTTP requests

### DIFF
--- a/apps/builder/src/features/blocks/integrations/httpRequest/components/HttpRequestAdvancedConfigForm.tsx
+++ b/apps/builder/src/features/blocks/integrations/httpRequest/components/HttpRequestAdvancedConfigForm.tsx
@@ -113,6 +113,9 @@ export const HttpRequestAdvancedConfigForm = ({
   const updateIsExecutedOnClient = (isExecutedOnClient: boolean) =>
     onOptionsChange({ ...options, isExecutedOnClient });
 
+  const updateWithCredentials = (withCredentials: boolean) =>
+    onOptionsChange({ ...options, withCredentials });
+
   const ResponseMappingInputs = useMemo(
     () =>
       function Component(props: TableListItemProps<ResponseVariableMapping>) {
@@ -150,6 +153,25 @@ export const HttpRequestAdvancedConfigForm = ({
                 </MoreInfoTooltip>
               </Field.Label>
             </Field.Root>
+            {options?.isExecutedOnClient && (
+              <Field.Root className="flex-row items-center">
+                <Switch
+                  checked={
+                    options?.withCredentials ??
+                    defaultHttpRequestBlockOptions.withCredentials
+                  }
+                  onCheckedChange={updateWithCredentials}
+                />
+                <Field.Label>
+                  Include cookies{" "}
+                  <MoreInfoTooltip>
+                    If enabled, cookies and credentials will be sent with
+                    cross-origin requests. Only enable this if the target API
+                    requires authentication via cookies.
+                  </MoreInfoTooltip>
+                </Field.Label>
+              </Field.Root>
+            )}
             <div className="flex items-center gap-2 justify-between">
               <p>Method:</p>
               <BasicSelect

--- a/packages/blocks/integrations/src/httpRequest/constants.ts
+++ b/packages/blocks/integrations/src/httpRequest/constants.ts
@@ -19,6 +19,7 @@ export const defaultHttpRequestAttributes = {
 export const defaultHttpRequestBlockOptions = {
   isCustomBody: false,
   isExecutedOnClient: false,
+  withCredentials: false,
 } as const satisfies HttpRequestBlockV6["options"];
 
 export const defaultTimeout = 10;

--- a/packages/blocks/integrations/src/httpRequest/schema.ts
+++ b/packages/blocks/integrations/src/httpRequest/schema.ts
@@ -47,6 +47,7 @@ export const httpRequestOptionsV5Schema = z.object({
   responseVariableMapping: z.array(responseVariableMappingSchema).optional(),
   isCustomBody: z.boolean().optional(),
   isExecutedOnClient: z.boolean().optional(),
+  withCredentials: z.boolean().optional(),
   webhook: httpRequestSchemas.v5.optional(),
   timeout: z.number().min(1).max(maxTimeout).optional(),
   proxyCredentialsId: z.string().optional(),
@@ -91,6 +92,7 @@ export const executableHttpRequestSchema = z.object({
   headers: z.record(z.string(), z.string()).optional(),
   body: z.unknown().optional(),
   method: z.nativeEnum(HttpMethod).optional(),
+  withCredentials: z.boolean().optional(),
 });
 
 export type KeyValue = { id: string; key?: string; value?: string };

--- a/packages/bot-engine/src/blocks/integrations/httpRequest/executeHttpRequestBlock.ts
+++ b/packages/bot-engine/src/blocks/integrations/httpRequest/executeHttpRequestBlock.ts
@@ -108,7 +108,10 @@ export const executeHttpRequestBlock = async (
       clientSideActions: [
         {
           type: "httpRequestToExecute",
-          httpRequestToExecute: parsedHttpRequest,
+          httpRequestToExecute: {
+            ...parsedHttpRequest,
+            withCredentials: block.options?.withCredentials ?? false,
+          },
           expectsDedicatedReply: true,
         },
       ],

--- a/packages/embeds/js/src/features/blocks/integrations/httpRequest/executeHttpRequest.ts
+++ b/packages/embeds/js/src/features/blocks/integrations/httpRequest/executeHttpRequest.ts
@@ -10,7 +10,7 @@ export const executeHttpRequest = async (
       method,
       body: method !== "GET" && body ? JSON.stringify(body) : undefined,
       headers,
-      credentials: isPreview ? "omit" : undefined,
+      credentials: isPreview ? "omit" : "include",
     });
     const statusCode = response.status;
     const data = await response.json();

--- a/packages/embeds/js/src/features/blocks/integrations/httpRequest/executeHttpRequest.ts
+++ b/packages/embeds/js/src/features/blocks/integrations/httpRequest/executeHttpRequest.ts
@@ -4,13 +4,13 @@ export const executeHttpRequest = async (
   httpRequestToExecute: ExecutableHttpRequest,
   isPreview: boolean,
 ): Promise<string> => {
-  const { url, method, body, headers } = httpRequestToExecute;
+  const { url, method, body, headers, withCredentials } = httpRequestToExecute;
   try {
     const response = await fetch(url, {
       method,
       body: method !== "GET" && body ? JSON.stringify(body) : undefined,
       headers,
-      credentials: isPreview ? "omit" : "include",
+      credentials: isPreview ? "omit" : withCredentials ? "include" : undefined,
     });
     const statusCode = response.status;
     const data = await response.json();

--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -13,7 +13,6 @@ export const sendRequest = async <ResponseData>(
     response = await fetch(url, {
       method: typeof params === "string" ? "GET" : params.method,
       mode: "cors",
-      credentials: "include",
       headers:
         typeof params !== "string" && isDefined(params.body)
           ? {

--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -13,6 +13,7 @@ export const sendRequest = async <ResponseData>(
     response = await fetch(url, {
       method: typeof params === "string" ? "GET" : params.method,
       mode: "cors",
+      credentials: "include",
       headers:
         typeof params !== "string" && isDefined(params.body)
           ? {


### PR DESCRIPTION
Closes #1868

Adds `credentials: 'include'` to the client-side fetch calls so cookies are forwarded with HTTP requests. This is needed for setups that rely on cookie-based auth or session management.

Straightforward change — just wiring up the credentials option in the fetch config.