### PR TITLE
🔧 Prepare v3.17.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+<a name="3.17.1"></a>
+## 3.17.1 (2026-05-22)
+
+### Fixed
+
+- 🐛 Fix upload proxy public URL (#2508) [[9d6708b](https://github.com/baptisteArno/typebot.io/commit/9d6708bbeebc97dc9d933650ad4a8de725179b4f)]
+
+### Content
+
+- 📝 Update manual deploy docs for Nx (#2507) [[5f01ecf](https://github.com/baptisteArno/typebot.io/commit/5f01ecff64667f9ded0c88bdb835158fe4bf3b2e)]
+
 <a name="3.17.0"></a>
 ## 3.17.0 (2026-05-21)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/root",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "private": true,
   "workspaces": [
     "packages/*",


### PR DESCRIPTION
- Bump root package version to 3.17.1.
- Add the 3.17.1 changelog section for the upload proxy fix and manual deploy docs update.