### PR TITLE
📝 Remove urgent support section from help docs

### DIFF
--- a/apps/docs/guides/how-to-get-help.mdx
+++ b/apps/docs/guides/how-to-get-help.mdx
@@ -7,14 +7,3 @@ Here is what you should do if you have an issue or even a question (this list is
 1. Read this documentation. I do my best to keep it up to date and to cover all the possible issues and questions. Use the search bar to find what you are looking for.
 2. You can ask for help or report your bug in the [Discord community](https://typebot.io/discord). Specifically in the `#help-and-questions` channel. I try to answer all the questions there daily. There is also a good chance that someone else has already asked the same question and you can find the answer there using the search bar.
 3. Users subscribed to the `Starter` or `Pro` plan can directly reach out to me through the chat widget in the bottom right corner of the app.
-
-## If this is urgent
-
-An urgent report is when you have a bot live with users actively using it, something used to work fine and, all of the sudden, something stopped working.
-
-<Warning>
-  If your report does not match this description, **you won't even get a
-  response**. So don't waste your time!
-</Warning>
-
-Report it [here](https://typebot.co/urgent-support).


### PR DESCRIPTION
- Remove the "If this is urgent" section and link to `typebot.co/urgent-support` from the how-to-get-help docs page