### PR TITLE
fix: include cookies in HTTP request executed from client

### DIFF
--- a/packages/embeds/js/src/features/blocks/integrations/httpRequest/executeHttpRequest.ts
+++ b/packages/embeds/js/src/features/blocks/integrations/httpRequest/executeHttpRequest.ts
@@ -10,7 +10,7 @@ export const executeHttpRequest = async (
       method,
       body: method !== "GET" && body ? JSON.stringify(body) : undefined,
       headers,
-      credentials: isPreview ? "omit" : undefined,
+      credentials: isPreview ? "omit" : "include",
     });
     const statusCode = response.status;
     const data = await response.json();


### PR DESCRIPTION
This change adds `credentials: include` to the fetch call when executing HTTP requests from the client (non-preview mode). This allows cookies to be properly sent and stored by the browser when making HTTP requests.

Fixes #1868