### PR TITLE
⏪ Revert Google Sheets picker fixes (#2486, #2487)

### DIFF
--- a/apps/builder/src/features/blocks/integrations/googleSheets/api/handleGetConsentUrl.ts
+++ b/apps/builder/src/features/blocks/integrations/googleSheets/api/handleGetConsentUrl.ts
@@ -29,7 +29,6 @@ export const handleGetConsentUrl = async ({
     access_type: "offline",
     scope: googleSheetsScopes,
     prompt: "consent",
-    trigger_onepick: "true",
     state: Buffer.from(JSON.stringify(input)).toString("base64"),
   });
   return {

--- a/apps/builder/src/features/blocks/integrations/googleSheets/components/GoogleSpreadsheetPicker.tsx
+++ b/apps/builder/src/features/blocks/integrations/googleSheets/components/GoogleSpreadsheetPicker.tsx
@@ -76,7 +76,7 @@ export const GoogleSpreadsheetPicker = ({
     if (!accessToken) return;
     if (!isPickerInitialized) throw new Error("Google Picker not inited");
 
-    const pickerBuilder = new window.google.picker.PickerBuilder()
+    const picker = new window.google.picker.PickerBuilder()
       .addView(
         new window.google.picker.View(
           window.google.picker.ViewId.SPREADSHEETS,
@@ -84,12 +84,8 @@ export const GoogleSpreadsheetPicker = ({
       )
       .setOAuthToken(accessToken)
       .setDeveloperKey(env.NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY)
-      .setCallback(pickerCallback);
-
-    if (env.NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID)
-      pickerBuilder.setAppId(env.NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID);
-
-    const picker = pickerBuilder.build();
+      .setCallback(pickerCallback)
+      .build();
 
     picker.setVisible(true);
   };

--- a/apps/docs/self-hosting/configuration.mdx
+++ b/apps/docs/self-hosting/configuration.mdx
@@ -78,9 +78,7 @@ Used for sending email notifications and authentication
 
 3. Create an API key. This will be your `NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY`
 
-4. The Cloud Project number (visible in the Cloud Console dashboard) will be your `NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID`. It is required by the Google Picker when using the `drive.file` scope.
-
-5. Create a OAuth client ID. This will be your `GOOGLE_SHEETS_CLIENT_ID` and `GOOGLE_SHEETS_CLIENT_SECRET`
+4. Create a OAuth client ID. This will be your `GOOGLE_SHEETS_CLIENT_ID` and `GOOGLE_SHEETS_CLIENT_SECRET`
 
    Make sure to set the following scopes located in your OAuth Consent Screen: `spreadsheets`, `drive.file`
    https://developers.google.com/identity/protocols/oauth2/scopes
@@ -92,16 +90,15 @@ Used for sending email notifications and authentication
    - For development:
      - http://localhost:3000/api/credentials/google-sheets/callback
 
-6. To avoid having to always reconnect a Google Sheets credentials every 7 days, you need to promote your OAuth client to production (https://developers.google.com/nest/device-access/reference/errors/authorization#refresh_token_keeps_expiring)
+5. To avoid having to always reconnect a Google Sheets credentials every 7 days, you need to promote your OAuth client to production (https://developers.google.com/nest/device-access/reference/errors/authorization#refresh_token_keeps_expiring)
 
 </Accordion>
 
-| Parameter                         | Default | Description                                       |
-| --------------------------------- | ------- | ------------------------------------------------- |
-| GOOGLE_SHEETS_CLIENT_ID           |         | The Client ID from the Google API Console         |
-| GOOGLE_SHEETS_CLIENT_SECRET       |         | The Client secret from the Google API Console     |
-| NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY |         | The API Key from the Google API Console           |
-| NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID  |         | The Cloud Project number from the Cloud Console   |
+| Parameter                         | Default | Description                                   |
+| --------------------------------- | ------- | --------------------------------------------- |
+| GOOGLE_SHEETS_CLIENT_ID           |         | The Client ID from the Google API Console     |
+| GOOGLE_SHEETS_CLIENT_SECRET       |         | The Client secret from the Google API Console |
+| NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY |         | The API Key from the Google API Console       |
 
 ## Gmail
 

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -249,14 +249,10 @@ const googleSheetsEnv = {
   },
   client: {
     NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY: z.string().min(1).optional(),
-    NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID: z.string().min(1).optional(),
   },
   runtimeEnv: {
     NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY: getRuntimeVariable(
       "NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY",
-    ),
-    NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID: getRuntimeVariable(
-      "NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID",
     ),
   },
 };


### PR DESCRIPTION
- Revert #2487 (trigger_onepick OAuth param) and #2486 (setAppId + NEXT_PUBLIC_GOOGLE_SHEETS_APP_ID env var) which broke the Google Sheets picker in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)