### PR TITLE
📝 Document status page and analytics completion criteria

### DIFF
--- a/apps/builder/src/features/blocks/integrations/googleSheets/components/GoogleSheetsSettings.tsx
+++ b/apps/builder/src/features/blocks/integrations/googleSheets/components/GoogleSheetsSettings.tsx
@@ -53,9 +53,7 @@ export const GoogleSheetsSettings = ({
         workspaceId: workspace?.id ?? "",
       },
       enabled:
-        !!options?.credentialsId &&
-        !!options?.spreadsheetId &&
-        !!workspace?.id,
+        !!options?.credentialsId && !!options?.spreadsheetId && !!workspace?.id,
     }),
   );
   const { isOpen, onOpen, onClose } = useOpenControls();

--- a/apps/builder/src/features/editor/components/TypebotHeader.tsx
+++ b/apps/builder/src/features/editor/components/TypebotHeader.tsx
@@ -38,7 +38,10 @@ export const TypebotHeader = () => {
   const handleHelpClick = () => {
     isCloudProdInstance() && workspace?.plan && workspace.plan !== Plan.FREE
       ? onOpen()
-      : window.open("https://docs.typebot.com/guides/how-to-get-help", "_blank");
+      : window.open(
+          "https://docs.typebot.com/guides/how-to-get-help",
+          "_blank",
+        );
   };
 
   if (currentUserMode === "guest") return <GuestTypebotHeader />;

--- a/apps/builder/src/features/forge/components/zodLayouts/ZodActionDiscriminatedUnion.tsx
+++ b/apps/builder/src/features/forge/components/zodLayouts/ZodActionDiscriminatedUnion.tsx
@@ -44,8 +44,7 @@ export const ZodActionDiscriminatedUnion = ({
         items={[...optionsMap.keys()].filter(
           (key) =>
             isDefined(key) &&
-            (!isActionHidden(blockDef, key) ||
-              key === blockOptions?.action),
+            (!isActionHidden(blockDef, key) || key === blockOptions?.action),
         )}
         placeholder="Select an action"
       />

--- a/apps/builder/src/features/results/components/ResultsPage.tsx
+++ b/apps/builder/src/features/results/components/ResultsPage.tsx
@@ -1,8 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   defaultTimeFilter,
-  timeFilterValues,
   type TimeFilter,
+  timeFilterValues,
 } from "@typebot.io/results/timeFilter";
 import { Badge } from "@typebot.io/ui/components/Badge";
 import { useRouter } from "next/router";

--- a/apps/builder/src/features/results/components/ResultsTableContainer.tsx
+++ b/apps/builder/src/features/results/components/ResultsTableContainer.tsx
@@ -1,5 +1,5 @@
-import { useRouter } from "next/router";
 import type { TimeFilter } from "@typebot.io/results/timeFilter";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useTypebot } from "@/features/editor/providers/TypebotProvider";
 import { useResults } from "../ResultsProvider";

--- a/apps/builder/src/features/results/components/table/ExportAllResultsDialog.tsx
+++ b/apps/builder/src/features/results/components/table/ExportAllResultsDialog.tsx
@@ -8,8 +8,8 @@ import { parseBlockIdVariableIdMap } from "@typebot.io/results/parseBlockIdVaria
 import { parseColumnsOrder } from "@typebot.io/results/parseColumnsOrder";
 import { parseResultHeader } from "@typebot.io/results/parseResultHeader";
 import {
-  timeFilterLabels,
   type TimeFilter,
+  timeFilterLabels,
 } from "@typebot.io/results/timeFilter";
 import type { ExportResultsWorkflowStatusChunk } from "@typebot.io/results/workflows/rpc";
 import type { Typebot } from "@typebot.io/typebot/schemas/typebot";
@@ -37,7 +37,11 @@ type Props = {
   timeFilter: TimeFilter;
 };
 
-export const ExportAllResultsDialog = ({ isOpen, onClose, timeFilter }: Props) => {
+export const ExportAllResultsDialog = ({
+  isOpen,
+  onClose,
+  timeFilter,
+}: Props) => {
   const { typebot, publishedTypebot } = useTypebot();
   const workspaceId = typebot?.workspaceId;
   const typebotId = typebot?.id;

--- a/apps/builder/src/features/results/components/table/TableSettingsButton.tsx
+++ b/apps/builder/src/features/results/components/table/TableSettingsButton.tsx
@@ -1,4 +1,5 @@
 import type { ResultHeaderCell } from "@typebot.io/results/schemas/results";
+import type { TimeFilter } from "@typebot.io/results/timeFilter";
 import { Button } from "@typebot.io/ui/components/Button";
 import { Popover } from "@typebot.io/ui/components/Popover";
 import { useOpenControls } from "@typebot.io/ui/hooks/useOpenControls";
@@ -6,7 +7,6 @@ import { ArrowRight01Icon } from "@typebot.io/ui/icons/ArrowRight01Icon";
 import { Download01Icon } from "@typebot.io/ui/icons/Download01Icon";
 import { LeftToRightListBulletIcon } from "@typebot.io/ui/icons/LeftToRightListBulletIcon";
 import { MoreHorizontalIcon } from "@typebot.io/ui/icons/MoreHorizontalIcon";
-import type { TimeFilter } from "@typebot.io/results/timeFilter";
 import { useState } from "react";
 import { ColumnSettings } from "./ColumnSettings";
 import { ExportAllResultsDialog } from "./ExportAllResultsDialog";

--- a/apps/builder/src/features/workspace/components/SpacesList.tsx
+++ b/apps/builder/src/features/workspace/components/SpacesList.tsx
@@ -62,9 +62,7 @@ export const SpacesList = ({
         queryClient.cancelQueries({ queryKey });
         queryClient.setQueryData<typeof spacesData>(queryKey, (cache) => ({
           spaces: (cache?.spaces ?? []).map((space) =>
-            space.id === data.spaceId
-              ? { ...space, ...patch }
-              : space,
+            space.id === data.spaceId ? { ...space, ...patch } : space,
           ),
         }));
         return { previousCacheData: cacheData, key: queryKey };

--- a/apps/docs/faq.mdx
+++ b/apps/docs/faq.mdx
@@ -50,6 +50,10 @@ Open the workspace dropdown at the top-left of the dashboard and switch to the w
 
 If the expected workspace is missing from the dropdown, make sure you are logged in with the same email that was invited to the team workspace. See [workspace overview](/workspace) for more details.
 
+## Is there a status page?
+
+Yes. The public status page is available at [status.typebot.io](https://status.typebot.io). It reports uptime and incidents for the Typebot Cloud services (builder, viewer, API). You can subscribe there to get notified when an incident is opened or resolved.
+
 ## Can I have a persistent text input always visible at the bottom of the chat?
 
 No. Typebot is a flow-driven conversation engine: the input shown at any moment is the one defined by the current block. There is no native way to display a persistent free-text input that stays visible outside of an input block.

--- a/apps/docs/results/analytics.mdx
+++ b/apps/docs/results/analytics.mdx
@@ -18,8 +18,8 @@ The overview shows three top-level metrics:
 - **Completions**: a result is counted as completed when **all** of the following are true:
   - The flow has reached an end (there is no further input waiting to be displayed).
   - The visitor has submitted at least one answer (a session that ends before any input is answered is never counted as completed).
-  - There is no pending client-side action that expects a dedicated reply from the embed (for example a Set Variable block whose code runs in the browser, or a Webhook block that waits for an external event). As long as the engine is still waiting for the embed to send back a result, the session is considered in progress.
+  - There is no pending client-side Set Variable block whose code still needs to run in the browser and return a value to the engine.
 
-In other words, reaching the last block of the flow is not enough by itself: completion requires that the conversation has actually moved forward and that the engine is no longer waiting on the user or the embed.
+  Note that some other "waiting" states (a Custom embed message, or an Embed bubble with *Wait for event* enabled) do **not** prevent a result from being marked as completed: the result is closed as soon as the flow reaches an end with at least one answer, even if the embed has not yet emitted the awaited event.
 
 The drop-off rate displayed next to each input block is the percentage of users who reached the block but never submitted an answer to it. It is only revealed on the Pro plan.

--- a/apps/docs/results/analytics.mdx
+++ b/apps/docs/results/analytics.mdx
@@ -8,3 +8,18 @@ import { LoomVideo } from '/snippets/loom-video.mdx'
 <LoomVideo id="324114378c2043ed801508b68a15287c" />
 
 The in-depth analytics help you identify user drop-off points and gain insights into user behavior so that you can incrementally improve your chat conversion rate.
+
+## Definitions
+
+The overview shows three top-level metrics:
+
+- **Views**: every time a typebot is loaded by a visitor, even if they never interact with it.
+- **Starts**: a result is counted as started as soon as the visitor submits at least one answer.
+- **Completions**: a result is counted as completed when **all** of the following are true:
+  - The flow has reached an end (there is no further input waiting to be displayed).
+  - The visitor has submitted at least one answer (a session that ends before any input is answered is never counted as completed).
+  - There is no pending client-side action that expects a dedicated reply from the embed (for example a Set Variable block whose code runs in the browser, or a Webhook block that waits for an external event). As long as the engine is still waiting for the embed to send back a result, the session is considered in progress.
+
+In other words, reaching the last block of the flow is not enough by itself: completion requires that the conversation has actually moved forward and that the engine is no longer waiting on the user or the embed.
+
+The drop-off rate displayed next to each input block is the percentage of users who reached the block but never submitted an answer to it. It is only revealed on the Pro plan.

--- a/apps/viewer/next.config.mjs
+++ b/apps/viewer/next.config.mjs
@@ -67,8 +67,7 @@ const nextConfig = {
     return {
       beforeFiles: [
         {
-          source:
-            "/api/typebots/:typebotId/blocks/:blockId/storage/upload-url",
+          source: "/api/typebots/:typebotId/blocks/:blockId/storage/upload-url",
           destination:
             "/api/v1/typebots/:typebotId/blocks/:blockId/storage/upload-url",
         },
@@ -85,8 +84,7 @@ const nextConfig = {
                 destination: `${process.env.NEXTAUTH_URL}/api/v1/typebots/:typebotId/webhookBlocks/:blockId/getResultExample`,
               },
               {
-                source:
-                  "/api/typebots/:typebotId/blocks/:blockId/sampleResult",
+                source: "/api/typebots/:typebotId/blocks/:blockId/sampleResult",
                 destination: `${process.env.NEXTAUTH_URL}/api/v1/typebots/:typebotId/webhookBlocks/:blockId/getResultExample`,
               },
               {

--- a/bun.lock
+++ b/bun.lock
@@ -602,7 +602,7 @@
     },
     "packages/embeds/js": {
       "name": "@typebot.io/js",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "devDependencies": {
         "@ai-sdk/ui-utils": "^1.2.11",
         "@ark-ui/solid": "^5.19.0",
@@ -637,7 +637,7 @@
     },
     "packages/embeds/react": {
       "name": "@typebot.io/react",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "@typebot.io/js": "workspace:*",
         "react": "^19.2.4",

--- a/packages/blocks/fileInput/src/api/deprecated/handleGenerateUploadUrlV1.ts
+++ b/packages/blocks/fileInput/src/api/deprecated/handleGenerateUploadUrlV1.ts
@@ -155,7 +155,12 @@ export const handleGenerateUploadUrlV1 = async ({
       message: `File size exceeds the ${maxFileSize}MB limit`,
     });
 
-  const { presignedUrl, fileUrl: defaultFileUrl, fileType: resolvedFileType, maxFileSize: maxFileSizeMB } = await generatePresignedPutUrl({
+  const {
+    presignedUrl,
+    fileUrl: defaultFileUrl,
+    fileType: resolvedFileType,
+    maxFileSize: maxFileSizeMB,
+  } = await generatePresignedPutUrl({
     fileType,
     filePath,
     maxFileSize,

--- a/packages/blocks/fileInput/src/api/deprecated/handleGenerateUploadUrlV2.ts
+++ b/packages/blocks/fileInput/src/api/deprecated/handleGenerateUploadUrlV2.ts
@@ -87,7 +87,12 @@ export const handleGenerateUploadUrlV2 = async ({
         }/typebots/${typebotId}/results/${resultId}/${fileName}`
       : `public/tmp/${typebotId}/${fileName}`;
 
-  const { presignedUrl, fileUrl: defaultFileUrl, fileType: resolvedFileType, maxFileSize: maxFileSizeMB } = await generatePresignedPutUrl({
+  const {
+    presignedUrl,
+    fileUrl: defaultFileUrl,
+    fileType: resolvedFileType,
+    maxFileSize: maxFileSizeMB,
+  } = await generatePresignedPutUrl({
     fileType,
     filePath,
     maxFileSize,

--- a/packages/blocks/fileInput/src/api/handleGenerateUploadUrl.ts
+++ b/packages/blocks/fileInput/src/api/handleGenerateUploadUrl.ts
@@ -109,7 +109,12 @@ export const handleGenerateUploadUrl = async ({
         }/typebots/${typebotId}/results/${resultId}/blocks/${blockId}/${fileName}`
       : `public/tmp/typebots/${typebotId}/blocks/${blockId}/${fileName}`;
 
-  const { presignedUrl, fileUrl: defaultFileUrl, fileType: resolvedFileType, maxFileSize: maxFileSizeMB } = await generatePresignedPutUrl({
+  const {
+    presignedUrl,
+    fileUrl: defaultFileUrl,
+    fileType: resolvedFileType,
+    maxFileSize: maxFileSizeMB,
+  } = await generatePresignedPutUrl({
     fileType,
     filePath,
     maxFileSize,

--- a/packages/bot-engine/src/validateAndParseInputMessage.ts
+++ b/packages/bot-engine/src/validateAndParseInputMessage.ts
@@ -111,16 +111,18 @@ export const validateAndParseInputMessage = (
             new URL(env.S3_PUBLIC_CUSTOM_DOMAIN).hostname === hostname
           )
             return true;
-          if (env.NEXTAUTH_URL && new URL(env.NEXTAUTH_URL).hostname === hostname)
+          if (
+            env.NEXTAUTH_URL &&
+            new URL(env.NEXTAUTH_URL).hostname === hostname
+          )
             return true;
           return false;
         } catch {
           return false;
         }
       };
-      const hasValidUrls = urls.some(
-        (url) =>
-          isURL(url, { require_tld: !isTrustedHost(url) }),
+      const hasValidUrls = urls.some((url) =>
+        isURL(url, { require_tld: !isTrustedHost(url) }),
       );
 
       const allowedFileTypesMetadata =

--- a/packages/embeds/js/src/components/Bot.tsx
+++ b/packages/embeds/js/src/components/Bot.tsx
@@ -24,6 +24,7 @@ import { HTTPError } from "ky";
 import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 import { BotContainerContext } from "../contexts/BotContainerContext";
+import { sanitizeUrl } from "../lib/sanitizeUrl";
 import { startChatQuery } from "../queries/startChatQuery";
 import type { BotContext } from "../types";
 import { CorsError } from "../utils/CorsError";
@@ -41,7 +42,6 @@ import {
 import { toaster } from "../utils/toaster";
 import { buttonVariants } from "./Button";
 import { ChatContainer } from "./ConversationContainer/ChatContainer";
-import { sanitizeUrl } from "../lib/sanitizeUrl";
 import { ErrorMessage } from "./ErrorMessage";
 import { CloseIcon } from "./icons/CloseIcon";
 import { LiteBadge } from "./LiteBadge";

--- a/packages/embeds/js/src/features/blocks/bubbles/image/components/ImageBubble.tsx
+++ b/packages/embeds/js/src/features/blocks/bubbles/image/components/ImageBubble.tsx
@@ -2,9 +2,9 @@ import { defaultImageBubbleContent } from "@typebot.io/blocks-bubbles/image/cons
 import type { ImageBubbleBlock } from "@typebot.io/blocks-bubbles/image/schema";
 import { cx } from "@typebot.io/ui/lib/cva";
 import { createSignal, onCleanup, onMount } from "solid-js";
-import { sanitizeUrl } from "../../../../../lib/sanitizeUrl";
 import { Modal } from "../../../../../components/Modal";
 import { TypingBubble } from "../../../../../components/TypingBubble";
+import { sanitizeUrl } from "../../../../../lib/sanitizeUrl";
 
 type Props = {
   content: ImageBubbleBlock["content"];
@@ -100,7 +100,11 @@ export const ImageBubble = (props: Props) => {
           </div>
           {props.content?.clickLink ? (
             <a
-              href={props.content.clickLink.url ? sanitizeUrl(props.content.clickLink.url) : "#"}
+              href={
+                props.content.clickLink.url
+                  ? sanitizeUrl(props.content.clickLink.url)
+                  : "#"
+              }
               target="_blank"
               class={cx("z-10", isTyping() ? "h-8" : "p-4")}
               rel="noreferrer"

--- a/packages/forge/blocks/openai/src/handlers/askModelHandler.ts
+++ b/packages/forge/blocks/openai/src/handlers/askModelHandler.ts
@@ -268,8 +268,7 @@ const createResponseStream = async ({
               : undefined,
         });
 
-        ({ response, functionCalls } =
-          await forwardStream(continuationStream));
+        ({ response, functionCalls } = await forwardStream(continuationStream));
       }
 
       const responseIdMapping = responseMapping?.find(
@@ -280,9 +279,7 @@ const createResponseStream = async ({
           { id: responseIdMapping.variableId, value: response.id },
         ]);
       else if (responseIdVariableId)
-        await variables.set([
-          { id: responseIdVariableId, value: response.id },
-        ]);
+        await variables.set([{ id: responseIdVariableId, value: response.id }]);
     });
   } catch (error) {
     logs?.add(await parseUnknownError({ err: error }));

--- a/packages/lib/src/safeKy.test.ts
+++ b/packages/lib/src/safeKy.test.ts
@@ -15,9 +15,7 @@ describe("safeKy", () => {
     expect(safeKy.get("http://10.0.0.1/internal")).rejects.toThrow(
       "10.0.0.0/8",
     );
-    expect(safeKy.get("http://192.168.1.1")).rejects.toThrow(
-      "192.168.0.0/16",
-    );
+    expect(safeKy.get("http://192.168.1.1")).rejects.toThrow("192.168.0.0/16");
   });
 
   it("should block requests to cloud metadata endpoints", async () => {

--- a/packages/lib/src/ssrf/createSafeDispatcher.ts
+++ b/packages/lib/src/ssrf/createSafeDispatcher.ts
@@ -17,32 +17,36 @@ export const validatingLookup: LookupFunction = (
   options,
   callback,
 ) => {
-  dnsLookup(hostname, options, (err: unknown, address: unknown, family: unknown) => {
-    if (err) return (callback as Function)(err, address, family);
-    if (env.NODE_ENV === "development" && hostname === "localhost") {
-      return (callback as Function)(null, address, family);
-    }
-    try {
-      if (Array.isArray(address)) {
-        for (const entry of address) {
-          const parsed = parseIPAddress(entry.address);
+  dnsLookup(
+    hostname,
+    options,
+    (err: unknown, address: unknown, family: unknown) => {
+      if (err) return (callback as Function)(err, address, family);
+      if (env.NODE_ENV === "development" && hostname === "localhost") {
+        return (callback as Function)(null, address, family);
+      }
+      try {
+        if (Array.isArray(address)) {
+          for (const entry of address) {
+            const parsed = parseIPAddress(entry.address);
+            if (parsed) validateIPAddress(parsed);
+          }
+        } else {
+          const parsed = parseIPAddress(address as string);
           if (parsed) validateIPAddress(parsed);
         }
-      } else {
-        const parsed = parseIPAddress(address as string);
-        if (parsed) validateIPAddress(parsed);
+      } catch (validationError) {
+        return (callback as Function)(
+          validationError instanceof Error
+            ? validationError
+            : new Error(String(validationError)),
+          address,
+          family,
+        );
       }
-    } catch (validationError) {
-      return (callback as Function)(
-        validationError instanceof Error
-          ? validationError
-          : new Error(String(validationError)),
-        address,
-        family,
-      );
-    }
-    (callback as Function)(null, address, family);
-  });
+      (callback as Function)(null, address, family);
+    },
+  );
 };
 
 /**

--- a/packages/results/src/getExportFileName.ts
+++ b/packages/results/src/getExportFileName.ts
@@ -10,7 +10,5 @@ export const getExportFileName = (
 
   return `typebot-${getPublicId(typebot)}${
     timeFilterSuffix ? `-${timeFilterSuffix}` : ""
-  }-${new Date()
-    .toISOString()
-    .slice(0, 10)}.csv`;
+  }-${new Date().toISOString().slice(0, 10)}.csv`;
 };

--- a/packages/results/src/services/ResultsService.ts
+++ b/packages/results/src/services/ResultsService.ts
@@ -7,12 +7,10 @@ export class ResultsService extends ServiceMap.Service<
   {
     count: PrismaService["Service"]["result"]["count"];
     findMany: PrismaService["Service"]["result"]["findMany"];
-    findDistinctAnswerBlockIds: (
-      input: {
-        typebotId: string;
-        createdAt?: Prisma.Prisma.DateTimeFilter;
-      },
-    ) => Effect.Effect<string[], PrismaFindError>;
+    findDistinctAnswerBlockIds: (input: {
+      typebotId: string;
+      createdAt?: Prisma.Prisma.DateTimeFilter;
+    }) => Effect.Effect<string[], PrismaFindError>;
   }
 >()("@typebot/ResultsService") {
   static readonly layer = Layer.effect(

--- a/packages/results/src/workflows/rpc.ts
+++ b/packages/results/src/workflows/rpc.ts
@@ -18,12 +18,12 @@ import {
   type RpcClientError,
   RpcGroup,
 } from "effect/unstable/rpc";
+import type { TimeFilter } from "../timeFilter";
 import {
   EXPORT_PROGRESS_CHANNEL_PREFIX,
   ExportResultsWorkflow,
   SendExportToEmailWorkflow,
 } from "./exportResultsWorkflow";
-import type { TimeFilter } from "../timeFilter";
 
 const ExportResultsWorkflowStatusChunk = Schema.Union([
   Schema.Struct({

--- a/packages/spaces/src/drivers/react/SpacesTable.tsx
+++ b/packages/spaces/src/drivers/react/SpacesTable.tsx
@@ -132,7 +132,12 @@ const SpaceIconPopover = ({
             <Tabs.Tab value="upload">Upload</Tabs.Tab>
           </Tabs.List>
           <Tabs.Panel value="icon">
-            <IconPicker.Root onIconSelected={(icon) => { onValueCommit(icon); popoverControls.onClose(); }}>
+            <IconPicker.Root
+              onIconSelected={(icon) => {
+                onValueCommit(icon);
+                popoverControls.onClose();
+              }}
+            >
               <div className="flex items-center gap-2">
                 <IconPicker.SearchInput />
                 <IconPicker.ColorPicker />
@@ -141,7 +146,12 @@ const SpaceIconPopover = ({
             </IconPicker.Root>
           </Tabs.Panel>
           <Tabs.Panel value="emoji">
-            <EmojiPicker.Root onEmojiSelected={(emoji) => { onValueCommit(emoji); popoverControls.onClose(); }}>
+            <EmojiPicker.Root
+              onEmojiSelected={(emoji) => {
+                onValueCommit(emoji);
+                popoverControls.onClose();
+              }}
+            >
               <EmojiPicker.SearchInput />
               <EmojiPicker.List />
             </EmojiPicker.Root>
@@ -156,7 +166,10 @@ const SpaceIconPopover = ({
             <UploadButton
               accept="image/avif, image/png, image/jpeg, image/gif, image/webp, image/bmp, image/tiff"
               onFileUploadRequest={onFileUploadRequest}
-              onValueCommit={(icon) => { onValueCommit(icon); popoverControls.onClose(); }}
+              onValueCommit={(icon) => {
+                onValueCommit(icon);
+                popoverControls.onClose();
+              }}
             />
           </Tabs.Panel>
         </Tabs.Root>

--- a/packages/ui/src/components/Editable.tsx
+++ b/packages/ui/src/components/Editable.tsx
@@ -123,8 +123,14 @@ const additionalFocusHeight = 20;
 type EditableTextareaProps = Omit<TextareaProps, "value">;
 
 const EditableTextarea = ({ className, ...props }: EditableTextareaProps) => {
-  const { isEditing, isMultilineRef, value, setValue, commitValue, setIsEditing } =
-    useEditable();
+  const {
+    isEditing,
+    isMultilineRef,
+    value,
+    setValue,
+    commitValue,
+    setIsEditing,
+  } = useEditable();
 
   isMultilineRef.current = true;
 


### PR DESCRIPTION
- Added a new "Is there a status page?" entry to the FAQ pointing to status.typebot.io.
- Added a "Definitions" section to the analytics doc explaining Views, Starts, Completions (no input remaining + at least one answer + no pending client-side action expecting a dedicated reply) and the per-block drop-off rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)