### PR TITLE
🐛 Fix OpenAI audio transcription uploads

### DIFF
--- a/packages/forge/blocks/openai/package.json
+++ b/packages/forge/blocks/openai/package.json
@@ -26,6 +26,9 @@
     },
     "./package.json": "./package.json"
   },
+  "scripts": {
+    "test": "bun test"
+  },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.106",
     "@sentry/nextjs": "^10.43.0",

--- a/packages/forge/blocks/openai/src/handlers/createTranscriptionHandler.test.ts
+++ b/packages/forge/blocks/openai/src/handlers/createTranscriptionHandler.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { createOpenAITranscriptionFileName } from "./createTranscriptionHandler";
+
+describe("createOpenAITranscriptionFileName", () => {
+  it("normalizes audio/webm to an OpenAI-supported WebM filename", () => {
+    expect(
+      createOpenAITranscriptionFileName({
+        contentType: "audio/webm",
+        url: "https://files.typebot.io/audio.weba",
+      }),
+    ).toBe("audio.webm");
+  });
+
+  it("normalizes existing weba URLs to WebM", () => {
+    expect(
+      createOpenAITranscriptionFileName({
+        url: "https://files.typebot.io/audio.weba",
+      }),
+    ).toBe("audio.webm");
+  });
+
+  it("keeps OpenAI-supported URL extensions", () => {
+    expect(
+      createOpenAITranscriptionFileName({
+        contentType: "application/octet-stream",
+        url: "https://files.typebot.io/audio.mp3?token=123",
+      }),
+    ).toBe("audio.mp3");
+  });
+
+  it("falls back to WebM when neither URL nor content type is useful", () => {
+    expect(
+      createOpenAITranscriptionFileName({
+        contentType: "application/octet-stream",
+        url: "https://files.typebot.io/audio",
+      }),
+    ).toBe("audio.webm");
+  });
+});

--- a/packages/forge/blocks/openai/src/handlers/createTranscriptionHandler.ts
+++ b/packages/forge/blocks/openai/src/handlers/createTranscriptionHandler.ts
@@ -1,8 +1,9 @@
 import { createActionHandler } from "@typebot.io/forge";
 import { safeKy } from "@typebot.io/lib/ky";
+import { parseUnknownError } from "@typebot.io/lib/parseUnknownError";
 import { isNotEmpty } from "@typebot.io/lib/utils";
 import type { ClientOptions } from "openai";
-import OpenAI from "openai";
+import OpenAI, { toFile } from "openai";
 import { createTranscription } from "../actions/createTranscription";
 
 export const createTranscriptionHandler = createActionHandler(
@@ -28,15 +29,122 @@ export const createTranscriptionHandler = createActionHandler(
 
       const openai = new OpenAI(config);
 
-      const result = await openai.audio.transcriptions.create({
-        file: await safeKy.get(options.url),
-        model: isNotEmpty(options.model) ? options.model : "whisper-1",
-        ...(isNotEmpty(options.prompt) ? { prompt: options.prompt } : {}),
-      });
+      try {
+        const audioResponse = await safeKy.get(options.url);
+        const contentType = parseContentType(
+          audioResponse.headers.get("content-type"),
+        );
+        const file = await toFile(
+          audioResponse,
+          createOpenAITranscriptionFileName({
+            contentType,
+            url: options.url,
+          }),
+          contentType ? { type: contentType } : undefined,
+        );
 
-      variables.set([
-        { id: options.transcriptionVariableId, value: result.text },
-      ]);
+        const result = await openai.audio.transcriptions.create({
+          file,
+          model: isNotEmpty(options.model) ? options.model : "whisper-1",
+          ...(isNotEmpty(options.prompt) ? { prompt: options.prompt } : {}),
+        });
+
+        variables.set([
+          { id: options.transcriptionVariableId, value: result.text },
+        ]);
+      } catch (err) {
+        return logs.add(
+          await parseUnknownError({
+            err,
+            context: "While creating OpenAI transcription",
+          }),
+        );
+      }
     },
   },
 );
+
+const openAITranscriptionExtensions = new Set([
+  "flac",
+  "m4a",
+  "mp3",
+  "mp4",
+  "mpeg",
+  "mpga",
+  "oga",
+  "ogg",
+  "wav",
+  "webm",
+]);
+
+const openAITranscriptionExtensionFromContentType = new Map([
+  ["audio/flac", "flac"],
+  ["audio/mp4", "m4a"],
+  ["audio/x-m4a", "m4a"],
+  ["audio/mp3", "mp3"],
+  ["audio/mpeg", "mp3"],
+  ["audio/mpga", "mpga"],
+  ["audio/ogg", "ogg"],
+  ["application/ogg", "ogg"],
+  ["audio/wav", "wav"],
+  ["audio/wave", "wav"],
+  ["audio/x-wav", "wav"],
+  ["audio/webm", "webm"],
+  ["video/mp4", "mp4"],
+  ["video/mpeg", "mpeg"],
+  ["video/webm", "webm"],
+]);
+
+export const createOpenAITranscriptionFileName = ({
+  contentType,
+  url,
+}: {
+  contentType?: string;
+  url: string;
+}) =>
+  `audio.${parseOpenAITranscriptionFileExtension({
+    contentType,
+    url,
+  })}`;
+
+const parseOpenAITranscriptionFileExtension = ({
+  contentType,
+  url,
+}: {
+  contentType?: string;
+  url: string;
+}) => {
+  if (contentType) {
+    const extension =
+      openAITranscriptionExtensionFromContentType.get(contentType);
+    if (extension) return extension;
+  }
+
+  const extensionFromUrl = parseUrlExtension(url);
+
+  if (extensionFromUrl === "weba") return "webm";
+
+  if (extensionFromUrl && openAITranscriptionExtensions.has(extensionFromUrl))
+    return extensionFromUrl;
+
+  return "webm";
+};
+
+const parseContentType = (contentType: string | null) =>
+  contentType?.split(";")[0]?.trim().toLowerCase();
+
+const parseUrlExtension = (url: string) => {
+  const pathname = parseUrlPathname(url);
+  const filename = pathname.split("/").pop();
+  const extension = filename?.split(".").pop()?.toLowerCase();
+
+  return extension === filename ? undefined : extension;
+};
+
+const parseUrlPathname = (url: string) => {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url.split("?")[0] ?? url;
+  }
+};

--- a/packages/lib/src/extensionFromMimeType.ts
+++ b/packages/lib/src/extensionFromMimeType.ts
@@ -6,7 +6,7 @@ export const extensionFromMimeType: { [key: string]: string } = {
   "audio/ogg": "ogg",
   "audio/wav": "wav",
   "audio/wave": "wav",
-  "audio/webm": "weba",
+  "audio/webm": "webm",
   "image/avif": "avif",
   "image/bmp": "bmp",
   "image/gif": "gif",

--- a/packages/lib/src/s3/createUploadFilePath.test.ts
+++ b/packages/lib/src/s3/createUploadFilePath.test.ts
@@ -20,6 +20,12 @@ describe("createUploadFilePath", () => {
     expect(fileName).not.toContain("payload");
   });
 
+  it("uses the WebM extension for audio/webm uploads", () => {
+    const fileName = createUploadFileName("audio/webm");
+
+    expect(fileName.endsWith(".webm")).toBe(true);
+  });
+
   it("creates a path under the provided server prefix", () => {
     const filePath = createUploadFilePath({
       prefix: "public/tmp/typebots/typebot-id/blocks/block-id",


### PR DESCRIPTION
- Normalize `audio/webm` upload filenames to `.webm` instead of `.weba`.
- Send OpenAI transcription requests with an explicit supported audio filename.
- Log OpenAI transcription failures as block logs instead of bubbling a 500.
- Add focused tests for WebM upload naming and transcription filename normalization.