### PR TITLE
🔧 Copy skills during Conductor setup

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": ": \"${CONDUCTOR_ROOT_PATH:?Missing CONDUCTOR_ROOT_PATH}\" && : \"${CONDUCTOR_WORKSPACE_PATH:?Missing CONDUCTOR_WORKSPACE_PATH}\" && cd \"$CONDUCTOR_WORKSPACE_PATH\" && cp \"$CONDUCTOR_ROOT_PATH/.env\" . && cp \"$CONDUCTOR_ROOT_PATH/packages/scripts/.env.production\" ./packages/scripts && cp -r \"$CONDUCTOR_ROOT_PATH/apps/viewer/src/test/.auth\" apps/viewer/src/test/.auth && bun install && bunx nx build @typebot.io/react",
+    "setup": ": \"${CONDUCTOR_ROOT_PATH:?Missing CONDUCTOR_ROOT_PATH}\" && : \"${CONDUCTOR_WORKSPACE_PATH:?Missing CONDUCTOR_WORKSPACE_PATH}\" && cd \"$CONDUCTOR_WORKSPACE_PATH\" && cp \"$CONDUCTOR_ROOT_PATH/.env\" . && cp \"$CONDUCTOR_ROOT_PATH/packages/scripts/.env.production\" ./packages/scripts && cp -r \"$CONDUCTOR_ROOT_PATH/apps/viewer/src/test/.auth\" apps/viewer/src/test/.auth && mkdir -p .agents/skills .claude/skills && cp -R \"$CONDUCTOR_ROOT_PATH/.agents/skills/.\" .agents/skills && cp -R \"$CONDUCTOR_ROOT_PATH/.claude/skills/.\" .claude/skills && bun install && bunx nx build @typebot.io/react",
     "run": "bun run dev"
   },
   "runScriptMode": "sequential"


### PR DESCRIPTION
- Copy .agents/skills from the repository root during Conductor workspace setup.
- Copy .claude/skills from the repository root during Conductor workspace setup.
- Ensure both skill directories exist before copying ignored skill files.