### PR TITLE
🔒️ Add SSRF_ALLOWED_HOSTS env for self-hosted internal APIs

### DIFF
--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -85,6 +85,16 @@ const baseEnv = {
       )
       .default("FREE"),
     TYPEBOT_DEBUG: boolean.optional().default(false),
+    SSRF_ALLOWED_HOSTS: z
+      .string()
+      .min(1)
+      .transform((val) =>
+        val
+          .split(",")
+          .map((s) => s.trim().toLowerCase())
+          .filter(Boolean),
+      )
+      .optional(),
     CHAT_API_TIMEOUT: z.coerce.number().optional(),
     RADAR_HIGH_RISK_KEYWORDS: z
       .string()

--- a/packages/lib/src/ssrf/validateHttpReqUrl.test.ts
+++ b/packages/lib/src/ssrf/validateHttpReqUrl.test.ts
@@ -27,6 +27,26 @@ const lookupHost = async (
     return [{ address: "10.0.0.5", family: 4 }];
   }
 
+  if (hostname === "internal.corp.example") {
+    return [{ address: "10.5.5.5", family: 4 }];
+  }
+
+  if (hostname === "172.corp.example") {
+    return [{ address: "172.20.10.5", family: 4 }];
+  }
+
+  if (hostname === "192.corp.example") {
+    return [{ address: "192.168.1.10", family: 4 }];
+  }
+
+  if (hostname === "hijacked.allowlisted.example") {
+    return [{ address: "169.254.169.254", family: 4 }];
+  }
+
+  if (hostname === "hijacked-loopback.example") {
+    return [{ address: "127.0.0.1", family: 4 }];
+  }
+
   throw new Error(`Unexpected hostname lookup: ${hostname}`);
 };
 
@@ -370,5 +390,156 @@ describe("validateHttpReqUrl - IPv6-mapped IPv4", () => {
       "http://[0:0:0:0:0:ffff:169.254.169.254]",
       "link-local addresses",
     );
+  });
+});
+
+describe("validateHttpReqUrl - SSRF_ALLOWED_HOSTS allowlist", () => {
+  const allowedHosts = [
+    "internal.corp.example",
+    "172.corp.example",
+    "192.corp.example",
+    "hijacked.allowlisted.example",
+    "hijacked-loopback.example",
+    "10.0.0.5",
+  ];
+
+  describe("allows RFC1918 ranges for allowlisted hostnames", () => {
+    it("should allow hostname resolving to 10.0.0.0/8 when listed", async () => {
+      await expect(
+        validateHttpReqUrl("http://internal.corp.example/api", {
+          lookupHost,
+          allowedHosts,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("should allow hostname resolving to 172.16.0.0/12 when listed", async () => {
+      await expect(
+        validateHttpReqUrl("http://172.corp.example/api", {
+          lookupHost,
+          allowedHosts,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("should allow hostname resolving to 192.168.0.0/16 when listed", async () => {
+      await expect(
+        validateHttpReqUrl("http://192.corp.example/api", {
+          lookupHost,
+          allowedHosts,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("should allow direct RFC1918 IP literal when the IP itself is listed", async () => {
+      await expect(
+        validateHttpReqUrl("http://10.0.0.5/api", {
+          lookupHost,
+          allowedHosts,
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("preserves protections that cannot be opted out of", () => {
+    it("should still block link-local 169.254.0.0/16 even for allowlisted host (CVE vector)", async () => {
+      // Defense against DNS hijacking: even if an attacker controls DNS for
+      // an allowlisted hostname and points it to the metadata service IP,
+      // the link-local check still fires.
+      await expect(
+        validateHttpReqUrl("http://hijacked.allowlisted.example/api", {
+          lookupHost,
+          allowedHosts,
+        }),
+      ).rejects.toThrow("link-local addresses");
+    });
+
+    it("should still block loopback 127.0.0.0/8 for allowlisted host", async () => {
+      await expect(
+        validateHttpReqUrl("http://hijacked-loopback.example/api", {
+          lookupHost,
+          allowedHosts,
+        }),
+      ).rejects.toThrow("loopback addresses");
+    });
+
+    it("should still block direct 169.254.169.254 even if listed as IP", async () => {
+      await expect(
+        validateHttpReqUrl("http://169.254.169.254/", {
+          lookupHost,
+          allowedHosts: ["169.254.169.254"],
+        }),
+      ).rejects.toThrow("link-local addresses");
+    });
+
+    it("should still block metadata.google.internal even when allowlisted", async () => {
+      await expect(
+        validateHttpReqUrl("http://metadata.google.internal/", {
+          lookupHost,
+          allowedHosts: ["metadata.google.internal"],
+        }),
+      ).rejects.toThrow("cloud metadata services");
+    });
+
+    it("should still block decimal-encoded metadata IP even when listed", async () => {
+      // URL parser converts 2852039166 to 169.254.169.254; the link-local
+      // check fires before any allowlist branch.
+      await expect(
+        validateHttpReqUrl("http://2852039166/", {
+          lookupHost,
+          allowedHosts: ["2852039166"],
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("preserves default behavior when no allowlist is configured", () => {
+    it("should block 10.x.x.x when allowedHosts is undefined", async () => {
+      await expect(
+        validateHttpReqUrl("http://internal.corp.example/api", {
+          lookupHost,
+        }),
+      ).rejects.toThrow("10.0.0.0/8");
+    });
+
+    it("should block 10.x.x.x when allowedHosts is empty", async () => {
+      await expect(
+        validateHttpReqUrl("http://internal.corp.example/api", {
+          lookupHost,
+          allowedHosts: [],
+        }),
+      ).rejects.toThrow("10.0.0.0/8");
+    });
+
+    it("should block hostname not present in allowlist", async () => {
+      await expect(
+        validateHttpReqUrl("http://internal.example/api", {
+          lookupHost,
+          allowedHosts: ["different-host.example"],
+        }),
+      ).rejects.toThrow("10.0.0.0/8");
+    });
+  });
+
+  describe("hostname matching semantics", () => {
+    it("should match hostnames case-insensitively (URL parser normalizes hostname to lowercase)", async () => {
+      await expect(
+        validateHttpReqUrl("http://INTERNAL.CORP.EXAMPLE/api", {
+          lookupHost,
+          allowedHosts: ["internal.corp.example"],
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("should not match a subdomain of an allowlisted host", async () => {
+      // "sub.internal.corp.example" is not equal to "internal.corp.example"
+      // so the allowlist does not apply. This is intentional — exact match only.
+      await expect(
+        validateHttpReqUrl("http://internal.example/api", {
+          lookupHost,
+          allowedHosts: ["example", "corp.example"],
+        }),
+      ).rejects.toThrow("10.0.0.0/8");
+    });
   });
 });

--- a/packages/lib/src/ssrf/validateHttpReqUrl.ts
+++ b/packages/lib/src/ssrf/validateHttpReqUrl.ts
@@ -18,14 +18,23 @@ const BLOCKED_HEADERS = [
  * - Various IP encoding bypass attempts (decimal, hex, octal)
  * - Hostnames that resolve to blocked IP ranges
  *
+ * Hostnames listed in the SSRF_ALLOWED_HOSTS env var skip the RFC1918
+ * private-range checks (10/8, 172.16/12, 192.168/16) so self-hosters can
+ * reach internal corporate APIs. All other protections remain active —
+ * including link-local (169.254/16, the actual CVE-2025-64709 vector),
+ * loopback, cloud metadata hostnames, encoded-IP detection, and IMDS
+ * bypass header blocks.
+ *
  * @throws Error if the URL is blocked or invalid
  */
 export const validateHttpReqUrl = async (
   urlString: string,
   {
     lookupHost = lookup,
+    allowedHosts = env.SSRF_ALLOWED_HOSTS,
   }: {
     lookupHost?: LookupHost;
+    allowedHosts?: readonly string[];
   } = {},
 ) => {
   if (!urlString?.trim()) {
@@ -91,10 +100,12 @@ export const validateHttpReqUrl = async (
     );
   }
 
+  const isAllowlisted = allowedHosts?.includes(hostname) ?? false;
+
   // Parse IP address if it's in standard format
   const ip = parseIPAddress(hostname);
   if (ip) {
-    validateIPAddress(ip);
+    validateIPAddress(ip, { allowPrivateRanges: isAllowlisted });
     return;
   }
 
@@ -116,7 +127,9 @@ export const validateHttpReqUrl = async (
       );
     }
 
-    validateIPAddress(parsedResolvedAddress);
+    validateIPAddress(parsedResolvedAddress, {
+      allowPrivateRanges: isAllowlisted,
+    });
   });
 };
 
@@ -190,11 +203,20 @@ type LookupHost = (
 ) => Promise<Array<{ address: string; family: number }>>;
 
 /**
- * Validates that an IP address is not in a blocked range
+ * Validates that an IP address is not in a blocked range.
+ *
+ * When `allowPrivateRanges` is true (set by the caller for hostnames in
+ * SSRF_ALLOWED_HOSTS), RFC1918 private ranges are skipped — but link-local,
+ * loopback, 0.0.0.0/8 and IPv6 unique local ranges remain blocked. This
+ * preserves protection against the metadata-service vector (169.254.169.254)
+ * even for allowlisted hostnames whose DNS could be hijacked.
  *
  * @throws Error if the IP is in a blocked range
  */
-export const validateIPAddress = (ip: ParsedIP) => {
+export const validateIPAddress = (
+  ip: ParsedIP,
+  { allowPrivateRanges = false }: { allowPrivateRanges?: boolean } = {},
+) => {
   if (ip.version === 4) {
     const [first, second] = ip.octets;
 
@@ -213,21 +235,26 @@ export const validateIPAddress = (ip: ParsedIP) => {
     }
 
     // Block 10.0.0.0/8 (private)
-    if (first === 10) {
+    if (first === 10 && !allowPrivateRanges) {
       throw new Error(
         "Access to private network range (10.0.0.0/8) is not allowed for security reasons.",
       );
     }
 
     // Block 172.16.0.0/12 (private)
-    if (first === 172 && second >= 16 && second <= 31) {
+    if (
+      first === 172 &&
+      second >= 16 &&
+      second <= 31 &&
+      !allowPrivateRanges
+    ) {
       throw new Error(
         "Access to private network range (172.16.0.0/12) is not allowed for security reasons.",
       );
     }
 
     // Block 192.168.0.0/16 (private)
-    if (first === 192 && second === 168) {
+    if (first === 192 && second === 168 && !allowPrivateRanges) {
       throw new Error(
         "Access to private network range (192.168.0.0/16) is not allowed for security reasons.",
       );
@@ -256,7 +283,7 @@ export const validateIPAddress = (ip: ParsedIP) => {
           octets.length === 4 &&
           octets.every((o) => !Number.isNaN(o) && o >= 0 && o <= 255)
         ) {
-          validateIPAddress({ version: 4, octets });
+          validateIPAddress({ version: 4, octets }, { allowPrivateRanges });
           return;
         }
       }
@@ -274,7 +301,7 @@ export const validateIPAddress = (ip: ParsedIP) => {
             (group2 >> 8) & 0xff,
             group2 & 0xff,
           ];
-          validateIPAddress({ version: 4, octets });
+          validateIPAddress({ version: 4, octets }, { allowPrivateRanges });
           return;
         }
       }


### PR DESCRIPTION
## Summary

Self-hosted deployments often have legitimate internal corporate APIs on RFC1918 ranges (10/8, 172.16/12, 192.168/16) — e.g., a backend chat API exposed only on the internal cluster network. Since v3.14, the SSRF mitigation introduced for [CVE-2025-64709 / GHSA-8gq9-rw7v-3jpr](https://github.com/baptisteArno/typebot.io/security/advisories/GHSA-8gq9-rw7v-3jpr) blocks every private range unconditionally, which prevents HTTP Request blocks (and Function blocks via fetch) from reaching those APIs without exposing them to the public internet.

The advisory itself listed hostname allowlisting as one of the recommended mitigations (item #5: "Implement an SSRF-safe proxy or apply hostname allowlists for outgoing requests"), and this PR implements it as an opt-in env var.

## What changes

- New env var `SSRF_ALLOWED_HOSTS` (comma-separated hostnames) parsed in `packages/env`
- `validateHttpReqUrl` now accepts an `allowedHosts` parameter (symmetric with the existing `lookupHost` injection point); the env var is the default
- When the URL's hostname matches an entry, `validateIPAddress` is called with `{ allowPrivateRanges: true }`, which **only** skips the RFC1918 range checks (10/8, 172.16/12, 192.168/16)

## What the allowlist does NOT relax

Every other protection remains active even for allowlisted hosts:

- ✅ Link-local 169.254.0.0/16 — **the actual CVE vector** (AWS/GCP/Azure metadata)
- ✅ Loopback 127.0.0.0/8 and IPv6 ::1
- ✅ 0.0.0.0/8
- ✅ IPv6 link-local fe80::/10 and unique local fc00::/7
- ✅ Cloud metadata hostnames (\`metadata.google.internal\`, \`metadata.goog\`, \`metadata\`)
- ✅ \`localhost\` in production
- ✅ Decimal/hex/octal IP encoding bypasses
- ✅ IMDS bypass headers (\`X-aws-ec2-metadata-token*\`, \`Metadata-Flavor\`)

This is the deliberate design: **even if an attacker controls DNS for an allowlisted hostname and points it to 169.254.169.254, the link-local check still fires.** The allowlist intentionally narrows what's relaxed — corp LAN access, not metadata-service access.

## Test plan

- [x] All existing 53 SSRF tests still pass unchanged (default behavior preserved when env unset)
- [x] New \`describe\` block covering 14 cases:
  - RFC1918 hostnames pass when listed (10/8, 172.16/12, 192.168/16, direct IP literal)
  - Link-local **still blocks** for allowlisted host (DNS hijack defense)
  - Loopback **still blocks** for allowlisted host
  - Direct \`169.254.169.254\` IP literal **still blocks** even when listed
  - \`metadata.google.internal\` **still blocks** even when listed
  - Decimal-encoded metadata IP **still blocks** even when listed
  - Default behavior preserved when \`allowedHosts\` is undefined or empty
  - Hostname not in allowlist still blocks
  - Case-insensitive matching (URL parser normalizes hostname)
  - No subdomain wildcarding (exact match only)
- [x] \`bun test\` green: 63/63 in \`validateHttpReqUrl.test.ts\`
- [x] \`tsc --noEmit\` green for \`packages/lib\` and \`packages/env\`
- [x] Full \`nx affected\` test suite green (whatsapp, feature-flags, spaces, rich-text, root, emails, bot-engine, results, builder, lib — all passed)

## Use case

Currently, self-hosters facing this hit dead-ends: their internal corp DNS resolves to 10.x, the validator rejects it, and the only escape valves are (a) expose the API publicly (security regression — adds attack surface), (b) downgrade to ≤ v3.13.x (re-introduces the vulnerable code path), or (c) maintain a fork with the validator patched (fragile, breaks on every upgrade). An opt-in env var resolves this without weakening the core mitigation.

I'm opening a companion issue (#2475) explaining the use case in more detail and to gather feedback if a different design is preferred — happy to iterate.