### PR TITLE
📝 Move database recommendation in self-hosting docs

### DIFF
--- a/apps/docs/self-hosting/get-started.mdx
+++ b/apps/docs/self-hosting/get-started.mdx
@@ -26,10 +26,6 @@ Typebot is fair source and can be self-hosted on your own server. This guide wil
 | Releases | Instant access to new features | New releases are published each beginning of the month. |
 | Support | Premium direct support available on STARTER and PRO plans | We don't offer support for your self-hosting issues that are not related to Typebot. You may reach out to the [Discord community](https://typebot.io/discord) for support. |
 
-## Database recommendation
-
-Typebot needs a Postgres database. For production, [Neon](https://typebot.com/neon) is my database provider of choice. This is not an affiliate link; it is simply the provider I use and recommend for a production database. You can still use any compatible Postgres provider or host Postgres yourself.
-
 ## License requirements
 
 Typebot is available under the Functional Source License (FSL).
@@ -96,6 +92,10 @@ Typebot is composed of 2 Next.js applications you need to deploy:
 
 - the builder, where you build your typebots
 - the viewer, where your user answer the typebot
+
+### Database recommendation
+
+Typebot needs a Postgres database. For production, [Neon](https://typebot.com/neon) is my database provider of choice. This is not an affiliate link; it is simply the provider I use and recommend for a production database. You can still use any compatible Postgres provider or host Postgres yourself.
 
 I've written guides on how to deploy Typebot using:
 


### PR DESCRIPTION
- Moved the database recommendation under the "Ready to self-host?" section.