### PR TITLE
🐛 Fix Google Sheets picker 401 by setting Cloud Project AppId

### DIFF
--- a/apps/builder/src/features/blocks/integrations/googleSheets/components/GoogleSpreadsheetPicker.tsx
+++ b/apps/builder/src/features/blocks/integrations/googleSheets/components/GoogleSpreadsheetPicker.tsx
@@ -76,7 +76,7 @@ export const GoogleSpreadsheetPicker = ({
     if (!accessToken) return;
     if (!isPickerInitialized) throw new Error("Google Picker not inited");
 
-    const picker = new window.google.picker.PickerBuilder()
+    const pickerBuilder = new window.google.picker.PickerBuilder()
       .addView(
         new window.google.picker.View(
           window.google.picker.ViewId.SPREADSHEETS,
@@ -84,8 +84,12 @@ export const GoogleSpreadsheetPicker = ({
       )
       .setOAuthToken(accessToken)
       .setDeveloperKey(env.NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY)
-      .setCallback(pickerCallback)
-      .build();
+      .setCallback(pickerCallback);
+
+    if (env.NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID)
+      pickerBuilder.setAppId(env.NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID);
+
+    const picker = pickerBuilder.build();
 
     picker.setVisible(true);
   };

--- a/apps/docs/self-hosting/configuration.mdx
+++ b/apps/docs/self-hosting/configuration.mdx
@@ -78,7 +78,9 @@ Used for sending email notifications and authentication
 
 3. Create an API key. This will be your `NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY`
 
-4. Create a OAuth client ID. This will be your `GOOGLE_SHEETS_CLIENT_ID` and `GOOGLE_SHEETS_CLIENT_SECRET`
+4. The Cloud Project number (visible in the Cloud Console dashboard) will be your `NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID`. It is required by the Google Picker when using the `drive.file` scope.
+
+5. Create a OAuth client ID. This will be your `GOOGLE_SHEETS_CLIENT_ID` and `GOOGLE_SHEETS_CLIENT_SECRET`
 
    Make sure to set the following scopes located in your OAuth Consent Screen: `spreadsheets`, `drive.file`
    https://developers.google.com/identity/protocols/oauth2/scopes
@@ -90,15 +92,16 @@ Used for sending email notifications and authentication
    - For development:
      - http://localhost:3000/api/credentials/google-sheets/callback
 
-5. To avoid having to always reconnect a Google Sheets credentials every 7 days, you need to promote your OAuth client to production (https://developers.google.com/nest/device-access/reference/errors/authorization#refresh_token_keeps_expiring)
+6. To avoid having to always reconnect a Google Sheets credentials every 7 days, you need to promote your OAuth client to production (https://developers.google.com/nest/device-access/reference/errors/authorization#refresh_token_keeps_expiring)
 
 </Accordion>
 
-| Parameter                         | Default | Description                                   |
-| --------------------------------- | ------- | --------------------------------------------- |
-| GOOGLE_SHEETS_CLIENT_ID           |         | The Client ID from the Google API Console     |
-| GOOGLE_SHEETS_CLIENT_SECRET       |         | The Client secret from the Google API Console |
-| NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY |         | The API Key from the Google API Console       |
+| Parameter                         | Default | Description                                       |
+| --------------------------------- | ------- | ------------------------------------------------- |
+| GOOGLE_SHEETS_CLIENT_ID           |         | The Client ID from the Google API Console         |
+| GOOGLE_SHEETS_CLIENT_SECRET       |         | The Client secret from the Google API Console     |
+| NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY |         | The API Key from the Google API Console           |
+| NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID  |         | The Cloud Project number from the Cloud Console   |
 
 ## Gmail
 

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -249,10 +249,14 @@ const googleSheetsEnv = {
   },
   client: {
     NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY: z.string().min(1).optional(),
+    NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID: z.string().min(1).optional(),
   },
   runtimeEnv: {
     NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY: getRuntimeVariable(
       "NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY",
+    ),
+    NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID: getRuntimeVariable(
+      "NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID",
     ),
   },
 };


### PR DESCRIPTION
- Call `PickerBuilder.setAppId()` with the Cloud Project number when building the Google Sheets picker (required by Google when the OAuth flow uses the `drive.file` scope, otherwise the picker iframe returns 401).
- Add new optional client env var `NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID` in `packages/env`.
- Document the new variable and setup step in `apps/docs/self-hosting/configuration.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)