### PR TITLE
🐛 Prevent cross-typebot webhook resume IDOR

### DIFF
--- a/packages/blocks/webhook/src/api/handleExecuteWebhook.ts
+++ b/packages/blocks/webhook/src/api/handleExecuteWebhook.ts
@@ -88,9 +88,10 @@ export const handleExecuteWebhook = async ({
       message: "Webhook block not found",
     });
 
-  const result = await prisma.result.findUnique({
+  const result = await prisma.result.findFirst({
     where: {
       id: resultId,
+      typebotId,
     },
     select: {
       lastChatSessionId: true,


### PR DESCRIPTION
- Scope `result` lookup in `handleExecuteWebhook` to the authorized `typebotId`, closing a cross-tenant IDOR where a caller with read access to one typebot could resume another typebot's waiting webhook session by supplying a foreign `resultId`.