### PR TITLE
🔧 Hash API tokens

### DIFF
--- a/apps/builder/src/features/user/server/handleCreateApiToken.ts
+++ b/apps/builder/src/features/user/server/handleCreateApiToken.ts
@@ -1,4 +1,4 @@
-import { generateId } from "@typebot.io/lib/utils";
+import { generateApiToken, hashApiToken } from "@typebot.io/lib/apiToken";
 import prisma from "@typebot.io/prisma";
 import type { User } from "@typebot.io/user/schemas";
 import { z } from "zod";
@@ -21,15 +21,16 @@ export const handleCreateApiToken = async ({
   context: { user: Pick<User, "id"> };
   input: z.infer<typeof createApiTokenInputSchema>;
 }) => {
+  const token = generateApiToken();
   const apiToken = await prisma.apiToken.create({
-    data: { name, ownerId: user.id, token: generateId(24) },
+    data: { name, ownerId: user.id, token: hashApiToken(token) },
   });
   return {
     apiToken: {
       id: apiToken.id,
       name: apiToken.name,
       createdAt: apiToken.createdAt,
-      token: apiToken.token,
+      token,
     },
   };
 };

--- a/apps/viewer/src/helpers/authenticateUser.ts
+++ b/apps/viewer/src/helpers/authenticateUser.ts
@@ -13,16 +13,21 @@ const authenticateByToken = async (
 ): Promise<Prisma.User | undefined> => {
   if (!apiToken) return;
   const hashedApiToken = hashApiToken(apiToken);
+  const hashedApiTokenRecord = await prisma.apiToken.findFirst({
+    where: { token: hashedApiToken },
+    include: { owner: true },
+  });
+  if (hashedApiTokenRecord) return hashedApiTokenRecord.owner as Prisma.User;
   const apiTokenRecord = await prisma.apiToken.findFirst({
-    where: { token: { in: [hashedApiToken, apiToken] } },
+    where: { token: apiToken },
     include: { owner: true },
   });
   if (!apiTokenRecord) return;
-  if (!isHashedApiToken(apiTokenRecord.token))
-    await prisma.apiToken.update({
-      where: { id: apiTokenRecord.id },
-      data: { token: hashedApiToken },
-    });
+  if (isHashedApiToken(apiTokenRecord.token)) return;
+  await prisma.apiToken.update({
+    where: { id: apiTokenRecord.id },
+    data: { token: hashedApiToken },
+  });
   return apiTokenRecord.owner as Prisma.User;
 };
 

--- a/apps/viewer/src/helpers/authenticateUser.ts
+++ b/apps/viewer/src/helpers/authenticateUser.ts
@@ -1,3 +1,4 @@
+import { hashApiToken, isHashedApiToken } from "@typebot.io/lib/apiToken";
 import prisma from "@typebot.io/prisma";
 import type { Prisma } from "@typebot.io/prisma/types";
 import type { NextApiRequest } from "next";
@@ -11,10 +12,19 @@ const authenticateByToken = async (
   apiToken?: string,
 ): Promise<Prisma.User | undefined> => {
   if (!apiToken) return;
-  return (await prisma.user.findFirst({
-    where: { apiTokens: { some: { token: apiToken } } },
-  })) as Prisma.User;
+  const hashedApiToken = hashApiToken(apiToken);
+  const apiTokenRecord = await prisma.apiToken.findFirst({
+    where: { token: { in: [hashedApiToken, apiToken] } },
+    include: { owner: true },
+  });
+  if (!apiTokenRecord) return;
+  if (!isHashedApiToken(apiTokenRecord.token))
+    await prisma.apiToken.update({
+      where: { id: apiTokenRecord.id },
+      data: { token: hashedApiToken },
+    });
+  return apiTokenRecord.owner as Prisma.User;
 };
 
 const extractBearerToken = (req: NextApiRequest) =>
-  req.headers.authorization?.slice(7);
+  req.headers.authorization?.match(/^Bearer\s+(.+)$/i)?.[1];

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "setup": ": \"${CONDUCTOR_ROOT_PATH:?Missing CONDUCTOR_ROOT_PATH}\" && : \"${CONDUCTOR_WORKSPACE_PATH:?Missing CONDUCTOR_WORKSPACE_PATH}\" && cd \"$CONDUCTOR_WORKSPACE_PATH\" && cp \"$CONDUCTOR_ROOT_PATH/.env\" . && cp \"$CONDUCTOR_ROOT_PATH/packages/scripts/.env.production\" ./packages/scripts && cp -r \"$CONDUCTOR_ROOT_PATH/apps/viewer/src/test/.auth\" apps/viewer/src/test/.auth && bun install && bunx nx build @typebot.io/react",
+    "run": "bun run dev"
+  },
+  "runScriptMode": "sequential"
+}

--- a/packages/auth/src/helpers/authenticateWithBearerToken.ts
+++ b/packages/auth/src/helpers/authenticateWithBearerToken.ts
@@ -8,16 +8,22 @@ export const authenticateWithBearerToken = async (
   const apiToken = extractBearerToken(req);
   if (!apiToken) return null;
   const hashedApiToken = hashApiToken(apiToken);
+  const hashedApiTokenRecord = await prisma.apiToken.findFirst({
+    where: { token: hashedApiToken },
+    include: { owner: true },
+  });
+  if (hashedApiTokenRecord)
+    return clientUserSchema.parse(hashedApiTokenRecord.owner);
   const apiTokenRecord = await prisma.apiToken.findFirst({
-    where: { token: { in: [hashedApiToken, apiToken] } },
+    where: { token: apiToken },
     include: { owner: true },
   });
   if (!apiTokenRecord) return null;
-  if (!isHashedApiToken(apiTokenRecord.token))
-    await prisma.apiToken.update({
-      where: { id: apiTokenRecord.id },
-      data: { token: hashedApiToken },
-    });
+  if (isHashedApiToken(apiTokenRecord.token)) return null;
+  await prisma.apiToken.update({
+    where: { id: apiTokenRecord.id },
+    data: { token: hashedApiToken },
+  });
   return clientUserSchema.parse(apiTokenRecord.owner);
 };
 

--- a/packages/auth/src/helpers/authenticateWithBearerToken.ts
+++ b/packages/auth/src/helpers/authenticateWithBearerToken.ts
@@ -1,3 +1,4 @@
+import { hashApiToken, isHashedApiToken } from "@typebot.io/lib/apiToken";
 import prisma from "@typebot.io/prisma";
 import { type ClientUser, clientUserSchema } from "@typebot.io/user/schemas";
 
@@ -6,12 +7,19 @@ export const authenticateWithBearerToken = async (
 ): Promise<ClientUser | null> => {
   const apiToken = extractBearerToken(req);
   if (!apiToken) return null;
-  const user = await prisma.user.findFirst({
-    where: { apiTokens: { some: { token: apiToken } } },
+  const hashedApiToken = hashApiToken(apiToken);
+  const apiTokenRecord = await prisma.apiToken.findFirst({
+    where: { token: { in: [hashedApiToken, apiToken] } },
+    include: { owner: true },
   });
-  if (!user) return null;
-  return clientUserSchema.parse(user);
+  if (!apiTokenRecord) return null;
+  if (!isHashedApiToken(apiTokenRecord.token))
+    await prisma.apiToken.update({
+      where: { id: apiTokenRecord.id },
+      data: { token: hashedApiToken },
+    });
+  return clientUserSchema.parse(apiTokenRecord.owner);
 };
 
 const extractBearerToken = (req: Request) =>
-  req.headers.get("authorization")?.slice(7);
+  req.headers.get("authorization")?.match(/^Bearer\s+(.+)$/i)?.[1];

--- a/packages/lib/src/apiToken.ts
+++ b/packages/lib/src/apiToken.ts
@@ -1,0 +1,9 @@
+import { createHash, randomBytes } from "node:crypto";
+
+export const generateApiToken = () => randomBytes(32).toString("base64url");
+
+export const hashApiToken = (apiToken: string) =>
+  createHash("sha256").update(apiToken).digest("hex");
+
+export const isHashedApiToken = (apiToken: string) =>
+  /^[0-9a-f]{64}$/.test(apiToken);

--- a/packages/playwright/src/databaseSetup.ts
+++ b/packages/playwright/src/databaseSetup.ts
@@ -1,6 +1,7 @@
 import { encrypt } from "@typebot.io/credentials/encrypt";
 import type { StripeCredentials } from "@typebot.io/credentials/schemas";
 import { env } from "@typebot.io/env";
+import { hashApiToken } from "@typebot.io/lib/apiToken";
 import prisma from "@typebot.io/prisma";
 import { Plan, WorkspaceRole } from "@typebot.io/prisma/enum";
 import { createTypebots } from "./databaseActions";
@@ -64,19 +65,19 @@ export const setupUsers = async () => {
       {
         ownerId: authenticatedUser.id,
         name: "Token 1",
-        token: apiToken,
+        token: hashApiToken(apiToken),
         createdAt: new Date(2022, 1, 1),
       },
       {
         ownerId: authenticatedUser.id,
         name: "Github",
-        token: "jirowjgrwGREHEgdrgithub",
+        token: hashApiToken("jirowjgrwGREHEgdrgithub"),
         createdAt: new Date(2022, 1, 2),
       },
       {
         ownerId: authenticatedUser.id,
         name: "N8n",
-        token: "jirowjgrwGREHrgwhrwn8n",
+        token: hashApiToken("jirowjgrwGREHrgwhrwn8n"),
         createdAt: new Date(2022, 1, 3),
       },
     ],


### PR DESCRIPTION
- Store newly created API tokens as SHA-256 hashes while returning the raw token once.
- Authenticate bearer tokens against both hashed and legacy plaintext records, then lazily hash legacy records on successful use.
- Seed Playwright API tokens as hashes.
- Add Conductor setup and run scripts for local workspaces.