### PR TITLE
📝 Fill common docs gaps (logs, user commands, downgrade, persistent input)

### DIFF
--- a/apps/docs/editor/events/command.mdx
+++ b/apps/docs/editor/events/command.mdx
@@ -5,6 +5,10 @@ sidebarTitle: Command
 
 This event allows you to trigger a specifc flow when a command is sent to the bot. This command can be sent with an [continueChat HTTP request](/api-reference/chat/continue-chat) with a `command` message type or with the [Typebot.sendCommand](/deploy/web/html-javascript#commands) function if your bot is embedded on a website.
 
+<Note>
+  Looking to trigger behavior when the user **types** a keyword like `restart` or `help`? Use a [Reply event](./reply) instead — the Command event is only for triggers sent programmatically from outside the chat. See the [user commands guide](/guides/user-commands) for a concrete example.
+</Note>
+
 You assign a unique command name for each node and you can optionally resume the flow after the command is sent.
 
 <Frame>

--- a/apps/docs/editor/events/reply.mdx
+++ b/apps/docs/editor/events/reply.mdx
@@ -5,6 +5,10 @@ sidebarTitle: Reply
 
 This event will trigger everytime a reply is received, meaning whenever a user replies to any input in the flow. This is triggered even before the reply is processed and validated. This is useful when you need to execute a specific flow / automation whenever the user replies to the bot.
 
+<Note>
+  Not sure whether to use a Reply event or a [Command event](./command)? Use **Reply** when the trigger comes from inside the chat (the user types or clicks something). Use **Command** when the trigger comes from outside the chat (a button on your website, an external webhook, etc.).
+</Note>
+
 <Frame>
 	<img src="/images/events/reply-event.avif" alt="On New Message event in Typebot editor" />
 </Frame>
@@ -25,3 +29,4 @@ By default, when an event is executed, the session will end and not return to th
 
 - Automatically end the session if the user replies with "end", "exit", "quit".
 - Automatically trigger a feedback collection flow whenever a user replies with specific keywords like "feedback" "suggestion" or "comment".
+- Implement user commands like `restart` or `help`. See the [user commands guide](/guides/user-commands) for a step-by-step recipe.

--- a/apps/docs/faq.mdx
+++ b/apps/docs/faq.mdx
@@ -37,3 +37,12 @@ Typebot doesn't store any password. Its login works with Github, Google, Faceboo
 ## Can I set a variable with the Script block?
 
 No, the script block is only meant to execute a script. You can't set a variable with/in it. If you need to set a variable with some code, you can use the [Set variable block](/editor/blocks/logic/set-variable).
+
+## Can I have a persistent text input always visible at the bottom of the chat?
+
+No. Typebot is a flow-driven conversation engine: the input shown at any moment is the one defined by the current block. There is no native way to display a persistent free-text input that stays visible outside of an input block.
+
+If you need that kind of UX, you have two options:
+
+- **Accept user keywords at any input.** Add a [Reply event](/editor/events/reply) that reacts to specific keywords (see the [user commands guide](/guides/user-commands)). The input still belongs to the current block, but the user can type commands like `help` or `restart` from anywhere.
+- **Build a custom UI.** Use the [continueChat HTTP API](/api-reference/chat/continue-chat) to drive the conversation yourself and render whatever chat interface you want, including a persistent input. This is significantly more work than using the official embeds.

--- a/apps/docs/guides/user-commands.mdx
+++ b/apps/docs/guides/user-commands.mdx
@@ -1,0 +1,52 @@
+---
+title: How to add user commands (restart, help...)
+---
+
+A common pattern is letting the user type keywords like `restart`, `help`, or `menu` at any point in the conversation to trigger a specific behavior. Typebot does not ship a dedicated block for this, but you can build it with a [Reply event](/editor/events/reply) combined with [Jump](/editor/blocks/logic/jump) and [Return](/editor/blocks/logic/return) blocks.
+
+## Reply event vs Command event
+
+These two events are easy to confuse:
+
+- **[Reply event](/editor/events/reply)** fires on every user reply (text, button click, etc.). Use it when the trigger is something the user types or selects inside the chat. This is what you want for `restart` or `help` keywords.
+- **[Command event](/editor/events/command)** fires only when a command is sent programmatically via [`Typebot.sendCommand`](/deploy/web/html-javascript#commands) or the [continueChat API](/api-reference/chat/continue-chat). Use it to trigger flows from outside the conversation (a button on your page, an external webhook, etc.).
+
+If you want the user to type a keyword to trigger behavior, use the Reply event.
+
+## Implement a `restart` command
+
+The goal: whenever the user replies with `restart`, the conversation jumps back to the very first block of the flow.
+
+<Steps>
+  <Step title="Add a Reply event">
+    From the events sidebar, drag a Reply event onto the graph.
+  </Step>
+  <Step title="Filter the reply content">
+    Inside the event subflow, add a [Condition block](/editor/blocks/logic/condition) that checks if the reply content equals `restart` (case-insensitive if you prefer).
+  </Step>
+  <Step title="Jump to the first block">
+    On the `true` branch of the condition, add a [Jump block](/editor/blocks/logic/jump) pointing to the first block of your main flow.
+  </Step>
+  <Step title="Return on the false branch">
+    On the `false` branch, add a [Return block](/editor/blocks/logic/return) so the conversation resumes normally when the user types anything else.
+  </Step>
+</Steps>
+
+<Note>
+  The Reply event fires **before** the reply is validated against the current input. This means the keyword works even if the user is currently on a number or email input.
+</Note>
+
+## Implement a `help` command
+
+Same pattern, but instead of jumping to the start of the flow, jump to a dedicated "Help" group that sends a few text bubbles explaining what the bot can do. End that group with a Return block so the user comes back to where they were.
+
+## Handling multiple commands
+
+You can chain several conditions inside a single Reply event subflow:
+
+- `restart` → Jump to start
+- `help` → Jump to help group
+- `agent` → Jump to human handoff group
+- anything else → Return
+
+Keeping all your command routing inside one Reply event makes it easier to maintain than duplicating logic in every group.

--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -234,7 +234,8 @@
         "guides/rtl",
         "guides/utm-in-results",
         "guides/how-to-create-loops",
-        "guides/how-to-split-ai-messages-in-multi-blocks"
+        "guides/how-to-split-ai-messages-in-multi-blocks",
+        "guides/user-commands"
       ]
     },
     {

--- a/apps/docs/results/overview.mdx
+++ b/apps/docs/results/overview.mdx
@@ -52,8 +52,12 @@ You can see the transcript of a result by expanding the result row, clicking on 
 
 ## Logs
 
-For each result, you'll find a "See logs" button that can show you what went wrong while executing an integration such as Send email, Google Sheets, or a Webhook call:
+Typebot does not expose a global activity feed. Logs are attached to individual results, so they live inside the `Results` table.
+
+To see what happened during a conversation (including integration errors like Send email, Google Sheets, or HTTP request), open a specific result and look at the logs column. Each row has a "See logs" button:
 
 <Frame>
   <img src="/images/results/logs-button.png" alt="See logs buttons" />
 </Frame>
+
+Logs include integration outputs, errors, and warnings for that specific conversation. If an integration silently fails, this is where to look first.

--- a/apps/docs/workspace/subscription.mdx
+++ b/apps/docs/workspace/subscription.mdx
@@ -15,8 +15,32 @@ This tab displays your bots total usage, your current plan and paid invoices.
 
 You can choose to upgrade to your desired plan here.
 
-## Cancel plan
+## Cancel or downgrade plan
 
-In order to cancel your workspace plan, you need to open the `Settings & Members` modal in your homepage and navigate on the `Billing & Usage` tab.
+To cancel or downgrade your workspace plan:
 
-There, you should see a `Billing portal` button. Clicking on it will redirect you to the billing portal where you can manage and cancel your subscription.
+<Steps>
+  <Step title="Open workspace settings">
+    From your homepage, open the `Settings & Members` modal.
+  </Step>
+  <Step title="Go to Billing & Usage">
+    Navigate to the `Billing & Usage` tab.
+  </Step>
+  <Step title="Open the billing portal">
+    Click the `Billing portal` button. This redirects you to the Stripe-hosted billing portal.
+  </Step>
+  <Step title="Cancel the subscription">
+    From the billing portal you can cancel your subscription or switch to a different plan.
+  </Step>
+</Steps>
+
+Once the current billing period ends, the workspace automatically reverts to the **Free** plan.
+
+## Free plan limits
+
+When your workspace is on the Free plan, the following limits apply:
+
+- **200 chats per month.** A chat is counted once a user starts a conversation with your bot. Additional messages from the same user within the same session do not count.
+- **1 seat.** You cannot invite members to a Free workspace. To collaborate with others, upgrade to Starter or above.
+
+Higher limits are available on Starter, Pro, and Enterprise plans. See the [pricing page](https://typebot.com/pricing) for an up-to-date comparison.


### PR DESCRIPTION
- Clarify that logs are per-result and not a global activity feed in `results/overview.mdx`
- Add `guides/user-commands.mdx` with a concrete Reply event + Jump + Return recipe for `restart` / `help` commands
- Cross-link Reply event vs Command event in `editor/events/reply.mdx` and `editor/events/command.mdx`
- Add FAQ entry explaining that a persistent text input is not native, with keyword and custom-UI workarounds
- Restructure `workspace/subscription.mdx` with a Steps-based cancel/downgrade flow and explicit Free plan limits (200 chats, 1 seat)
- Register the new user-commands guide in `mint.json` navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)