### PR TITLE
🐛 Fix OpenAI chat completions endpoint

### DIFF
--- a/packages/forge/blocks/openai/src/handlers/createChatCompletionHandler.test.ts
+++ b/packages/forge/blocks/openai/src/handlers/createChatCompletionHandler.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import { generateText } from "ai";
+import { createOpenAIChatLanguageModel } from "./createOpenAIChatLanguageModel";
+
+type OpenAIProviderFetch = NonNullable<
+  Parameters<typeof createOpenAIChatLanguageModel>[0]["fetch"]
+>;
+type OpenAIProviderFetchInput = Parameters<OpenAIProviderFetch>[0];
+type OpenAIProviderFetchInit = Parameters<OpenAIProviderFetch>[1];
+
+describe("createOpenAIChatLanguageModel", () => {
+  it("targets the chat completions endpoint", async () => {
+    let requestedUrl: string | undefined;
+    let requestedBody: unknown;
+
+    const fetch: OpenAIProviderFetch = Object.assign(
+      async (
+        input: OpenAIProviderFetchInput,
+        init?: OpenAIProviderFetchInit,
+      ) => {
+        requestedUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+
+        if (typeof init?.body === "string")
+          requestedBody = JSON.parse(init.body);
+
+        return new Response(
+          JSON.stringify({
+            id: "chatcmpl-test",
+            object: "chat.completion",
+            created: 0,
+            model: "agent_9ufXYw8-UBjnwj5uMWbnk",
+            choices: [
+              {
+                index: 0,
+                message: {
+                  role: "assistant",
+                  content: "Bonjour !",
+                },
+                finish_reason: "stop",
+              },
+            ],
+            usage: {
+              prompt_tokens: 1,
+              completion_tokens: 1,
+              total_tokens: 2,
+            },
+          }),
+          {
+            headers: {
+              "Content-Type": "application/json",
+            },
+          },
+        );
+      },
+      { preconnect: () => undefined },
+    );
+
+    await generateText({
+      model: createOpenAIChatLanguageModel({
+        apiKey: "sk-test",
+        baseUrl: "https://example.com/api/agents/v1",
+        modelName: "agent_9ufXYw8-UBjnwj5uMWbnk",
+        fetch,
+      }),
+      messages: [{ role: "user", content: "Hello" }],
+    });
+
+    expect(requestedUrl).toBe(
+      "https://example.com/api/agents/v1/chat/completions",
+    );
+    expect(requestedBody).toEqual({
+      model: "agent_9ufXYw8-UBjnwj5uMWbnk",
+      messages: [{ role: "user", content: "Hello" }],
+    });
+  });
+});

--- a/packages/forge/blocks/openai/src/handlers/createChatCompletionHandler.ts
+++ b/packages/forge/blocks/openai/src/handlers/createChatCompletionHandler.ts
@@ -1,9 +1,9 @@
-import { createOpenAI } from "@ai-sdk/openai";
 import { runChatCompletion } from "@typebot.io/ai/runChatCompletion";
 import { runChatCompletionStream } from "@typebot.io/ai/runChatCompletionStream";
 import { createActionHandler } from "@typebot.io/forge";
 import { createChatCompletion } from "../actions/createChatCompletion";
 import { isModelCompatibleWithVision } from "../helpers/isModelCompatibleWithVision";
+import { createOpenAIChatLanguageModel } from "./createOpenAIChatLanguageModel";
 
 export const createChatCompletionHandler = createActionHandler(
   createChatCompletion,
@@ -21,10 +21,11 @@ export const createChatCompletionHandler = createActionHandler(
       if (!options.messages) return logs.add("No messages provided");
 
       await runChatCompletion({
-        model: createOpenAI({
-          baseURL: baseUrl ?? options.baseUrl,
+        model: createOpenAIChatLanguageModel({
           apiKey,
-        })(modelName),
+          baseUrl: baseUrl ?? options.baseUrl,
+          modelName,
+        }),
         variables,
         messages: options.messages,
         tools: options.tools,
@@ -67,10 +68,11 @@ export const createChatCompletionHandler = createActionHandler(
           };
 
         return runChatCompletionStream({
-          model: createOpenAI({
-            baseURL: baseUrl ?? options.baseUrl,
+          model: createOpenAIChatLanguageModel({
             apiKey,
-          })(modelName),
+            baseUrl: baseUrl ?? options.baseUrl,
+            modelName,
+          }),
           variables,
           messages: options.messages,
           isVisionEnabled: isModelCompatibleWithVision(modelName),

--- a/packages/forge/blocks/openai/src/handlers/createOpenAIChatLanguageModel.ts
+++ b/packages/forge/blocks/openai/src/handlers/createOpenAIChatLanguageModel.ts
@@ -1,0 +1,20 @@
+import { createOpenAI, type OpenAIProviderSettings } from "@ai-sdk/openai";
+
+type Props = {
+  apiKey: string;
+  baseUrl: string | undefined;
+  modelName: string;
+  fetch?: OpenAIProviderSettings["fetch"];
+};
+
+export const createOpenAIChatLanguageModel = ({
+  apiKey,
+  baseUrl,
+  modelName,
+  fetch,
+}: Props) =>
+  createOpenAI({
+    baseURL: baseUrl,
+    apiKey,
+    fetch,
+  }).chat(modelName);


### PR DESCRIPTION
- Fixed the OpenAI chat completion handler to explicitly use the AI SDK chat model for custom base URLs.
- Added regression coverage to verify OpenAI-compatible requests target `/chat/completions` with the expected payload.