### PR TITLE
🔧 Add WhatsApp status forward URL update script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ content-collections.d.ts
 **/next-env.d.ts
 
 .pi
+
+.agents/skills/typebot-prod-db
+.claude/skills/typebot-prod-db

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -25,6 +25,7 @@
     "redeemCoupon": "SKIP_ENV_CHECK=true dotenv -e ./.env.production -- tsx --tsconfig ./tsconfig.json src/redeemCoupon.ts",
     "exportResults": "SKIP_ENV_CHECK=true dotenv -e ./.env.production -- tsx --tsconfig ./tsconfig.json src/exportResults.ts",
     "updateUserEmail": "SKIP_ENV_CHECK=true dotenv -e ./.env.production -- tsx --tsconfig ./tsconfig.json src/updateUserEmail.ts",
+    "updateWhatsAppStatusForwardUrl": "SKIP_ENV_CHECK=true dotenv -e ./.env.production -- tsx --tsconfig ./tsconfig.json src/updateWhatsAppStatusForwardUrl.ts",
     "inspectChatSession": "tsx --tsconfig ./tsconfig.json src/inspectChatSession.ts",
     "searchResult": "SKIP_ENV_CHECK=true dotenv -e ./.env.production -- tsx --tsconfig ./tsconfig.json src/searchResult.ts",
     "inspectResult": "SKIP_ENV_CHECK=true dotenv -e ./.env.production -- tsx --tsconfig ./tsconfig.json src/inspectResult.ts",

--- a/packages/scripts/src/updateWhatsAppStatusForwardUrl.ts
+++ b/packages/scripts/src/updateWhatsAppStatusForwardUrl.ts
@@ -1,0 +1,87 @@
+import * as p from "@clack/prompts";
+import prisma from "@typebot.io/prisma";
+import { settingsSchema } from "@typebot.io/settings/schemas";
+import { promptAndSetEnvironment } from "./utils";
+
+const updateWhatsAppStatusForwardUrl = async () => {
+  await promptAndSetEnvironment("production");
+
+  const typebotId = await p.text({ message: "Typebot ID?" });
+  if (!typebotId || p.isCancel(typebotId)) process.exit();
+
+  const newUrl = await p.text({
+    message: "New forward URL?",
+    validate: (value) => {
+      try {
+        new URL(value);
+      } catch {
+        return "Invalid URL";
+      }
+    },
+  });
+  if (!newUrl || p.isCancel(newUrl)) process.exit();
+
+  const typebot = await prisma.typebot.findUnique({
+    where: { id: typebotId },
+    select: {
+      id: true,
+      name: true,
+      settings: true,
+      publishedTypebot: { select: { id: true, settings: true } },
+    },
+  });
+
+  if (!typebot) {
+    console.log("Typebot not found");
+    return;
+  }
+
+  const draftSettings = settingsSchema.parse(typebot.settings);
+  const publishedSettings = typebot.publishedTypebot
+    ? settingsSchema.parse(typebot.publishedTypebot.settings)
+    : null;
+
+  console.log({
+    name: typebot.name,
+    currentDraftUrl:
+      draftSettings.whatsApp?.errorAndMarketingStatusWebhookForwardUrl,
+    currentPublishedUrl:
+      publishedSettings?.whatsApp?.errorAndMarketingStatusWebhookForwardUrl,
+    newUrl,
+  });
+
+  const shouldProceed = await p.confirm({ message: "Apply update?" });
+  if (!shouldProceed || p.isCancel(shouldProceed)) process.exit();
+
+  await prisma.typebot.update({
+    where: { id: typebotId },
+    data: {
+      settings: {
+        ...draftSettings,
+        whatsApp: {
+          ...draftSettings.whatsApp,
+          errorAndMarketingStatusWebhookForwardUrl: newUrl,
+        },
+      },
+    },
+  });
+
+  if (publishedSettings && typebot.publishedTypebot) {
+    await prisma.publicTypebot.update({
+      where: { id: typebot.publishedTypebot.id },
+      data: {
+        settings: {
+          ...publishedSettings,
+          whatsApp: {
+            ...publishedSettings.whatsApp,
+            errorAndMarketingStatusWebhookForwardUrl: newUrl,
+          },
+        },
+      },
+    });
+  }
+
+  console.log("Done.");
+};
+
+updateWhatsAppStatusForwardUrl();

--- a/packages/scripts/tsconfig.lib.json
+++ b/packages/scripts/tsconfig.lib.json
@@ -8,6 +8,9 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
+      "path": "../settings/tsconfig.lib.json"
+    },
+    {
       "path": "../embeds/react/tsconfig.lib.json"
     },
     {


### PR DESCRIPTION
- Add a production script to update the WhatsApp status webhook forward URL on draft and published typebot settings.
- Register the script in `@typebot.io/scripts` and add the settings project reference needed for typechecking.
- Ignore local `typebot-prod-db` skill folders for agent tooling.