### PR TITLE
Add Ask Model file search controls

### DIFF
--- a/apps/builder/src/features/forge/components/zodLayouts/ZodFieldLayout.tsx
+++ b/apps/builder/src/features/forge/components/zodLayouts/ZodFieldLayout.tsx
@@ -149,6 +149,9 @@ export const ZodFieldLayout = ({
             defaultValue={data ?? layout?.defaultValue}
             onValueChange={onDataChange}
             placeholder={layout?.placeholder}
+            min={layout?.min}
+            max={layout?.max}
+            step={layout?.step}
           />
           {layout?.helperText && (
             <Field.Description>
@@ -216,6 +219,9 @@ export const ZodFieldLayout = ({
             defaultValue={data ?? layout?.defaultValue}
             onValueChange={onDataChange}
             placeholder={layout?.placeholder}
+            min={layout?.min}
+            max={layout?.max}
+            step={layout?.step}
           />
           {layout?.helperText && (
             <Field.Description>

--- a/packages/forge/blocks/openai/src/actions/askModel.ts
+++ b/packages/forge/blocks/openai/src/actions/askModel.ts
@@ -53,6 +53,9 @@ export const askModel = createAction({
         moreInfoTooltip:
           "Maximum number of chunks to retrieve from the vector store. Applied only when Vector store IDs are set.",
         accordion: "Built-in tools",
+        min: 1,
+        max: 50,
+        step: 1,
       },
     }),
     fileSearchScoreThreshold: option.number.meta({

--- a/packages/forge/blocks/openai/src/actions/askModel.ts
+++ b/packages/forge/blocks/openai/src/actions/askModel.ts
@@ -47,6 +47,26 @@ export const askModel = createAction({
         accordion: "Built-in tools",
       },
     }),
+    fileSearchMaxNumResults: option.number.meta({
+      layout: {
+        label: "Number of retrieved chunks",
+        moreInfoTooltip:
+          "Maximum number of chunks to retrieve from the vector store. Applied only when Vector store IDs are set.",
+        accordion: "Built-in tools",
+      },
+    }),
+    fileSearchScoreThreshold: option.number.meta({
+      layout: {
+        label: "Score threshold",
+        moreInfoTooltip:
+          "Minimum relevance score between 0 and 1 for retrieved chunks. Applied only when Vector store IDs are set.",
+        accordion: "Built-in tools",
+        min: 0,
+        max: 1,
+        step: 0.1,
+        placeholder: "0.5",
+      },
+    }),
     webSearchEnabled: option.boolean.meta({
       layout: {
         label: "Web Search",

--- a/packages/forge/blocks/openai/src/handlers/askModelHandler.ts
+++ b/packages/forge/blocks/openai/src/handlers/askModelHandler.ts
@@ -138,8 +138,8 @@ const createResponseStream = async ({
     code?: string;
   }[];
   fileSearchVectorStoreIds?: string[];
-  fileSearchMaxNumResults?: number;
-  fileSearchScoreThreshold?: number;
+  fileSearchMaxNumResults?: number | string;
+  fileSearchScoreThreshold?: number | string;
   webSearchEnabled?: boolean;
   codeInterpreterEnabled?: boolean;
   temperature?: number;

--- a/packages/forge/blocks/openai/src/handlers/askModelHandler.ts
+++ b/packages/forge/blocks/openai/src/handlers/askModelHandler.ts
@@ -33,6 +33,8 @@ export const askModelHandler = createActionHandler(askModel, {
         functions: options.functions,
         fileSearchVectorStoreIds:
           options.fileSearchVectorStoreIds?.filter(isDefined),
+        fileSearchMaxNumResults: options.fileSearchMaxNumResults,
+        fileSearchScoreThreshold: options.fileSearchScoreThreshold,
         webSearchEnabled: options.webSearchEnabled,
         codeInterpreterEnabled: options.codeInterpreterEnabled,
         temperature: options.temperature,
@@ -60,6 +62,8 @@ export const askModelHandler = createActionHandler(askModel, {
       functions: options.functions,
       fileSearchVectorStoreIds:
         options.fileSearchVectorStoreIds?.filter(isDefined),
+      fileSearchMaxNumResults: options.fileSearchMaxNumResults,
+      fileSearchScoreThreshold: options.fileSearchScoreThreshold,
       webSearchEnabled: options.webSearchEnabled,
       codeInterpreterEnabled: options.codeInterpreterEnabled,
       temperature: options.temperature,
@@ -104,6 +108,8 @@ const createResponseStream = async ({
   responseIdVariableId,
   functions,
   fileSearchVectorStoreIds,
+  fileSearchMaxNumResults,
+  fileSearchScoreThreshold,
   webSearchEnabled,
   codeInterpreterEnabled,
   temperature,
@@ -132,6 +138,8 @@ const createResponseStream = async ({
     code?: string;
   }[];
   fileSearchVectorStoreIds?: string[];
+  fileSearchMaxNumResults?: number;
+  fileSearchScoreThreshold?: number;
   webSearchEnabled?: boolean;
   codeInterpreterEnabled?: boolean;
   temperature?: number;
@@ -171,6 +179,8 @@ const createResponseStream = async ({
   const tools = parseToolsForResponsesApi({
     functions,
     fileSearchVectorStoreIds,
+    fileSearchMaxNumResults,
+    fileSearchScoreThreshold,
     webSearchEnabled,
     codeInterpreterEnabled,
   });

--- a/packages/forge/blocks/openai/src/helpers/parseToolsForResponsesApi.ts
+++ b/packages/forge/blocks/openai/src/helpers/parseToolsForResponsesApi.ts
@@ -25,8 +25,8 @@ export const parseToolsForResponsesApi = ({
 }: {
   functions?: FunctionDef[];
   fileSearchVectorStoreIds?: string[];
-  fileSearchMaxNumResults?: number;
-  fileSearchScoreThreshold?: number;
+  fileSearchMaxNumResults?: number | string;
+  fileSearchScoreThreshold?: number | string;
   webSearchEnabled?: boolean;
   codeInterpreterEnabled?: boolean;
 }): Responses.Tool[] => {
@@ -65,26 +65,54 @@ export const parseToolsForResponsesApi = ({
 };
 
 const parseFileSearchMaxNumResults = (
-  fileSearchMaxNumResults?: number,
+  fileSearchMaxNumResults?: number | string,
 ): number | undefined => {
-  if (typeof fileSearchMaxNumResults !== "number") return;
-  if (Number.isNaN(fileSearchMaxNumResults)) return;
-  if (fileSearchMaxNumResults < 1 || fileSearchMaxNumResults > 50) return;
+  const parsedFileSearchMaxNumResults = parseNumberOption(
+    fileSearchMaxNumResults,
+  );
+  if (parsedFileSearchMaxNumResults == null) return;
+  if (!Number.isInteger(parsedFileSearchMaxNumResults)) return;
+  if (
+    parsedFileSearchMaxNumResults < 1 ||
+    parsedFileSearchMaxNumResults > 50
+  )
+    return;
 
-  return fileSearchMaxNumResults;
+  return parsedFileSearchMaxNumResults;
 };
 
 const parseFileSearchRankingOptions = (
-  fileSearchScoreThreshold?: number,
+  fileSearchScoreThreshold?: number | string,
 ): Responses.FileSearchTool.RankingOptions | undefined => {
-  if (typeof fileSearchScoreThreshold !== "number") return;
-  if (Number.isNaN(fileSearchScoreThreshold)) return;
-  if (fileSearchScoreThreshold < 0 || fileSearchScoreThreshold > 1) return;
+  const parsedFileSearchScoreThreshold = parseNumberOption(
+    fileSearchScoreThreshold,
+  );
+  if (parsedFileSearchScoreThreshold == null) return;
+  if (
+    parsedFileSearchScoreThreshold < 0 ||
+    parsedFileSearchScoreThreshold > 1
+  )
+    return;
 
   return {
     ranker: "auto",
-    score_threshold: fileSearchScoreThreshold,
+    score_threshold: parsedFileSearchScoreThreshold,
   };
+};
+
+const parseNumberOption = (
+  value?: number | string,
+): number | undefined => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== "string") return;
+
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) return;
+
+  const parsedValue = Number(trimmedValue);
+  if (!Number.isFinite(parsedValue)) return;
+
+  return parsedValue;
 };
 
 const parseParametersToJsonSchema = (

--- a/packages/forge/blocks/openai/src/helpers/parseToolsForResponsesApi.ts
+++ b/packages/forge/blocks/openai/src/helpers/parseToolsForResponsesApi.ts
@@ -18,11 +18,15 @@ type FunctionDef = {
 export const parseToolsForResponsesApi = ({
   functions,
   fileSearchVectorStoreIds,
+  fileSearchMaxNumResults,
+  fileSearchScoreThreshold,
   webSearchEnabled,
   codeInterpreterEnabled,
 }: {
   functions?: FunctionDef[];
   fileSearchVectorStoreIds?: string[];
+  fileSearchMaxNumResults?: number;
+  fileSearchScoreThreshold?: number;
   webSearchEnabled?: boolean;
   codeInterpreterEnabled?: boolean;
 }): Responses.Tool[] => {
@@ -31,7 +35,12 @@ export const parseToolsForResponsesApi = ({
   if (fileSearchVectorStoreIds) {
     const ids = fileSearchVectorStoreIds.filter(isNotEmpty);
     if (ids.length > 0)
-      tools.push({ type: "file_search", vector_store_ids: ids });
+      tools.push({
+        type: "file_search",
+        vector_store_ids: ids,
+        max_num_results: parseFileSearchMaxNumResults(fileSearchMaxNumResults),
+        ranking_options: parseFileSearchRankingOptions(fileSearchScoreThreshold),
+      });
   }
 
   if (webSearchEnabled) tools.push({ type: "web_search" });
@@ -53,6 +62,29 @@ export const parseToolsForResponsesApi = ({
   }
 
   return tools;
+};
+
+const parseFileSearchMaxNumResults = (
+  fileSearchMaxNumResults?: number,
+): number | undefined => {
+  if (typeof fileSearchMaxNumResults !== "number") return;
+  if (Number.isNaN(fileSearchMaxNumResults)) return;
+  if (fileSearchMaxNumResults < 1 || fileSearchMaxNumResults > 50) return;
+
+  return fileSearchMaxNumResults;
+};
+
+const parseFileSearchRankingOptions = (
+  fileSearchScoreThreshold?: number,
+): Responses.FileSearchTool.RankingOptions | undefined => {
+  if (typeof fileSearchScoreThreshold !== "number") return;
+  if (Number.isNaN(fileSearchScoreThreshold)) return;
+  if (fileSearchScoreThreshold < 0 || fileSearchScoreThreshold > 1) return;
+
+  return {
+    ranker: "auto",
+    score_threshold: fileSearchScoreThreshold,
+  };
 };
 
 const parseParametersToJsonSchema = (

--- a/packages/forge/core/src/zodLayout.ts
+++ b/packages/forge/core/src/zodLayout.ts
@@ -15,6 +15,9 @@ export type ZodLayoutMetadata<TDefaultValue = unknown> = {
   itemLabel?: string;
   isOrdered?: boolean;
   moreInfoTooltip?: string;
+  min?: number;
+  max?: number;
+  step?: number;
   isHidden?: boolean | ((currentObj: Record<string, unknown>) => boolean);
   isDebounceDisabled?: boolean;
   hiddenItems?: string[] | readonly string[];


### PR DESCRIPTION
Add chunk count and score threshold options to Ask Model, pass them to the OpenAI file_search tool, and constrain Score threshold to the 0-1 range in the builder.