### PR TITLE
fix(security): strip Basic Auth credentials from HTTP request logs and sanitize upload filenames

### DIFF
--- a/packages/blocks/fileInput/src/api/handleGenerateUploadUrl.ts
+++ b/packages/blocks/fileInput/src/api/handleGenerateUploadUrl.ts
@@ -10,6 +10,7 @@ import { parseAllowedFileTypesMetadata } from "@typebot.io/lib/extensionFromMime
 import { generatePresignedPutUrl } from "@typebot.io/lib/s3/generatePresignedPutUrl";
 import prisma from "@typebot.io/prisma";
 import type { Prisma } from "@typebot.io/prisma/types";
+import { basename } from "path";
 import { z } from "zod";
 
 export const generateUploadUrlInputSchema = z.object({
@@ -102,12 +103,13 @@ export const handleGenerateUploadUrl = async ({
 
   const resultId = session.state.typebotsQueue[0].resultId;
 
+  const safeFileName = basename(fileName);
   const filePath =
     "workspaceId" in typebot && typebot.workspaceId && resultId
       ? `${visibility === "Private" ? "private" : "public"}/workspaces/${
           typebot.workspaceId
-        }/typebots/${typebotId}/results/${resultId}/blocks/${blockId}/${fileName}`
-      : `public/tmp/typebots/${typebotId}/blocks/${blockId}/${fileName}`;
+        }/typebots/${typebotId}/results/${resultId}/blocks/${blockId}/${safeFileName}`
+      : `public/tmp/typebots/${typebotId}/blocks/${blockId}/${safeFileName}`;
 
   const { presignedUrl, fileUrl: defaultFileUrl, fileType: resolvedFileType, maxFileSize: maxFileSizeMB } = await generatePresignedPutUrl({
     fileType,
@@ -121,7 +123,7 @@ export const handleGenerateUploadUrl = async ({
     maxFileSize: maxFileSizeMB,
     fileUrl:
       visibility === "Private" && !isPreview
-        ? `${env.NEXTAUTH_URL}/api/typebots/${typebotId}/results/${resultId}/blocks/${blockId}/${fileName}`
+        ? `${env.NEXTAUTH_URL}/api/typebots/${typebotId}/results/${resultId}/blocks/${blockId}/${safeFileName}`
         : defaultFileUrl,
   };
 };

--- a/packages/bot-engine/src/blocks/integrations/httpRequest/executeHttpRequestBlock.ts
+++ b/packages/bot-engine/src/blocks/integrations/httpRequest/executeHttpRequestBlock.ts
@@ -308,6 +308,8 @@ export const executeHttpRequest = async (
       : { ...baseRequest, body }
     : baseRequest;
 
+  const safeRequest = omit(request, "username", "password");
+
   try {
     const response = await safeKy(request.url, omit(request, "url"));
     const body = await response.text();
@@ -317,7 +319,7 @@ export const executeHttpRequest = async (
       details: JSON.stringify({
         statusCode: response.status,
         response: body,
-        request,
+        request: safeRequest,
       }),
     });
     return {
@@ -339,7 +341,7 @@ export const executeHttpRequest = async (
         description: webhookErrorDescription,
         details: JSON.stringify({
           statusCode: error.response.status,
-          request,
+          request: safeRequest,
           response,
         }),
       });
@@ -361,7 +363,7 @@ export const executeHttpRequest = async (
         }s)`,
         details: JSON.stringify({
           response,
-          request,
+          request: safeRequest,
         }),
       });
       return { response, logs, startTimeShouldBeUpdated: true };
@@ -380,7 +382,7 @@ export const executeHttpRequest = async (
       description: "Webhook failed to execute.",
       details: JSON.stringify({
         response,
-        request,
+        request: safeRequest,
       }),
     });
     return { response, logs, startTimeShouldBeUpdated: true };


### PR DESCRIPTION
## Summary

Two security issues found in the HTTP request block execution path and file upload URL generation.

### 1. Basic Auth credentials leaked in execution logs (High)

`executeHttpRequestBlock.ts` extracts `username` and `password` from the `Authorization: Basic ...` header into a `basicAuth` object and spreads it onto the `request` object. That same `request` object is then serialized verbatim into every log entry — success, HTTP error, timeout, and unknown error.

Anyone with access to bot execution logs (the bot owner, workspace admins, or anyone with log storage access) can read plaintext passwords from any HTTP block that uses Basic Auth.

**Before:**
```ts
logs.push({
  status: "success",
  details: JSON.stringify({ statusCode: response.status, response: body, request }),
  //                                                                       ^ includes username + password
});
```

**After:**
```ts
const safeRequest = omit(request, "username", "password");
// safeRequest used in all logs; original request used for the actual call
```

### 2. Unsanitized filename in S3 key construction (Medium)

`handleGenerateUploadUrl.ts` incorporates the user-supplied `fileName` directly into the S3 object key and the `fileUrl` returned to the client without any sanitization. While S3 doesn't resolve `../` as filesystem traversal, the raw filename could contain path separators that produce unexpected key structures or confuse downstream URL parsing.

**Fix:** `basename(fileName)` applied before building the key, stripping any directory components.

## Test plan

- [ ] HTTP block with Basic Auth: execution logs should show `headers` and `url` but **no** `username`/`password` fields
- [ ] File upload with filename `../../../evil.txt` — S3 key and returned `fileUrl` should use `evil.txt` only
- [ ] Normal HTTP block execution and file upload continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)