### PR TITLE
🐛 Fix PostHog tracking by updating cookie domain to typebot.com

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -602,7 +602,7 @@
     },
     "packages/embeds/js": {
       "name": "@typebot.io/js",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "devDependencies": {
         "@ai-sdk/ui-utils": "^1.2.11",
         "@ark-ui/solid": "^5.19.0",
@@ -637,7 +637,7 @@
     },
     "packages/embeds/react": {
       "name": "@typebot.io/react",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "@typebot.io/js": "workspace:*",
         "react": "^19.2.4",

--- a/packages/telemetry/src/cookies/constants.ts
+++ b/packages/telemetry/src/cookies/constants.ts
@@ -2,4 +2,4 @@ export const TYPEBOT_COOKIE_NAME = "typebot" as const;
 export const VISITOR_ID_PREFIX = "visitor_" as const;
 export const SESSION_EXPIRATION = 60 * 60 * 24; // 24 hours
 export const COOKIE_EXPIRATION = 60 * 60 * 24 * 365; // 1 year
-export const DEFAULT_COOKIE_DOMAIN = "typebot.io" as const;
+export const DEFAULT_COOKIE_DOMAIN = "typebot.com" as const;


### PR DESCRIPTION
## Summary
- Update `DEFAULT_COOKIE_DOMAIN` from `typebot.io` to `typebot.com` in telemetry constants
- Fixes "Failed to execute 'set' on 'CookieStore': Cookie domain must domain-match current host" error that was preventing all PostHog pageview tracking since the domain migration

## Test plan
- [ ] Verify PostHog pageviews are being recorded on typebot.com
- [ ] Confirm no cookie domain mismatch errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)