### PR TITLE
🐛 Fix PartyKit deploy workflow gate

### DIFF
--- a/.github/workflows/deploy-partykit.yml
+++ b/.github/workflows/deploy-partykit.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "packages/partykit/**"
 
 permissions:
   contents: read
@@ -26,29 +28,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: "package.json"
-      # https://github.com/vercel/turborepo/issues/6348
-      - name: Run Turbo ignore
-        id: check_changes
-        run: |
-          echo "Running script..."
-
-          set +e
-          bunx turbo-ignore @typebot.io/partykit
-          exit_code=$?
-          set -e
-
-          echo "Exit code: $exit_code"
-
-          if [ $exit_code -eq 0 ]; then
-            echo "hasClientApiHostChanged=0" >> $GITHUB_OUTPUT
-          else
-            echo "hasClientApiHostChanged=1" >> $GITHUB_OUTPUT
-          fi
       - run: bun install
-        if: steps.check_changes.outputs.hasClientApiHostChanged == '1'
-      - run: bunx partykit deploy --domain ${PARTYKIT_DOMAIN}
-        if: steps.check_changes.outputs.hasClientApiHostChanged == '1'
-        working-directory: ./packages/partykit
+      - run: bunx nx deploy @typebot.io/partykit -- --domain ${PARTYKIT_DOMAIN}
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN  }}


### PR DESCRIPTION
- Limit the PartyKit deploy workflow to pushes that change `packages/partykit`.
- Remove the broken `turbo-ignore` gate and deploy through the Nx target.