### PR TITLE
📝 Recommend Neon in self-hosting docs

### DIFF
--- a/apps/docs/self-hosting/deploy/manual.mdx
+++ b/apps/docs/self-hosting/deploy/manual.mdx
@@ -21,7 +21,7 @@ title: Manual
 
 ## Requirements
 
-- A PostgresDB database hosted somewhere. [Supabase](https://supabase.com/) offer great free options. But you can also setup your own database on your server.
+- A Postgres database hosted somewhere. For production, [Neon](https://typebot.com/neon) is my provider of choice. This is not an affiliate link; it is simply the provider I use and recommend for a production database. You can also use any compatible Postgres provider or host Postgres yourself.
 - A server with Node.js 24.x, [bun](https://bun.sh/docs/installation), Nginx, and PM2 installed.
 - Experience in deploying Next.js applications with PM2. Check out [this guide](https://www.coderrocketfuel.com/article/how-to-deploy-a-next-js-website-to-a-digital-ocean-server/) for more information.
 

--- a/apps/docs/self-hosting/deploy/vercel.mdx
+++ b/apps/docs/self-hosting/deploy/vercel.mdx
@@ -15,7 +15,7 @@ title: Vercel
 
 ## Requirements
 
-You need a PostgresDB database hosted somewhere. [Supabase](https://supabase.com/) and [Heroku](https://www.heroku.com/) offer great free options.
+You need a Postgres database hosted somewhere. For production, [Neon](https://typebot.com/neon) is my provider of choice. This is not an affiliate link; it is simply the provider I use and recommend for a production database. You can also use any compatible Postgres provider.
 
 ## Getting Started
 

--- a/apps/docs/self-hosting/get-started.mdx
+++ b/apps/docs/self-hosting/get-started.mdx
@@ -26,6 +26,10 @@ Typebot is fair source and can be self-hosted on your own server. This guide wil
 | Releases | Instant access to new features | New releases are published each beginning of the month. |
 | Support | Premium direct support available on STARTER and PRO plans | We don't offer support for your self-hosting issues that are not related to Typebot. You may reach out to the [Discord community](https://typebot.io/discord) for support. |
 
+## Database recommendation
+
+Typebot needs a Postgres database. For production, [Neon](https://typebot.com/neon) is my database provider of choice. This is not an affiliate link; it is simply the provider I use and recommend for a production database. You can still use any compatible Postgres provider or host Postgres yourself.
+
 ## License requirements
 
 Typebot is available under the Functional Source License (FSL).

--- a/biome.json
+++ b/biome.json
@@ -16,6 +16,7 @@
       "!**/iconNames.ts",
       "!**/.last-run.json",
       "!**/test/assets/**/*.json",
+      "!.context",
       "!.opencode",
       "!.codex",
       "!.cursor",


### PR DESCRIPTION
- Add Neon as the recommended production Postgres provider in self-hosting docs, with a non-affiliate note.
- Link database recommendations to `https://typebot.com/neon`.
- Ignore `.context` files from Biome checks.