### PR TITLE
fix the button position close in modal

### DIFF
--- a/packages/embeds/js/package.json
+++ b/packages/embeds/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/js",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Javascript library to display typebots on your website",
   "license": "FSL-1.1-ALv2",
   "type": "module",

--- a/packages/embeds/js/src/components/Modal.tsx
+++ b/packages/embeds/js/src/components/Modal.tsx
@@ -18,12 +18,12 @@ export const Modal = (props: Props) => (
   >
     {/* Ideally we would want to mount it on the parent's body but Tailwind classes are (potentially) not defined there. */}
     <Portal mount={useBotContainer()()}>
-      <Dialog.Backdrop class="absolute inset-0 bg-[rgba(0,0,0,0.8)] h-screen z-50" />
+      <Dialog.Backdrop class="absolute inset-0 z-50 h-full bg-[rgba(0,0,0,0.8)]" />
       <Dialog.Positioner class="absolute inset-0 z-50 flex items-center justify-center px-2">
         <Dialog.Content class="focus:outline-none">
           {props.children}
         </Dialog.Content>
-        <Dialog.CloseTrigger class="fixed top-4 right-4 z-50 rounded-md bg-[#202020] p-2 text-white">
+        <Dialog.CloseTrigger class="absolute top-4 right-4 z-50 rounded-md bg-[#202020] p-2 text-white">
           <CloseIcon class="w-6 h-6" />
         </Dialog.CloseTrigger>
       </Dialog.Positioner>

--- a/packages/embeds/react/package.json
+++ b/packages/embeds/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/react",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Convenient library to display typebots on your React app",
   "license": "FSL-1.1-ALv2",
   "type": "module",


### PR DESCRIPTION
When clicking on an image in the chat preview/runtime, the X button to close the modal appeared misplaced outside the correct area. This happened because the button was positioned with `position: fixed`, remaining stuck to the entire page viewport instead of being inside the modal/chat container.

before:
<img width="490" height="542" alt="image" src="https://github.com/user-attachments/assets/ed17cf29-6397-46c7-9779-01aec89c3c5b" />

after:
<img width="502" height="523" alt="image" src="https://github.com/user-attachments/assets/8ac64782-6af4-4417-bad1-971450e0f66c" />