### PR TITLE
📝 Document VAT ID for B2B reverse charge

### DIFF
--- a/apps/docs/workspace/subscription.mdx
+++ b/apps/docs/workspace/subscription.mdx
@@ -36,6 +36,28 @@ To cancel or downgrade your workspace plan:
 
 Once the current billing period ends, the workspace automatically reverts to the **Free** plan.
 
+## Add a VAT ID for B2B reverse charge
+
+If you are a VAT-registered business in the EU (outside of France), you can add your VAT ID to your billing details so that future invoices are issued under the reverse charge mechanism, without VAT.
+
+<Steps>
+  <Step title="Open the billing portal">
+    From your homepage, open the `Settings & Members` modal, navigate to the `Billing & Usage` tab and click `Billing portal`.
+  </Step>
+  <Step title="Update your billing information">
+    In the billing portal, click `Update information` in the billing details section.
+  </Step>
+  <Step title="Add your VAT ID">
+    Click `Add tax ID`, pick your country prefix (for example `EU VAT`) and paste your VAT number, then save.
+  </Step>
+</Steps>
+
+<Note>
+  Adding a VAT ID only affects **future invoices**. Past invoices cannot be reissued without VAT, even after a valid VAT ID is added. Add your VAT ID before your next renewal to make sure the reverse charge is applied.
+</Note>
+
+Without a valid VAT ID on file, your billing country's destination VAT is charged on every invoice as for a standard B2C customer.
+
 ## Free plan limits
 
 When your workspace is on the Free plan, the following limits apply:


### PR DESCRIPTION
- Add a new "Add a VAT ID for B2B reverse charge" section to `apps/docs/workspace/subscription.mdx`
- Document the steps to add a VAT ID through the Stripe billing portal
- Clarify that the reverse charge only applies to future invoices, not retroactively
- Note that without a VAT ID, destination VAT is charged as for a standard B2C customer

🤖 Generated with [Claude Code](https://claude.com/claude-code)