### PR TITLE
🐛 Fix monthly cron tx timeout when deleting archived typebots

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -602,7 +602,7 @@
     },
     "packages/embeds/js": {
       "name": "@typebot.io/js",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "devDependencies": {
         "@ai-sdk/ui-utils": "^1.2.11",
         "@ark-ui/solid": "^5.19.0",
@@ -637,7 +637,7 @@
     },
     "packages/embeds/react": {
       "name": "@typebot.io/react",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "@typebot.io/js": "workspace:*",
         "react": "^19.2.4",

--- a/packages/scripts/src/helpers/cleanArchivedData.ts
+++ b/packages/scripts/src/helpers/cleanArchivedData.ts
@@ -119,10 +119,16 @@ const deleteResultsFromArchivedTypebotsIfAny = async (
         typebotId: archivedTypebot.id,
       },
     });
-    await prisma.result.deleteMany({
-      where: {
-        typebotId: archivedTypebot.id,
-      },
-    });
+    while (true) {
+      const batch = await prisma.$primary().result.findMany({
+        where: { typebotId: archivedTypebot.id },
+        select: { id: true },
+        take: 500,
+      });
+      if (batch.length === 0) break;
+      await prisma.result.deleteMany({
+        where: { id: { in: batch.map((r) => r.id) } },
+      });
+    }
   }
 };


### PR DESCRIPTION
- Delete archived results in batches of 500 before `prisma.typebot.deleteMany` to avoid Prisma cascade wrapping the entire delete in a single Vitess transaction that exceeds the max duration
- Use `prisma.$primary().result.findMany` for the batch lookup so read replica lag does not exit the loop while results still exist on primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)