### PR TITLE
🐛 Fix transcript compute crash on choice items with session-var display condition

### DIFF
--- a/apps/builder/src/features/results/components/ResultDialog.tsx
+++ b/apps/builder/src/features/results/components/ResultDialog.tsx
@@ -77,7 +77,12 @@ const Transcript = ({
   typebotId: string;
   resultId: string;
 }) => {
-  const { data: transcriptData, isLoading: isTranscriptLoading } = useQuery(
+  const {
+    data: transcriptData,
+    isLoading: isTranscriptLoading,
+    isError: isTranscriptError,
+    error: transcriptError,
+  } = useQuery(
     orpc.results.getResultTranscript.queryOptions({
       input: { typebotId, resultId },
     }),
@@ -88,6 +93,16 @@ const Transcript = ({
       <div className="flex flex-col gap-2 items-center py-8">
         <LoaderCircleIcon className="animate-spin" />
         <p>Loading transcript...</p>
+      </div>
+    );
+
+  if (isTranscriptError)
+    return (
+      <div className="border rounded-md p-4 bg-gray-1 text-sm text-gray-11">
+        <p>Could not load transcript.</p>
+        {transcriptError?.message && (
+          <p className="mt-1 text-xs">{transcriptError.message}</p>
+        )}
       </div>
     );
 

--- a/packages/bot-engine/bunfig.toml
+++ b/packages/bot-engine/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/test-preload.ts"]

--- a/packages/bot-engine/src/blocks/inputs/buttons/injectVariableValuesInButtonsInputBlock.ts
+++ b/packages/bot-engine/src/blocks/inputs/buttons/injectVariableValuesInButtonsInputBlock.ts
@@ -14,7 +14,12 @@ export const injectVariableValuesInButtonsInputBlock = (
   {
     sessionStore,
     variables,
-  }: { sessionStore: SessionStore; variables: Variable[] },
+    skipDisplayConditionCheck,
+  }: {
+    sessionStore: SessionStore;
+    variables: Variable[];
+    skipDisplayConditionCheck?: boolean;
+  },
 ): ChoiceInputBlock => {
   if (block.options?.dynamicVariableId) {
     const variable = variables.find(
@@ -38,7 +43,9 @@ export const injectVariableValuesInButtonsInputBlock = (
     };
   }
   return deepParseVariables(
-    filterChoiceItems(block, { sessionStore, variables }),
+    skipDisplayConditionCheck
+      ? block
+      : filterChoiceItems(block, { sessionStore, variables }),
     {
       variables,
       sessionStore,

--- a/packages/bot-engine/src/blocks/inputs/pictureChoice/injectVariableValuesInPictureChoiceBlock.ts
+++ b/packages/bot-engine/src/blocks/inputs/pictureChoice/injectVariableValuesInPictureChoiceBlock.ts
@@ -13,7 +13,12 @@ export const injectVariableValuesInPictureChoiceBlock = (
   {
     sessionStore,
     variables,
-  }: { sessionStore: SessionStore; variables: Variable[] },
+    skipDisplayConditionCheck,
+  }: {
+    sessionStore: SessionStore;
+    variables: Variable[];
+    skipDisplayConditionCheck?: boolean;
+  },
 ): PictureChoiceBlock => {
   if (
     block.options?.dynamicItems?.isEnabled &&
@@ -68,7 +73,9 @@ export const injectVariableValuesInPictureChoiceBlock = (
     };
   }
   return deepParseVariables(
-    filterPictureChoiceItems(block, { variables, sessionStore }),
+    skipDisplayConditionCheck
+      ? block
+      : filterPictureChoiceItems(block, { variables, sessionStore }),
     {
       variables,
       sessionStore,

--- a/packages/bot-engine/src/computeResultTranscript.test.ts
+++ b/packages/bot-engine/src/computeResultTranscript.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+import { InputBlockType } from "@typebot.io/blocks-inputs/constants";
+import type { TypebotInSessionV6 } from "@typebot.io/chat-session/schemas";
+import { ComparisonOperators } from "@typebot.io/conditions/constants";
+import { EventType } from "@typebot.io/events/constants";
+import { SessionStore } from "@typebot.io/runtime-session-store";
+import { computeResultTranscript } from "./computeResultTranscript";
+
+const buildTypebotWithSessionVarDisplayCondition = (): TypebotInSessionV6 => ({
+  version: "6.1",
+  id: "typebot-1",
+  variables: [
+    {
+      id: "session-var-id",
+      name: "Page Url",
+      isSessionVariable: true,
+    },
+  ],
+  events: [
+    {
+      id: "start-event",
+      type: EventType.START,
+      graphCoordinates: { x: 0, y: 0 },
+      outgoingEdgeId: "edge-start",
+    },
+  ],
+  edges: [
+    {
+      id: "edge-start",
+      from: { eventId: "start-event" },
+      to: { groupId: "group-choice" },
+    },
+    {
+      id: "edge-product",
+      from: { blockId: "choice-block", itemId: "item-product" },
+      to: { groupId: "group-product" },
+    },
+    {
+      id: "edge-other",
+      from: { blockId: "choice-block", itemId: "item-other" },
+      to: { groupId: "group-other" },
+    },
+  ],
+  groups: [
+    {
+      id: "group-choice",
+      title: "Choice",
+      graphCoordinates: { x: 0, y: 0 },
+      blocks: [
+        {
+          id: "choice-block",
+          type: InputBlockType.CHOICE,
+          items: [
+            {
+              id: "item-product",
+              content: "Show product page",
+              outgoingEdgeId: "edge-product",
+              displayCondition: {
+                isEnabled: true,
+                condition: {
+                  comparisons: [
+                    {
+                      id: "cmp-1",
+                      variableId: "session-var-id",
+                      comparisonOperator: ComparisonOperators.CONTAINS,
+                      value: "/product/",
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              id: "item-other",
+              content: "Other",
+              outgoingEdgeId: "edge-other",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: "group-product",
+      title: "Product",
+      graphCoordinates: { x: 0, y: 0 },
+      blocks: [],
+    },
+    {
+      id: "group-other",
+      title: "Other",
+      graphCoordinates: { x: 0, y: 0 },
+      blocks: [],
+    },
+  ],
+});
+
+describe("computeResultTranscript", () => {
+  it("does not throw when a chosen item's displayCondition relies on an unset session variable", () => {
+    const typebot = buildTypebotWithSessionVarDisplayCondition();
+    const sessionStore = new SessionStore();
+
+    const transcript = computeResultTranscript({
+      typebot,
+      answers: [{ blockId: "choice-block", content: "Show product page" }],
+      setVariableHistory: [],
+      visitedEdges: ["edge-start", "edge-product"],
+      sessionStore,
+    });
+
+    expect(transcript).toEqual([
+      {
+        id: "choice-block-0",
+        role: "user",
+        type: "text",
+        text: "Show product page",
+      },
+    ]);
+  });
+});

--- a/packages/bot-engine/src/test-preload.ts
+++ b/packages/bot-engine/src/test-preload.ts
@@ -1,0 +1,9 @@
+import { mock } from "bun:test";
+
+process.env.SKIP_ENV_CHECK = "true";
+
+mock.module("isolated-vm", () => ({
+  default: {},
+  Isolate: class {},
+  Context: class {},
+}));

--- a/packages/bot-engine/src/validateAndParseInputMessage.ts
+++ b/packages/bot-engine/src/validateAndParseInputMessage.ts
@@ -67,6 +67,7 @@ export const validateAndParseInputMessage = (
       const displayedItems = injectVariableValuesInButtonsInputBlock(block, {
         variables,
         sessionStore,
+        skipDisplayConditionCheck: skipValidation,
       }).items;
       if (block.options?.isMultipleChoice)
         return parseMultipleChoiceReply(message.text, {
@@ -169,6 +170,7 @@ export const validateAndParseInputMessage = (
       const displayedItems = injectVariableValuesInPictureChoiceBlock(block, {
         variables,
         sessionStore,
+        skipDisplayConditionCheck: skipValidation,
       }).items;
       if (block.options?.isMultipleChoice)
         return parseMultipleChoiceReply(message.text, {


### PR DESCRIPTION
- Add `skipDisplayConditionCheck` option to `injectVariableValuesInButtonsInputBlock` and `injectVariableValuesInPictureChoiceBlock` to skip runtime display-condition filtering
- Propagate the flag from `validateAndParseInputMessage` when `skipValidation` is true, so transcript compute no longer filters out the item the user actually chose
- Show an error state in `ResultDialog` when the transcript query fails instead of rendering an empty container
- Add a unit test reproducing the bug (choice item with `displayCondition` on an unset session variable)
- Add `bunf​ig.toml` + `test-preload.ts` for `bot-engine` to mock `isolated-vm` and set `SKIP_ENV_CHECK` at test time