### PR TITLE
🐛 Handle GA script load failure to prevent bot from hanging

### DIFF
--- a/packages/embeds/js/package.json
+++ b/packages/embeds/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/js",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Javascript library to display typebots on your website",
   "license": "FSL-1.1-ALv2",
   "type": "module",

--- a/packages/embeds/js/src/lib/gtag.ts
+++ b/packages/embeds/js/src/lib/gtag.ts
@@ -34,6 +34,10 @@ export const initGoogleAnalytics = (id: string): Promise<void> => {
       script.onload = () => {
         resolve();
       };
+      script.onerror = () => {
+        console.error("Failed to load Google Analytics script");
+        resolve();
+      };
     }
     if (existingScript) resolve();
   });

--- a/packages/embeds/react/package.json
+++ b/packages/embeds/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/react",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Convenient library to display typebots on your React app",
   "license": "FSL-1.1-ALv2",
   "type": "module",


### PR DESCRIPTION
## Summary
- Add `script.onerror` handler in `initGoogleAnalytics` so the promise resolves even when the GA script fails to load (ad blockers, network errors), preventing the bot from hanging indefinitely.
- Bump `@typebot.io/js` and `@typebot.io/react` versions to `0.10.2`.

## Test plan
- [ ] Enable a Google Analytics integration block in a bot
- [ ] Block `googletagmanager.com` (e.g. via ad blocker) and verify the bot still loads
- [ ] Check that `"Failed to load Google Analytics script"` appears in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)