### PR TITLE
🐛 Add trigger_onepick OAuth param for Google Sheets picker

### DIFF
--- a/apps/builder/src/features/blocks/integrations/googleSheets/api/handleGetConsentUrl.ts
+++ b/apps/builder/src/features/blocks/integrations/googleSheets/api/handleGetConsentUrl.ts
@@ -29,6 +29,7 @@ export const handleGetConsentUrl = async ({
     access_type: "offline",
     scope: googleSheetsScopes,
     prompt: "consent",
+    trigger_onepick: "true",
     state: Buffer.from(JSON.stringify(input)).toString("base64"),
   });
   return {


### PR DESCRIPTION
- Add `trigger_onepick=true` parameter to the Google Sheets OAuth consent URL, required by Google for the `drive.file` scope since the April 21, 2026 enforcement; without it the picker iframe returns 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)