### PR TITLE
📝 Add Pro-only callout, workspace switcher doc, external messaging guide

### DIFF
--- a/apps/docs/deploy/web/custom-domain.mdx
+++ b/apps/docs/deploy/web/custom-domain.mdx
@@ -2,6 +2,10 @@
 title: Add a custom domain
 ---
 
+<Note>
+  Custom domains are available on the **Pro plan** and above. If you are on Free or Starter, the option will not appear in the Share tab. See the [pricing page](https://typebot.com/pricing) for details.
+</Note>
+
 You can bind a custom domain to your typebot in the "Share" tab.
 
 <Frame>

--- a/apps/docs/faq.mdx
+++ b/apps/docs/faq.mdx
@@ -38,6 +38,18 @@ Typebot doesn't store any password. Its login works with Github, Google, Faceboo
 
 No, the script block is only meant to execute a script. You can't set a variable with/in it. If you need to set a variable with some code, you can use the [Set variable block](/editor/blocks/logic/set-variable).
 
+## I don't see my bots after login, where did they go?
+
+Typebots live inside a workspace, and each account can belong to several workspaces. A common case is having a personal Free workspace and being invited to a team workspace: after login you land on one of them, and your bots may actually be in the other.
+
+Open the workspace dropdown at the top-left of the dashboard and switch to the workspace that contains your bots.
+
+<Frame>
+  <img src="/images/workspace/workspaces-dropdown.png" alt="Workspaces dropdown" />
+</Frame>
+
+If the expected workspace is missing from the dropdown, make sure you are logged in with the same email that was invited to the team workspace. See [workspace overview](/workspace) for more details.
+
 ## Can I have a persistent text input always visible at the bottom of the chat?
 
 No. Typebot is a flow-driven conversation engine: the input shown at any moment is the one defined by the current block. There is no native way to display a persistent free-text input that stays visible outside of an input block.

--- a/apps/docs/guides/external-messaging-apps.mdx
+++ b/apps/docs/guides/external-messaging-apps.mdx
@@ -1,0 +1,60 @@
+---
+title: Integrate with external messaging apps via HTTP API
+sidebarTitle: External messaging apps
+---
+
+Typebot ships native integrations for the web and WhatsApp. For messaging platforms that don't have a dedicated integration (KakaoTalk, LINE, WeChat, Telegram, Viber, or any proprietary chat app), you can still drive a Typebot conversation by calling the HTTP API yourself.
+
+The integration sits between the messaging app and Typebot: it receives each incoming message from the platform, forwards it to Typebot, and relays the bot reply back to the user.
+
+<Frame>
+  <img src="/images/api/publicId.png" alt="Find your typebot public ID" />
+</Frame>
+
+## How it works
+
+For each user, you need to persist one Typebot `sessionId` so the conversation stays stateful across messages.
+
+<Steps>
+  <Step title="Receive a webhook from the messaging app">
+    Most messaging platforms (KakaoTalk, LINE, Telegram, etc.) let you register a webhook URL that is called whenever a user sends a message. Create an HTTP endpoint on your server to handle those calls.
+  </Step>
+  <Step title="Start a chat on the first message">
+    If you don't have a `sessionId` for this user yet, call the [start chat endpoint](/api-reference/chat/start-chat):
+
+    ```sh
+    curl -X POST https://typebot.co/api/v1/typebots/<publicId>/startChat \
+      -H "Content-Type: application/json" \
+      -d '{}'
+    ```
+
+    Store the returned `sessionId` next to the user's platform ID in your database.
+  </Step>
+  <Step title="Forward subsequent messages">
+    For every following message from the same user, call [continueChat](/api-reference/chat/continue-chat) with the stored session:
+
+    ```sh
+    curl -X POST https://typebot.co/api/v1/sessions/<sessionId>/continueChat \
+      -H "Content-Type: application/json" \
+      -d '{"message": "user reply here"}'
+    ```
+  </Step>
+  <Step title="Render the bot response on the messaging app">
+    Both endpoints return a `messages` array describing what the bot wants to say (text bubbles, images, buttons, etc.). Map each message to the equivalent primitive on the target platform — for example a KakaoTalk text bubble, a LINE template message, or a Telegram inline keyboard.
+
+    If the response contains an `input`, present it to the user (buttons become quick replies, a text input just waits for the next message, etc.). When the user answers, loop back to the previous step.
+  </Step>
+</Steps>
+
+## Things to keep in mind
+
+- **Authentication.** Public endpoints (`/api/v1/typebots/<publicId>/startChat`) don't require a token. If you want to use the preview endpoint or any authenticated route, [generate an API token](/api-reference/authentication).
+- **Session lifetime.** Sessions expire after a period of inactivity. Handle 404 errors from `continueChat` by starting a new session transparently.
+- **Block compatibility.** Blocks that rely on the web embed (file upload UI, payment form, embedded videos...) don't have a 1:1 equivalent on most messaging apps. Keep the flow text-first when you target external platforms.
+- **Rate limits.** Messaging platforms usually enforce strict rate limits. Queue outgoing messages if the bot sends several bubbles in a row.
+
+## Related
+
+- [Chat API reference](/api-reference/chat/start-chat)
+- [continueChat reference](/api-reference/chat/continue-chat)
+- [API authentication](/api-reference/authentication)

--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -235,7 +235,8 @@
         "guides/utm-in-results",
         "guides/how-to-create-loops",
         "guides/how-to-split-ai-messages-in-multi-blocks",
-        "guides/user-commands"
+        "guides/user-commands",
+        "guides/external-messaging-apps"
       ]
     },
     {

--- a/apps/docs/workspace.mdx
+++ b/apps/docs/workspace.mdx
@@ -9,6 +9,16 @@ Your plan is tied to your workspace. It means that if you have a Personal Pro wo
 
 You can create as many workspaces as you want.
 
+## Switch workspace
+
+When you belong to several workspaces (for example, a personal workspace and a team workspace you were invited to), you can switch between them at any time from the workspace dropdown at the top-left of the dashboard:
+
+<Frame>
+  <img src="/images/workspace/workspaces-dropdown.png" alt="Workspaces dropdown" />
+</Frame>
+
+If you log in and can't find your bots, you are most likely viewing a different workspace than the one that owns them. Open the dropdown and pick the right workspace. If the expected workspace is missing, make sure you are logged in with the email address that was invited to it.
+
 ## Members
 
 <Frame>


### PR DESCRIPTION
- Add a Pro-only `<Note>` callout at the top of `deploy/web/custom-domain.mdx`
- Add a "Switch workspace" section in `workspace.mdx` covering the workspace dropdown
- Add a FAQ entry "I don't see my bots after login" pointing to the workspace switcher
- Add new guide `guides/external-messaging-apps.mdx` on integrating Typebot with external messaging apps (KakaoTalk, LINE, Telegram, etc.) via the HTTP API
- Register the new guide in `mint.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)