### PR TITLE
🐛 Fix SSRF safe dispatcher DNS lookup handling

### DIFF
--- a/packages/lib/src/ssrf/createSafeDispatcher.ts
+++ b/packages/lib/src/ssrf/createSafeDispatcher.ts
@@ -1,5 +1,6 @@
-import { lookup as dnsLookup, type LookupOneOptions } from "node:dns";
+import { lookup as dnsLookup } from "node:dns";
 import type { LookupFunction } from "node:net";
+import { env } from "@typebot.io/env";
 import { Agent } from "undici";
 import { parseIPAddress, validateIPAddress } from "./validateHttpReqUrl";
 
@@ -7,34 +8,41 @@ import { parseIPAddress, validateIPAddress } from "./validateHttpReqUrl";
  * A DNS lookup function that validates resolved IPs against SSRF blocklists.
  * Used as the `connect.lookup` in an undici Agent to ensure IP validation
  * happens at connection time — eliminating the TOCTOU gap of DNS rebinding.
+ *
+ * Handles both single-address and all-addresses modes since undici may pass
+ * `{ all: true }` in lookup options.
  */
 export const validatingLookup: LookupFunction = (
   hostname,
   options,
   callback,
 ) => {
-  dnsLookup(
-    hostname,
-    // LookupFunction always passes LookupOneOptions (never all:true),
-    // so the callback receives a single address string, not an array.
-    options as LookupOneOptions,
-    (err, address, family) => {
-      if (err) return callback(err, address, family);
-      try {
-        const parsed = parseIPAddress(address);
+  dnsLookup(hostname, options, (err: unknown, address: unknown, family: unknown) => {
+    if (err) return (callback as Function)(err, address, family);
+    if (env.NODE_ENV === "development" && hostname === "localhost") {
+      return (callback as Function)(null, address, family);
+    }
+    try {
+      if (Array.isArray(address)) {
+        for (const entry of address) {
+          const parsed = parseIPAddress(entry.address);
+          if (parsed) validateIPAddress(parsed);
+        }
+      } else {
+        const parsed = parseIPAddress(address as string);
         if (parsed) validateIPAddress(parsed);
-      } catch (validationError) {
-        return callback(
-          validationError instanceof Error
-            ? validationError
-            : new Error(String(validationError)),
-          address,
-          family,
-        );
       }
-      callback(null, address, family);
-    },
-  );
+    } catch (validationError) {
+      return (callback as Function)(
+        validationError instanceof Error
+          ? validationError
+          : new Error(String(validationError)),
+        address,
+        family,
+      );
+    }
+    (callback as Function)(null, address, family);
+  });
 };
 
 /**


### PR DESCRIPTION
- Fix `validatingLookup` to handle `{ all: true }` DNS lookup mode that undici passes, which returns an array of addresses instead of a single string
- Add localhost bypass in development mode to match existing `validateHttpReqUrl` behavior
- Without this fix, `fetch()` in Set Variable code blocks silently failed for external URLs