### PR TITLE
📝 Document graph edge pitfall and theme republish requirement

### DIFF
--- a/apps/docs/editor/graph.mdx
+++ b/apps/docs/editor/graph.mdx
@@ -24,3 +24,16 @@ In the user preferences, under the `Graph Gestures` section, you can choose betw
 **Zoom**: Pinch
 
 **Pan**: Use two finger
+
+## Common pitfalls
+
+### A block without an outgoing edge stops the flow
+
+Every block (except the final one of a conversation) needs an outgoing edge connected to the next block or group. If a block has no outgoing edge, the conversation will stop right there, even if other groups exist below.
+
+<Warning>
+  This is the most common cause of "my bot stops in the middle of the flow". The
+  editor does not display a visual warning when a non-terminal block has no
+  outgoing edge, so double-check that every block you expect to continue has a
+  connection.
+</Warning>

--- a/apps/docs/theme/overview.mdx
+++ b/apps/docs/theme/overview.mdx
@@ -12,6 +12,13 @@ The theme tab allows you to customize the look of your typebot.
 
 This section allows you to enable or disable the typebot branding, change the font and the background of your bot.
 
+<Note>
+  Toggling the **Typebot branding** option (or any other theme change) only
+  affects the live bot once you [republish](./../editor/publish) it. If you have
+  just disabled the branding but still see it on your published bot, hit the
+  **Publish** button to propagate the change.
+</Note>
+
 ### Progress Bar
 
 The Progress Bar allows you to visually indicate a user’s progress through the bot. This helps improve user experience by providing a sense of advancement and completion.


### PR DESCRIPTION
- Add a "Common pitfalls" section to `apps/docs/editor/graph.mdx` warning that a block without an outgoing edge stops the flow.
- Add a note in `apps/docs/theme/overview.mdx` clarifying that toggling Typebot branding (or any theme change) requires a republish to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)