### PR TITLE
🐛 Sanitize CSV exports against formula injection

### DIFF
--- a/apps/builder/src/features/results/components/table/ExportAllResultsDialog.tsx
+++ b/apps/builder/src/features/results/components/table/ExportAllResultsDialog.tsx
@@ -7,6 +7,7 @@ import { getExportFileName } from "@typebot.io/results/getExportFileName";
 import { parseBlockIdVariableIdMap } from "@typebot.io/results/parseBlockIdVariableIdMap";
 import { parseColumnsOrder } from "@typebot.io/results/parseColumnsOrder";
 import { parseResultHeader } from "@typebot.io/results/parseResultHeader";
+import { sanitizeCsvCell } from "@typebot.io/results/sanitizeCsvCell";
 import {
   type TimeFilter,
   timeFilterLabels,
@@ -163,8 +164,11 @@ export const ExportAllResultsDialog = ({
       headerIds?.forEach((headerId) => {
         const headerLabel = resultHeader.find(byId(headerId))?.label;
         if (!headerLabel) return;
-        const newKey = parseUniqueKey(headerLabel, Object.keys(newObject));
-        newObject[newKey] = data[headerId]?.plainText;
+        const newKey = parseUniqueKey(
+          sanitizeCsvCell(headerLabel),
+          Object.keys(newObject),
+        );
+        newObject[newKey] = sanitizeCsvCell(data[headerId]?.plainText);
       });
       return newObject;
     });

--- a/apps/builder/src/features/results/components/table/SelectionToolbar.tsx
+++ b/apps/builder/src/features/results/components/table/SelectionToolbar.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from "@tolgee/react";
 import { parseUniqueKey } from "@typebot.io/lib/parseUniqueKey";
 import { byId } from "@typebot.io/lib/utils";
 import { parseColumnsOrder } from "@typebot.io/results/parseColumnsOrder";
+import { sanitizeCsvCell } from "@typebot.io/results/sanitizeCsvCell";
 import { AlertDialog } from "@typebot.io/ui/components/AlertDialog";
 import { Button } from "@typebot.io/ui/components/Button";
 import { useOpenControls } from "@typebot.io/ui/hooks/useOpenControls";
@@ -107,8 +108,11 @@ export const SelectionToolbar = ({
       headerIds?.forEach((headerId) => {
         const headerLabel = resultHeader.find(byId(headerId))?.label;
         if (!headerLabel) return;
-        const newKey = parseUniqueKey(headerLabel, Object.keys(newObject));
-        newObject[newKey] = data[headerId]?.plainText;
+        const newKey = parseUniqueKey(
+          sanitizeCsvCell(headerLabel),
+          Object.keys(newObject),
+        );
+        newObject[newKey] = sanitizeCsvCell(data[headerId]?.plainText);
       });
       return newObject;
     });

--- a/packages/results/src/sanitizeCsvCell.ts
+++ b/packages/results/src/sanitizeCsvCell.ts
@@ -1,0 +1,11 @@
+const formulaPrefixes = ["=", "+", "-", "@", "\t", "\r"];
+
+export const sanitizeCsvCell = <T extends string | undefined | null>(
+  value: T,
+): T extends string ? string : T => {
+  if (typeof value !== "string" || value.length === 0)
+    return value as T extends string ? string : T;
+  return (
+    formulaPrefixes.includes(value[0]!) ? `'${value}` : value
+  ) as T extends string ? string : T;
+};

--- a/packages/results/src/streamAllResultsToCsv.ts
+++ b/packages/results/src/streamAllResultsToCsv.ts
@@ -12,6 +12,7 @@ import { convertResultsToTableData } from "./convertResultsToTableData";
 import { parseBlockIdVariableIdMap } from "./parseBlockIdVariableIdMap";
 import { parseColumnsOrder } from "./parseColumnsOrder";
 import { parseResultHeader } from "./parseResultHeader";
+import { sanitizeCsvCell } from "./sanitizeCsvCell";
 import { resultWithAnswersSchema } from "./schemas/results";
 
 const BATCH_SIZE = 500;
@@ -106,7 +107,7 @@ export const streamAllResultsToCsv = async (
 
   const csvHeaders = headerIds.map((headerId) => {
     const headerLabel = resultHeader.find(byId(headerId))?.label;
-    return headerLabel ?? headerId;
+    return sanitizeCsvCell(headerLabel ?? headerId);
   });
 
   const csvStream = writableStream ?? createWriteStream(writeStreamPath!);
@@ -180,7 +181,7 @@ export const streamAllResultsToCsv = async (
             const headerLabel = resultHeader.find(byId(headerId))?.label;
             if (!headerLabel) return;
             const newKey = parseUniqueKey(headerLabel, Object.keys(newObject));
-            newObject[newKey] = data[headerId]?.plainText;
+            newObject[newKey] = sanitizeCsvCell(data[headerId]?.plainText);
           });
           return newObject;
         });

--- a/packages/results/src/streamAllResultsToCsvV2.ts
+++ b/packages/results/src/streamAllResultsToCsvV2.ts
@@ -12,6 +12,7 @@ import { convertResultsToTableData } from "./convertResultsToTableData";
 import { parseBlockIdVariableIdMap } from "./parseBlockIdVariableIdMap";
 import { parseColumnsOrder } from "./parseColumnsOrder";
 import { parseResultHeader } from "./parseResultHeader";
+import { sanitizeCsvCell } from "./sanitizeCsvCell";
 import { resultWithAnswersSchema } from "./schemas/results";
 import { ResultsService } from "./services/ResultsService";
 import {
@@ -111,7 +112,7 @@ export const streamResultsToCsvV2 = Effect.fn("streamResultsToCsvV2")(
 
     const csvHeaders = headerIds.map((headerId) => {
       const headerLabel = resultHeader.find(byId(headerId))?.label;
-      return headerLabel ?? headerId;
+      return sanitizeCsvCell(headerLabel ?? headerId);
     });
 
     const totalResultsToExport = yield* resultsService.count({
@@ -202,7 +203,9 @@ export const streamResultsToCsvV2 = Effect.fn("streamResultsToCsvV2")(
                     headerLabel,
                     Object.keys(newObject),
                   );
-                  newObject[newKey] = data[headerId]?.plainText;
+                  newObject[newKey] = sanitizeCsvCell(
+                    data[headerId]?.plainText,
+                  );
                 });
                 return newObject;
               },


### PR DESCRIPTION
- Added `sanitizeCsvCell` helper that escapes values starting with `=`, `+`, `-`, `@`, `\t`, or `\r` with a leading apostrophe to prevent CSV/formula injection (CWE-1236) in spreadsheet apps.
- Applied sanitization to both server-side CSV streams (`streamAllResultsToCsv`, `streamAllResultsToCsvV2`) for cells and headers.
- Applied sanitization to client-side exports (`SelectionToolbar`, `ExportAllResultsDialog`) for cells and header keys.