### PR TITLE
✨ Add Ask Model action using OpenAI Responses API

### DIFF
--- a/apps/builder/public/templates/openai-assistant-chat.json
+++ b/apps/builder/public/templates/openai-assistant-chat.json
@@ -1,7 +1,7 @@
 {
   "version": "6.1",
   "id": "clvqu4l5j00015bxibaf44slo",
-  "name": "OpenAI Assistant Chat",
+  "name": "OpenAI Chat",
   "events": [
     {
       "id": "rjtz087ma51znox79ztbl24d",
@@ -26,8 +26,9 @@
           "type": "openai",
           "options": {
             "credentialsId": "clvqq3hey0007pub4almxnhk2",
-            "action": "Ask Assistant",
-            "threadVariableId": "vf5gxmpqddsy4qugev6o0qs5c",
+            "action": "Ask Model",
+            "model": "gpt-5.4",
+            "responseIdVariableId": "vf5gxmpqddsy4qugev6o0qs5c",
             "message": "{{User last message}}",
             "responseMapping": [{ "variableId": "vn8h1gigkjwv40godw2hrgclh" }]
           }
@@ -61,7 +62,7 @@
                 "type": "p",
                 "children": [
                   {
-                    "text": "You need to add your OpenAI credentials and select your Assistant to make this bot work. 🪄"
+                    "text": "You need to add your OpenAI credentials to make this bot work."
                   }
                 ]
               }
@@ -83,7 +84,7 @@
                   { "bold": true, "text": "Start" },
                   { "text": " event with " },
                   { "bold": true, "text": "AI loop" },
-                  { "text": " 🚀" }
+                  { "text": "" }
                 ]
               }
             ]
@@ -115,7 +116,7 @@
     },
     {
       "id": "vf5gxmpqddsy4qugev6o0qs5c",
-      "name": "Thread ID",
+      "name": "Response ID",
       "isSessionVariable": true
     },
     {

--- a/apps/builder/src/features/forge/components/zodLayouts/ZodActionDiscriminatedUnion.tsx
+++ b/apps/builder/src/features/forge/components/zodLayouts/ZodActionDiscriminatedUnion.tsx
@@ -41,7 +41,12 @@ export const ZodActionDiscriminatedUnion = ({
         className="w-full"
         value={blockOptions?.action}
         onChange={(item) => onDataChange({ ...blockOptions, action: item })}
-        items={[...optionsMap.keys()].filter(isDefined)}
+        items={[...optionsMap.keys()].filter(
+          (key) =>
+            isDefined(key) &&
+            (!isActionHidden(blockDef, key) ||
+              key === blockOptions?.action),
+        )}
         placeholder="Select an action"
       />
       {currentOptions && (
@@ -57,6 +62,11 @@ export const ZodActionDiscriminatedUnion = ({
     </>
   );
 };
+
+const isActionHidden = (
+  blockDef: ForgedBlockDefinition | undefined,
+  actionName: string,
+) => blockDef?.actions.find((a) => a.name === actionName)?.isHidden === true;
 
 const isZodDiscriminatedUnion = (
   schema: z.ZodTypeAny,

--- a/apps/docs/editor/blocks/integrations/openai.mdx
+++ b/apps/docs/editor/blocks/integrations/openai.mdx
@@ -52,17 +52,42 @@ If you'd like to set variables directly in this code block, you can use the [`se
   here](../logic/script#limitations-on-scripts-executed-on-server).
 </Warning>
 
-## Ask assistant
+## Ask Model
 
-This action allows you to talk with your [OpenAI assistant](https://platform.openai.com/assistants). All you have to do is to provide its ID.
+This action uses OpenAI's [Responses API](https://platform.openai.com/docs/api-reference/responses) to generate model responses with optional built-in tools and multi-turn conversation support.
 
-In order for your block to remember the conversation history, you need to provide a `Thread ID` variable. If the variable is empty, it will create a new thread and automatically save the new thread ID in the variable.
+### Basic setup
 
-<LoomVideo id="daa20fcc5984472a875a3ad4d3fc2a3a" />
+Select a **Model** (e.g. `gpt-5.4`), write a **Message** (typically the user's input), and optionally provide **Instructions** (system-level prompt for the model).
+
+### Multi-turn conversations
+
+To remember conversation history across messages, assign a variable to the **Response ID** field. If the variable is empty, a new conversation is started. On each response, the variable is automatically updated so the next invocation continues the same conversation.
+
+### Built-in tools
+
+You can enable the following OpenAI built-in tools in the **Built-in tools** section:
+
+- **File Search** — select one or more vector stores from your OpenAI account. The model will search them for relevant content when answering.
+- **Web Search** — let the model search the web for up-to-date information.
+- **Code Interpreter** — let the model write and execute Python code.
 
 ### Functions
 
-If you defined functions in your assistant, you can define the function to execute in the `Functions` section.
+The **Functions** section lets you define custom functions the model can call. Each function has a name, description, typed parameters, and a JavaScript code block that returns a value.
+
+The code block expects the body of a Javascript function. Use the `return` keyword to return a value back to the model.
+
+If you'd like to set variables directly in this code block, you can use the [`setVariable` function](../logic/script#setvariable-function).
+
+<Warning>
+  A function is executed on the server so it comes with [some limitations listed
+  here](../logic/script#limitations-on-scripts-executed-on-server).
+</Warning>
+
+:::note
+**Migrating from Ask Assistant?** The Ask Assistant action (based on the deprecated OpenAI Assistants API) will be removed in August 2026. To migrate, create a new Ask Model block and configure the model, instructions, and tools directly — the Responses API no longer requires an assistant ID.
+:::
 
 ## Create speech
 
@@ -108,7 +133,7 @@ I also demonstrate how formatting can be affected by the presence of text before
 
 ## Vision support
 
-`Create Chat Message` and `Ask Assistant` blocks support vision. This means that Typebot automatically detects images URL in any user message provided to OpenAI and parse it. The URL needs to be isolated from the rest of the text message to be properly detected. Here is an example of a message with an image URL:
+`Create Chat Message` and `Ask Model` blocks support vision. This means that Typebot automatically detects images URL in any user message provided to OpenAI and parse it. The URL needs to be isolated from the rest of the text message to be properly detected. Here is an example of a message with an image URL:
 
 If the selected model is [not compatible with vision](https://platform.openai.com/docs/models), the image URL will be parsed as a plain text message.
 

--- a/bun.lock
+++ b/bun.lock
@@ -845,6 +845,7 @@
       "dependencies": {
         "@ai-sdk/openai": "^1.3.24",
         "@ai-sdk/ui-utils": "^1.2.11",
+        "@sentry/nextjs": "^10.43.0",
         "@typebot.io/ai": "workspace:*",
         "@typebot.io/forge": "workspace:*",
         "@typebot.io/lib": "workspace:*",

--- a/packages/forge/blocks/openai/package.json
+++ b/packages/forge/blocks/openai/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.24",
+    "@sentry/nextjs": "^10.43.0",
     "@typebot.io/ai": "workspace:*",
     "@ai-sdk/ui-utils": "^1.2.11",
     "openai": "^6.9.1",

--- a/packages/forge/blocks/openai/src/actions/askAssistant.ts
+++ b/packages/forge/blocks/openai/src/actions/askAssistant.ts
@@ -16,6 +16,7 @@ export const askAssistant = createAction({
   auth,
   baseOptions,
   name: "Ask Assistant",
+  isHidden: true,
   options: option
     .object({
       assistantId: option.string.meta({

--- a/packages/forge/blocks/openai/src/actions/askModel.ts
+++ b/packages/forge/blocks/openai/src/actions/askModel.ts
@@ -1,0 +1,118 @@
+import { toolParametersSchema } from "@typebot.io/ai/schemas";
+import { createAction, option } from "@typebot.io/forge";
+import { isDefined } from "@typebot.io/lib/utils";
+import { auth } from "../auth";
+import { baseOptions } from "../baseOptions";
+import { models } from "../constants";
+
+export const askModel = createAction({
+  auth,
+  baseOptions,
+  name: "Ask Model",
+  options: option.object({
+    model: option.string.meta({
+      layout: {
+        label: "Model",
+        placeholder: "Select a model",
+        autoCompleteItems: models,
+        moreInfoTooltip: "The model to use for generating the response.",
+      },
+    }),
+    message: option.string.meta({
+      layout: {
+        label: "Message",
+        inputType: "textarea",
+      },
+    }),
+    instructions: option.string.meta({
+      layout: {
+        label: "Instructions",
+        inputType: "textarea",
+        placeholder: "System instructions for the model...",
+      },
+    }),
+    responseIdVariableId: option.string.meta({
+      layout: {
+        label: "Response ID",
+        moreInfoTooltip:
+          "Used to remember the conversation with the user. If empty, a new conversation is started.",
+        inputType: "variableDropdown",
+      },
+    }),
+    fileSearchVectorStoreIds: option.array(option.string).meta({
+      layout: {
+        label: "Vector store IDs",
+        moreInfoTooltip:
+          "Vector store IDs for file search. Leave empty to disable.",
+        accordion: "Built-in tools",
+      },
+    }),
+    webSearchEnabled: option.boolean.meta({
+      layout: {
+        label: "Web Search",
+        accordion: "Built-in tools",
+      },
+    }),
+    codeInterpreterEnabled: option.boolean.meta({
+      layout: {
+        label: "Code Interpreter",
+        accordion: "Built-in tools",
+      },
+    }),
+    functions: option
+      .array(
+        option.object({
+          name: option.string.meta({
+            layout: {
+              label: "Name",
+              placeholder: "myFunctionName",
+              withVariableButton: false,
+            },
+          }),
+          description: option.string.meta({
+            layout: {
+              label: "Description",
+              placeholder: "A brief description of what this function does.",
+              withVariableButton: false,
+            },
+          }),
+          parameters: toolParametersSchema,
+          code: option.string.meta({
+            layout: {
+              inputType: "code",
+              label: "Code",
+              lang: "js",
+              moreInfoTooltip:
+                "A javascript code snippet that can use the defined parameters. It should return a value.",
+              withVariableButton: false,
+            },
+          }),
+        }),
+      )
+      .meta({ layout: { accordion: "Functions", itemLabel: "function" } }),
+    temperature: option.number.meta({
+      layout: {
+        label: "Temperature",
+        accordion: "Advanced settings",
+        direction: "row",
+        defaultValue: 1,
+      },
+    }),
+    responseMapping: option
+      .saveResponseArray(["Message", "Response ID"] as const, {
+        item: { hiddenItems: ["Response ID"] },
+      })
+      .meta({
+        layout: {
+          accordion: "Save response",
+        },
+      }),
+  }),
+  getSetVariableIds: ({ responseMapping, responseIdVariableId }) =>
+    [
+      ...(responseMapping?.map((r) => r.variableId) ?? []),
+      responseIdVariableId,
+    ].filter(isDefined),
+  getStreamVariableId: ({ responseMapping }) =>
+    responseMapping?.find((m) => !m.item || m.item === "Message")?.variableId,
+});

--- a/packages/forge/blocks/openai/src/actions/createChatCompletion.ts
+++ b/packages/forge/blocks/openai/src/actions/createChatCompletion.ts
@@ -4,7 +4,7 @@ import { parseChatCompletionOptions } from "@typebot.io/ai/parseChatCompletionOp
 import { createAction } from "@typebot.io/forge";
 import { auth } from "../auth";
 import { baseOptions } from "../baseOptions";
-import { chatModels, reasoningModels } from "../constants";
+import { models } from "../constants";
 
 export const createChatCompletion = createAction({
   name: "Create chat completion",
@@ -13,7 +13,7 @@ export const createChatCompletion = createAction({
   options: parseChatCompletionOptions({
     models: {
       type: "static",
-      models: chatModels.concat(reasoningModels),
+      models,
     },
   }),
   getSetVariableIds: getChatCompletionSetVarIds,

--- a/packages/forge/blocks/openai/src/actions/generateVariables.ts
+++ b/packages/forge/blocks/openai/src/actions/generateVariables.ts
@@ -4,17 +4,17 @@ import { createAction } from "@typebot.io/forge";
 import { isDefined } from "@typebot.io/lib/utils";
 import { auth } from "../auth";
 import { baseOptions } from "../baseOptions";
-import { chatModels, reasoningModels } from "../constants";
+import { models } from "../constants";
 
 export const generateVariables = createAction({
   name: "Generate variables",
   auth,
   baseOptions,
   options: parseGenerateVariablesOptions({
-    models: { type: "static", models: chatModels.concat(reasoningModels) },
+    models: { type: "static", models },
   }),
   aiGenerate: {
-    models: { type: "static", items: chatModels.concat(reasoningModels) },
+    models: { type: "static", items: models },
     getModel: ({ credentials, model }) =>
       createOpenAI({
         apiKey: credentials.apiKey,

--- a/packages/forge/blocks/openai/src/constants.ts
+++ b/packages/forge/blocks/openai/src/constants.ts
@@ -15,10 +15,13 @@ export const openAIVoices = [
   "shimmer",
 ] as const;
 
-export const chatModels = [
-  "gpt-5.4-nano",
+export const models = [
+  "gpt-5.4",
+  "gpt-5.4-pro",
   "gpt-5.4-mini",
+  "gpt-5.4-nano",
   "gpt-5.3-chat",
+  "gpt-5.2-pro",
   "gpt-5.2",
   "gpt-5.1-chat",
   "gpt-5",
@@ -29,12 +32,6 @@ export const chatModels = [
   "gpt-4.1-nano",
   "gpt-4o",
   "gpt-4o-mini",
-];
-
-export const reasoningModels = [
-  "gpt-5.4",
-  "gpt-5.4-pro",
-  "gpt-5.2-pro",
   "o3",
   "o4-mini",
   "o3-mini",

--- a/packages/forge/blocks/openai/src/handlers/askAssistantHandler.ts
+++ b/packages/forge/blocks/openai/src/handlers/askAssistantHandler.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { createActionHandler, createFetcherHandler } from "@typebot.io/forge";
 import type {
   AsyncVariableStore,
@@ -133,6 +134,8 @@ const createAssistantStream = async ({
   variables: AsyncVariableStore | VariableStore;
   sessionStore: SessionStore;
 }): Promise<ReadableStream<any> | undefined> => {
+  Sentry.captureMessage("Deprecated Ask Assistant action used");
+
   if (isEmpty(assistantId)) {
     logs?.add("Assistant ID is empty");
     return;

--- a/packages/forge/blocks/openai/src/handlers/askModelHandler.ts
+++ b/packages/forge/blocks/openai/src/handlers/askModelHandler.ts
@@ -15,7 +15,9 @@ import OpenAI from "openai";
 import type { ResponseStreamEvent } from "openai/resources/responses/responses";
 import { askModel } from "../actions/askModel";
 import { maxToolCalls } from "../constants";
+import { isModelCompatibleWithVision } from "../helpers/isModelCompatibleWithVision";
 import { parseToolsForResponsesApi } from "../helpers/parseToolsForResponsesApi";
+import { splitMessageIntoResponsesApiInputItems } from "../helpers/splitMessageIntoResponsesApiInputItems";
 
 export const askModelHandler = createActionHandler(askModel, {
   stream: {
@@ -179,10 +181,18 @@ const createResponseStream = async ({
       : temperature;
 
   try {
+    const messageContent = isModelCompatibleWithVision(model)
+      ? await splitMessageIntoResponsesApiInputItems(message)
+      : message;
+    const parsedInput =
+      typeof messageContent === "string"
+        ? messageContent
+        : [{ role: "user" as const, content: messageContent }];
+
     return createResponseFoundationalStream(async ({ forwardStream }) => {
       const stream = openai.responses.stream({
         model,
-        input: message,
+        input: parsedInput,
         instructions: instructions || undefined,
         tools: tools.length > 0 ? tools : undefined,
         previous_response_id: previousResponseId,
@@ -214,7 +224,19 @@ const createResponseStream = async ({
                   }),
                 };
 
-              const args = JSON.parse(fnCall.arguments);
+              let args: Record<string, unknown>;
+              try {
+                args = JSON.parse(fnCall.arguments);
+              } catch {
+                return {
+                  type: "function_call_output" as const,
+                  call_id: fnCall.call_id,
+                  output: JSON.stringify({
+                    error: `Failed to parse arguments for "${fnCall.name}"`,
+                  }),
+                };
+              }
+
               const { output, newVariables } = await executeFunction({
                 variables: variables.list(),
                 body: functionDef.code,

--- a/packages/forge/blocks/openai/src/handlers/askModelHandler.ts
+++ b/packages/forge/blocks/openai/src/handlers/askModelHandler.ts
@@ -1,0 +1,321 @@
+import { createActionHandler } from "@typebot.io/forge";
+import type {
+  AsyncVariableStore,
+  LogsStore,
+  VariableStore,
+} from "@typebot.io/forge/types";
+import { parseUnknownError } from "@typebot.io/lib/parseUnknownError";
+import { safeStringify } from "@typebot.io/lib/safeStringify";
+import { isDefined, isEmpty, isNotEmpty } from "@typebot.io/lib/utils";
+import type { SessionStore } from "@typebot.io/runtime-session-store";
+import { executeFunction } from "@typebot.io/variables/executeFunction";
+import { formatDataStreamPart, processDataStream } from "ai";
+import type { ClientOptions } from "openai";
+import OpenAI from "openai";
+import type { ResponseStreamEvent } from "openai/resources/responses/responses";
+import { askModel } from "../actions/askModel";
+import { maxToolCalls } from "../constants";
+import { parseToolsForResponsesApi } from "../helpers/parseToolsForResponsesApi";
+
+export const askModelHandler = createActionHandler(askModel, {
+  stream: {
+    run: async ({ credentials, options, variables, sessionStore }) => ({
+      stream: await createResponseStream({
+        apiKey: credentials.apiKey,
+        baseUrl: credentials.baseUrl ?? options.baseUrl,
+        apiVersion: options.apiVersion,
+        model: options.model,
+        message: options.message,
+        instructions: options.instructions,
+        responseIdVariableId: options.responseIdVariableId,
+        functions: options.functions,
+        fileSearchVectorStoreIds:
+          options.fileSearchVectorStoreIds?.filter(isDefined),
+        webSearchEnabled: options.webSearchEnabled,
+        codeInterpreterEnabled: options.codeInterpreterEnabled,
+        temperature: options.temperature,
+        responseMapping: options.responseMapping,
+        variables,
+        sessionStore,
+      }),
+    }),
+  },
+  server: async ({
+    credentials: { apiKey, baseUrl },
+    options,
+    variables,
+    logs,
+    sessionStore,
+  }) => {
+    const stream = await createResponseStream({
+      apiKey,
+      baseUrl: baseUrl ?? options.baseUrl,
+      apiVersion: options.apiVersion,
+      model: options.model,
+      message: options.message,
+      instructions: options.instructions,
+      responseIdVariableId: options.responseIdVariableId,
+      functions: options.functions,
+      fileSearchVectorStoreIds:
+        options.fileSearchVectorStoreIds?.filter(isDefined),
+      webSearchEnabled: options.webSearchEnabled,
+      codeInterpreterEnabled: options.codeInterpreterEnabled,
+      temperature: options.temperature,
+      responseMapping: options.responseMapping,
+      variables,
+      logs,
+      sessionStore,
+    });
+
+    if (!stream) {
+      logs.add("createResponseStream returned undefined");
+      return;
+    }
+
+    let writingMessage = "";
+
+    await processDataStream({
+      stream,
+      onTextPart: (text) => {
+        writingMessage += text;
+      },
+      onErrorPart: (error) => {
+        logs?.add(error);
+      },
+    });
+
+    options.responseMapping?.forEach((mapping) => {
+      if (!mapping.variableId) return;
+      if (!mapping.item || mapping.item === "Message")
+        variables.set([{ id: mapping.variableId, value: writingMessage }]);
+    });
+  },
+});
+
+const createResponseStream = async ({
+  apiKey,
+  baseUrl,
+  apiVersion,
+  model,
+  message,
+  instructions,
+  responseIdVariableId,
+  functions,
+  fileSearchVectorStoreIds,
+  webSearchEnabled,
+  codeInterpreterEnabled,
+  temperature,
+  responseMapping,
+  logs,
+  variables,
+  sessionStore,
+}: {
+  apiKey?: string;
+  baseUrl?: string;
+  apiVersion?: string;
+  model?: string;
+  message?: string;
+  instructions?: string;
+  responseIdVariableId?: string;
+  functions?: {
+    name?: string;
+    description?: string;
+    parameters?: {
+      type?: "string" | "number" | "boolean" | "enum";
+      name?: string;
+      description?: string;
+      required?: boolean;
+      values?: (string | undefined)[];
+    }[];
+    code?: string;
+  }[];
+  fileSearchVectorStoreIds?: string[];
+  webSearchEnabled?: boolean;
+  codeInterpreterEnabled?: boolean;
+  temperature?: number;
+  responseMapping?: {
+    item?: "Message" | "Response ID" | undefined;
+    variableId?: string | undefined;
+  }[];
+  logs?: LogsStore;
+  variables: AsyncVariableStore | VariableStore;
+  sessionStore: SessionStore;
+}): Promise<ReadableStream<Uint8Array> | undefined> => {
+  if (isEmpty(model)) {
+    logs?.add("Model is empty");
+    return;
+  }
+  if (isEmpty(message)) {
+    logs?.add("Message is empty");
+    return;
+  }
+
+  const config = {
+    apiKey,
+    baseURL: baseUrl,
+    defaultHeaders: { "api-key": apiKey },
+    defaultQuery: apiVersion ? { "api-version": apiVersion } : undefined,
+  } satisfies ClientOptions;
+
+  const openai = new OpenAI(config);
+
+  let previousResponseId: string | undefined;
+  if (
+    responseIdVariableId &&
+    isNotEmpty(variables.get(responseIdVariableId)?.toString())
+  )
+    previousResponseId = variables.get(responseIdVariableId)?.toString();
+
+  const tools = parseToolsForResponsesApi({
+    functions,
+    fileSearchVectorStoreIds,
+    webSearchEnabled,
+    codeInterpreterEnabled,
+  });
+
+  const parsedTemperature =
+    typeof temperature === "string"
+      ? Number.parseFloat(temperature)
+      : temperature;
+
+  try {
+    return createResponseFoundationalStream(async ({ forwardStream }) => {
+      const stream = openai.responses.stream({
+        model,
+        input: message,
+        instructions: instructions || undefined,
+        tools: tools.length > 0 ? tools : undefined,
+        previous_response_id: previousResponseId,
+        store: true,
+        temperature:
+          parsedTemperature != null && !Number.isNaN(parsedTemperature)
+            ? parsedTemperature
+            : undefined,
+      });
+
+      let { response, functionCalls } = await forwardStream(stream);
+
+      let toolCallCount = 0;
+      while (functionCalls.length > 0 && toolCallCount < maxToolCalls) {
+        toolCallCount++;
+
+        const functionCallOutputs: OpenAI.Responses.ResponseInputItem.FunctionCallOutput[] =
+          await Promise.all(
+            functionCalls.map(async (fnCall) => {
+              const functionDef = functions?.find(
+                (f) => f.name === fnCall.name,
+              );
+              if (!functionDef?.code)
+                return {
+                  type: "function_call_output" as const,
+                  call_id: fnCall.call_id,
+                  output: JSON.stringify({
+                    error: `Function "${fnCall.name}" not found`,
+                  }),
+                };
+
+              const args = JSON.parse(fnCall.arguments);
+              const { output, newVariables } = await executeFunction({
+                variables: variables.list(),
+                body: functionDef.code,
+                args,
+                sessionStore,
+              });
+
+              if (newVariables && newVariables.length > 0)
+                await variables.set(newVariables);
+
+              return {
+                type: "function_call_output" as const,
+                call_id: fnCall.call_id,
+                output: safeStringify(output) ?? "",
+              };
+            }),
+          );
+
+        const continuationStream = openai.responses.stream({
+          model,
+          input: functionCallOutputs,
+          previous_response_id: response.id,
+          store: true,
+          instructions: instructions || undefined,
+          tools: tools.length > 0 ? tools : undefined,
+          temperature:
+            parsedTemperature != null && !Number.isNaN(parsedTemperature)
+              ? parsedTemperature
+              : undefined,
+        });
+
+        ({ response, functionCalls } =
+          await forwardStream(continuationStream));
+      }
+
+      const responseIdMapping = responseMapping?.find(
+        (m) => m.item === "Response ID",
+      );
+      if (responseIdMapping?.variableId)
+        await variables.set([
+          { id: responseIdMapping.variableId, value: response.id },
+        ]);
+      else if (responseIdVariableId)
+        await variables.set([
+          { id: responseIdVariableId, value: response.id },
+        ]);
+    });
+  } catch (error) {
+    logs?.add(await parseUnknownError({ err: error }));
+  }
+};
+
+const createResponseFoundationalStream = (
+  process: (helpers: {
+    forwardStream: (stream: {
+      [Symbol.asyncIterator](): AsyncIterator<ResponseStreamEvent>;
+      finalResponse(): Promise<OpenAI.Responses.Response>;
+    }) => Promise<{
+      response: OpenAI.Responses.Response;
+      functionCalls: OpenAI.Responses.ResponseFunctionToolCall[];
+    }>;
+  }) => Promise<void>,
+) =>
+  new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const textEncoder = new TextEncoder();
+
+      const sendError = (errorMessage: string) => {
+        controller.enqueue(
+          textEncoder.encode(formatDataStreamPart("error", errorMessage)),
+        );
+      };
+
+      const forwardStream = async (stream: {
+        [Symbol.asyncIterator](): AsyncIterator<ResponseStreamEvent>;
+        finalResponse(): Promise<OpenAI.Responses.Response>;
+      }) => {
+        for await (const event of stream) {
+          if (event.type === "response.output_text.delta")
+            controller.enqueue(
+              textEncoder.encode(formatDataStreamPart("text", event.delta)),
+            );
+        }
+
+        const response = await stream.finalResponse();
+        const functionCalls = response.output.filter(
+          (item): item is OpenAI.Responses.ResponseFunctionToolCall =>
+            item.type === "function_call",
+        );
+
+        return { response, functionCalls };
+      };
+
+      try {
+        await process({ forwardStream });
+      } catch (error) {
+        sendError((error as any).message ?? `${error}`);
+      } finally {
+        controller.close();
+      }
+    },
+    pull() {},
+    cancel() {},
+  });

--- a/packages/forge/blocks/openai/src/handlers/index.ts
+++ b/packages/forge/blocks/openai/src/handlers/index.ts
@@ -3,6 +3,7 @@ import {
   fetchAssistantFunctionsHandler,
   fetchAssistantsHandler,
 } from "./askAssistantHandler";
+import { askModelHandler } from "./askModelHandler";
 import { createChatCompletionHandler } from "./createChatCompletionHandler";
 import {
   createSpeechHandler,
@@ -15,6 +16,7 @@ export default [
   askAssistantHandler,
   fetchAssistantsHandler,
   fetchAssistantFunctionsHandler,
+  askModelHandler,
   createChatCompletionHandler,
   createSpeechHandler,
   fetchSpeechModelsHandler,

--- a/packages/forge/blocks/openai/src/helpers/parseToolsForResponsesApi.ts
+++ b/packages/forge/blocks/openai/src/helpers/parseToolsForResponsesApi.ts
@@ -1,0 +1,96 @@
+import { isNotEmpty } from "@typebot.io/lib/utils";
+import type { Responses } from "openai/resources/responses/responses";
+import { z } from "zod";
+
+type FunctionDef = {
+  name?: string;
+  description?: string;
+  parameters?: Array<{
+    type?: "string" | "number" | "boolean" | "enum";
+    name?: string;
+    description?: string;
+    required?: boolean;
+    values?: (string | undefined)[];
+  }>;
+  code?: string;
+};
+
+export const parseToolsForResponsesApi = ({
+  functions,
+  fileSearchVectorStoreIds,
+  webSearchEnabled,
+  codeInterpreterEnabled,
+}: {
+  functions?: FunctionDef[];
+  fileSearchVectorStoreIds?: string[];
+  webSearchEnabled?: boolean;
+  codeInterpreterEnabled?: boolean;
+}): Responses.Tool[] => {
+  const tools: Responses.Tool[] = [];
+
+  if (fileSearchVectorStoreIds) {
+    const ids = fileSearchVectorStoreIds.filter(isNotEmpty);
+    if (ids.length > 0)
+      tools.push({ type: "file_search", vector_store_ids: ids });
+  }
+
+  if (webSearchEnabled) tools.push({ type: "web_search" });
+
+  if (codeInterpreterEnabled)
+    tools.push({ type: "code_interpreter", container: { type: "auto" } });
+
+  if (functions) {
+    for (const fn of functions) {
+      if (!fn.name || !fn.code) continue;
+      tools.push({
+        type: "function",
+        name: fn.name,
+        description: fn.description ?? "",
+        parameters: parseParametersToJsonSchema(fn.parameters),
+        strict: false,
+      });
+    }
+  }
+
+  return tools;
+};
+
+const parseParametersToJsonSchema = (
+  parameters: FunctionDef["parameters"],
+): Record<string, unknown> => {
+  if (!parameters || parameters.length === 0)
+    return { type: "object", properties: {} };
+
+  const shape: Record<string, z.ZodTypeAny> = {};
+  for (const param of parameters) {
+    if (!param.name) continue;
+    switch (param.type) {
+      case "string":
+        shape[param.name] = z.string();
+        break;
+      case "number":
+        shape[param.name] = z.number();
+        break;
+      case "boolean":
+        shape[param.name] = z.boolean();
+        break;
+      case "enum": {
+        const values = (param.values ?? []).filter(
+          (v): v is string => v !== undefined,
+        );
+        if (values.length === 0) continue;
+        shape[param.name] = z.enum(values as [string, ...string[]]);
+        break;
+      }
+    }
+    if (param.description && isNotEmpty(param.description))
+      shape[param.name] = shape[param.name]!.describe(param.description);
+    if (param.required === false)
+      shape[param.name] = shape[param.name]!.optional();
+  }
+
+  return z.object(shape).toJSONSchema({ target: "draft-07" }) as Record<
+    string,
+    unknown
+  >;
+};

--- a/packages/forge/blocks/openai/src/helpers/splitMessageIntoResponsesApiInputItems.ts
+++ b/packages/forge/blocks/openai/src/helpers/splitMessageIntoResponsesApiInputItems.ts
@@ -1,0 +1,51 @@
+import { safeKy } from "@typebot.io/lib/ky";
+import { HTTPError } from "ky";
+import type { Responses } from "openai/resources/responses/responses";
+
+type InputContent = Responses.ResponseInputText | Responses.ResponseInputImage;
+
+export const splitMessageIntoResponsesApiInputItems = async (
+  input: string,
+): Promise<string | InputContent[]> => {
+  const parts = input.split("\n\n");
+  let contents: InputContent[] = [];
+  for (const part of parts) {
+    if (part.startsWith("http") || part.startsWith('["http')) {
+      const urls: string[] = part.startsWith("[") ? JSON.parse(part) : [part];
+      for (const url of urls) {
+        const cleanUrl = url.trim();
+        try {
+          const response = await safeKy.get(cleanUrl);
+          if (
+            !response.ok ||
+            !response.headers.get("content-type")?.startsWith("image/")
+          ) {
+            contents.push({ type: "input_text", text: cleanUrl });
+          } else {
+            contents.push({
+              type: "input_image",
+              image_url: cleanUrl,
+              detail: "auto",
+            });
+          }
+        } catch (err) {
+          if (err instanceof HTTPError)
+            console.log(err.response.status, await err.response.text());
+          else console.error(err);
+        }
+      }
+    } else {
+      const lastContent = contents.at(-1);
+      if (lastContent?.type === "input_text") {
+        contents = contents.slice(0, -1);
+        contents.push({
+          type: "input_text",
+          text: `${lastContent.text}\n\n${part}`,
+        });
+      } else {
+        contents.push({ type: "input_text", text: part });
+      }
+    }
+  }
+  return contents;
+};

--- a/packages/forge/blocks/openai/src/index.ts
+++ b/packages/forge/blocks/openai/src/index.ts
@@ -1,5 +1,6 @@
 import { createBlock } from "@typebot.io/forge";
 import { askAssistant } from "./actions/askAssistant";
+import { askModel } from "./actions/askModel";
 import { createChatCompletion } from "./actions/createChatCompletion";
 import { createSpeech } from "./actions/createSpeech";
 import { createTranscription } from "./actions/createTranscription";
@@ -19,6 +20,7 @@ export const openAIBlock = createBlock({
   actions: [
     createChatCompletion,
     askAssistant,
+    askModel,
     generateVariables,
     createSpeech,
     createTranscription,

--- a/packages/forge/core/src/types.ts
+++ b/packages/forge/core/src/types.ts
@@ -129,6 +129,7 @@ export type ActionDefinition<
   >,
 > = {
   name: string;
+  isHidden?: boolean;
   parseBlockNodeLabel?: BivariantCallback<
     WithoutVariables<z.infer<BaseOptions> & z.infer<Options>>,
     string


### PR DESCRIPTION
## Summary

- **New "Ask Model" action** in the OpenAI block using the Responses API (`openai.responses.stream()`), supporting multi-turn conversations via `previous_response_id`, built-in tools (file search with vector store IDs, web search, code interpreter), custom function calling, and streaming.
- **Deprecated "Ask Assistant"** action: hidden from the action dropdown (still functional for existing typebots), with Sentry tracking for production usage monitoring.
- **Updated template** (`openai-assistant-chat.json`) to use the new Ask Model action with `gpt-5.4`.
- **Merged `chatModels` + `reasoningModels`** into a single `models` list in constants.
- **Updated docs** replacing Ask Assistant documentation with Ask Model.

## Test plan
- [ ] Create a typebot with OpenAI → "Ask Model", configure model + message + instructions, verify streaming works
- [ ] Test multi-turn: verify Response ID variable persists across exchanges
- [ ] Test built-in tools: web search toggle, vector store IDs tag input, code interpreter toggle
- [ ] Test custom function calling loop
- [ ] Verify "Ask Assistant" still works for existing typebots but is hidden from the dropdown for new ones
- [ ] Verify the template loads correctly in the builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)