### PR TITLE
👌 Add WhatsApp webhook forwarding options

### DIFF
--- a/apps/builder/src/features/publish/components/deploy/dialogs/whatsApp/WhatsAppDeployDialog.tsx
+++ b/apps/builder/src/features/publish/components/deploy/dialogs/whatsApp/WhatsAppDeployDialog.tsx
@@ -17,7 +17,7 @@ import { MoreInfoTooltip } from "@typebot.io/ui/components/MoreInfoTooltip";
 import { Switch } from "@typebot.io/ui/components/Switch";
 import { useOpenControls } from "@typebot.io/ui/hooks/useOpenControls";
 import { InformationSquareIcon } from "@typebot.io/ui/icons/InformationSquareIcon";
-import type { JSX } from "react";
+import { type JSX, useRef } from "react";
 import { BasicNumberInput } from "@/components/inputs/BasicNumberInput";
 import { BasicSelect } from "@/components/inputs/BasicSelect";
 import { TableList } from "@/components/TableList";
@@ -39,6 +39,8 @@ export const WhatsAppDeployDialog = ({
   onClose,
 }: DialogProps): JSX.Element => {
   const { typebot, updateTypebot, isPublished } = useTypebot();
+  const latestTypebotRef = useRef(typebot);
+  latestTypebotRef.current = typebot;
   const { workspace } = useWorkspace();
   const {
     isOpen: isCredentialsDialogOpen,
@@ -53,6 +55,29 @@ export const WhatsAppDeployDialog = ({
 
   const whatsAppSettings = typebot?.settings.whatsApp;
   const whatsAppCredentialsId = typebot?.whatsAppCredentialsId;
+
+  const updateWhatsAppSettings = (
+    whatsApp: NonNullable<typeof typebot>["settings"]["whatsApp"],
+  ) => {
+    const currentTypebot = latestTypebotRef.current;
+    if (!currentTypebot) return;
+
+    const settings = {
+      ...currentTypebot.settings,
+      whatsApp,
+    };
+
+    latestTypebotRef.current = {
+      ...currentTypebot,
+      settings,
+    };
+
+    updateTypebot({
+      updates: {
+        settings,
+      },
+    });
+  };
 
   const { data: phoneNumberData } = useQuery(
     orpc.whatsApp.getPhoneNumber.queryOptions({
@@ -185,50 +210,45 @@ export const WhatsAppDeployDialog = ({
   };
 
   const updateIsWebhookForwardingEnabled = (isEnabled: boolean) => {
-    if (!typebot) return;
-    updateTypebot({
-      updates: {
-        settings: {
-          ...typebot.settings,
-          whatsApp: {
-            ...typebot.settings.whatsApp,
-            errorAndMarketingStatusWebhookForwardUrl: undefined,
-            webhookForwarding: !isEnabled
-              ? undefined
-              : {
-                  ...typebot.settings.whatsApp?.webhookForwarding,
-                  url:
-                    typebot.settings.whatsApp?.webhookForwarding?.url ??
-                    typebot.settings.whatsApp
-                      ?.errorAndMarketingStatusWebhookForwardUrl,
-                  scope:
-                    typebot.settings.whatsApp?.webhookForwarding?.scope ??
-                    defaultWhatsAppWebhookForwardingScope,
-                },
+    const currentTypebot = latestTypebotRef.current;
+    if (!currentTypebot) return;
+    updateWhatsAppSettings({
+      ...currentTypebot.settings.whatsApp,
+      errorAndMarketingStatusWebhookForwardUrl: undefined,
+      webhookForwarding: !isEnabled
+        ? undefined
+        : {
+            ...currentTypebot.settings.whatsApp?.webhookForwarding,
+            url:
+              currentTypebot.settings.whatsApp?.webhookForwarding?.url ??
+              currentTypebot.settings.whatsApp
+                ?.errorAndMarketingStatusWebhookForwardUrl,
+            scope:
+              currentTypebot.settings.whatsApp?.webhookForwarding?.scope ??
+              defaultWhatsAppWebhookForwardingScope,
           },
-        },
-      },
     });
   };
 
   const updateWebhookForwardingUrl = (url: string) => {
-    if (!typebot) return;
-    updateTypebot({
-      updates: {
-        settings: {
-          ...typebot.settings,
-          whatsApp: {
-            ...typebot.settings.whatsApp,
-            errorAndMarketingStatusWebhookForwardUrl: undefined,
-            webhookForwarding: {
-              ...typebot.settings.whatsApp?.webhookForwarding,
-              url: url || undefined,
-              scope:
-                typebot.settings.whatsApp?.webhookForwarding?.scope ??
-                defaultWhatsAppWebhookForwardingScope,
-            },
-          },
-        },
+    const currentTypebot = latestTypebotRef.current;
+    if (!currentTypebot) return;
+    const isForwardingEnabled =
+      isDefined(currentTypebot.settings.whatsApp?.webhookForwarding) ||
+      isDefined(
+        currentTypebot.settings.whatsApp
+          ?.errorAndMarketingStatusWebhookForwardUrl,
+      );
+    if (!isForwardingEnabled) return;
+    updateWhatsAppSettings({
+      ...currentTypebot.settings.whatsApp,
+      errorAndMarketingStatusWebhookForwardUrl: undefined,
+      webhookForwarding: {
+        ...currentTypebot.settings.whatsApp?.webhookForwarding,
+        url: url || undefined,
+        scope:
+          currentTypebot.settings.whatsApp?.webhookForwarding?.scope ??
+          defaultWhatsAppWebhookForwardingScope,
       },
     });
   };
@@ -236,24 +256,18 @@ export const WhatsAppDeployDialog = ({
   const updateWebhookForwardingScope = (
     scope: WhatsAppWebhookForwardingScope | undefined,
   ) => {
-    if (!typebot) return;
-    updateTypebot({
-      updates: {
-        settings: {
-          ...typebot.settings,
-          whatsApp: {
-            ...typebot.settings.whatsApp,
-            errorAndMarketingStatusWebhookForwardUrl: undefined,
-            webhookForwarding: {
-              ...typebot.settings.whatsApp?.webhookForwarding,
-              url:
-                typebot.settings.whatsApp?.webhookForwarding?.url ??
-                typebot.settings.whatsApp
-                  ?.errorAndMarketingStatusWebhookForwardUrl,
-              scope: scope ?? defaultWhatsAppWebhookForwardingScope,
-            },
-          },
-        },
+    const currentTypebot = latestTypebotRef.current;
+    if (!currentTypebot) return;
+    updateWhatsAppSettings({
+      ...currentTypebot.settings.whatsApp,
+      errorAndMarketingStatusWebhookForwardUrl: undefined,
+      webhookForwarding: {
+        ...currentTypebot.settings.whatsApp?.webhookForwarding,
+        url:
+          currentTypebot.settings.whatsApp?.webhookForwarding?.url ??
+          currentTypebot.settings.whatsApp
+            ?.errorAndMarketingStatusWebhookForwardUrl,
+        scope: scope ?? defaultWhatsAppWebhookForwardingScope,
       },
     });
   };

--- a/apps/builder/src/features/publish/components/deploy/dialogs/whatsApp/WhatsAppDeployDialog.tsx
+++ b/apps/builder/src/features/publish/components/deploy/dialogs/whatsApp/WhatsAppDeployDialog.tsx
@@ -2,10 +2,15 @@ import { useQuery } from "@tanstack/react-query";
 import { LogicalOperator } from "@typebot.io/conditions/constants";
 import type { Comparison } from "@typebot.io/conditions/schemas";
 import { isDefined } from "@typebot.io/lib/utils";
-import { defaultSessionExpiryTimeout } from "@typebot.io/settings/constants";
+import {
+  defaultSessionExpiryTimeout,
+  defaultWhatsAppWebhookForwardingScope,
+  WhatsAppWebhookForwardingScope,
+} from "@typebot.io/settings/constants";
 import { Accordion } from "@typebot.io/ui/components/Accordion";
 import { Alert } from "@typebot.io/ui/components/Alert";
 import { Button } from "@typebot.io/ui/components/Button";
+import { DebouncedTextInput } from "@typebot.io/ui/components/DebouncedTextInput";
 import { Dialog } from "@typebot.io/ui/components/Dialog";
 import { Field } from "@typebot.io/ui/components/Field";
 import { MoreInfoTooltip } from "@typebot.io/ui/components/MoreInfoTooltip";
@@ -179,6 +184,91 @@ export const WhatsAppDeployDialog = ({
     });
   };
 
+  const updateIsWebhookForwardingEnabled = (isEnabled: boolean) => {
+    if (!typebot) return;
+    updateTypebot({
+      updates: {
+        settings: {
+          ...typebot.settings,
+          whatsApp: {
+            ...typebot.settings.whatsApp,
+            errorAndMarketingStatusWebhookForwardUrl: undefined,
+            webhookForwarding: !isEnabled
+              ? undefined
+              : {
+                  ...typebot.settings.whatsApp?.webhookForwarding,
+                  url:
+                    typebot.settings.whatsApp?.webhookForwarding?.url ??
+                    typebot.settings.whatsApp
+                      ?.errorAndMarketingStatusWebhookForwardUrl,
+                  scope:
+                    typebot.settings.whatsApp?.webhookForwarding?.scope ??
+                    defaultWhatsAppWebhookForwardingScope,
+                },
+          },
+        },
+      },
+    });
+  };
+
+  const updateWebhookForwardingUrl = (url: string) => {
+    if (!typebot) return;
+    updateTypebot({
+      updates: {
+        settings: {
+          ...typebot.settings,
+          whatsApp: {
+            ...typebot.settings.whatsApp,
+            errorAndMarketingStatusWebhookForwardUrl: undefined,
+            webhookForwarding: {
+              ...typebot.settings.whatsApp?.webhookForwarding,
+              url: url || undefined,
+              scope:
+                typebot.settings.whatsApp?.webhookForwarding?.scope ??
+                defaultWhatsAppWebhookForwardingScope,
+            },
+          },
+        },
+      },
+    });
+  };
+
+  const updateWebhookForwardingScope = (
+    scope: WhatsAppWebhookForwardingScope | undefined,
+  ) => {
+    if (!typebot) return;
+    updateTypebot({
+      updates: {
+        settings: {
+          ...typebot.settings,
+          whatsApp: {
+            ...typebot.settings.whatsApp,
+            errorAndMarketingStatusWebhookForwardUrl: undefined,
+            webhookForwarding: {
+              ...typebot.settings.whatsApp?.webhookForwarding,
+              url:
+                typebot.settings.whatsApp?.webhookForwarding?.url ??
+                typebot.settings.whatsApp
+                  ?.errorAndMarketingStatusWebhookForwardUrl,
+              scope: scope ?? defaultWhatsAppWebhookForwardingScope,
+            },
+          },
+        },
+      },
+    });
+  };
+
+  const webhookForwardingUrl =
+    whatsAppSettings?.webhookForwarding?.url ??
+    whatsAppSettings?.errorAndMarketingStatusWebhookForwardUrl ??
+    "";
+  const webhookForwardingScope =
+    whatsAppSettings?.webhookForwarding?.scope ??
+    defaultWhatsAppWebhookForwardingScope;
+  const isWebhookForwardingEnabled =
+    isDefined(whatsAppSettings?.webhookForwarding) ||
+    isDefined(whatsAppSettings?.errorAndMarketingStatusWebhookForwardUrl);
+
   return (
     <Dialog.Root isOpen={isOpen} onClose={onClose}>
       <Dialog.Popup className="max-w-xl">
@@ -266,6 +356,47 @@ export const WhatsAppDeployDialog = ({
                       <Field.Container>
                         <Field.Root className="flex-row items-center">
                           <Switch
+                            checked={isWebhookForwardingEnabled}
+                            onCheckedChange={updateIsWebhookForwardingEnabled}
+                          />
+                          <Field.Label>Webhook forwarding</Field.Label>
+                        </Field.Root>
+                        {isWebhookForwardingEnabled && (
+                          <>
+                            <Field.Root>
+                              <Field.Label>
+                                Forwarding URL
+                                <MoreInfoTooltip>
+                                  Forward incoming Meta WhatsApp webhook
+                                  payloads to this URL.
+                                </MoreInfoTooltip>
+                              </Field.Label>
+                              <DebouncedTextInput
+                                defaultValue={webhookForwardingUrl}
+                                onValueChange={updateWebhookForwardingUrl}
+                                placeholder="https://example.com/webhook"
+                              />
+                            </Field.Root>
+                            <Field.Root>
+                              <Field.Label>Events to forward</Field.Label>
+                              <BasicSelect
+                                className="w-full"
+                                value={webhookForwardingScope}
+                                onChange={updateWebhookForwardingScope}
+                                items={webhookForwardingScopeItems}
+                              />
+                              <Field.Description>
+                                The default keeps the current behavior and only
+                                forwards marketing conversation statuses and
+                                failed statuses.
+                              </Field.Description>
+                            </Field.Root>
+                          </>
+                        )}
+                      </Field.Container>
+                      <Field.Container>
+                        <Field.Root className="flex-row items-center">
+                          <Switch
                             checked={isDefined(
                               whatsAppSettings?.startCondition,
                             )}
@@ -337,3 +468,18 @@ export const WhatsAppDeployDialog = ({
     </Dialog.Root>
   );
 };
+
+const webhookForwardingScopeItems = [
+  {
+    label: "Marketing and failed statuses",
+    value: WhatsAppWebhookForwardingScope.ERROR_AND_MARKETING_STATUSES,
+  },
+  {
+    label: "All message statuses",
+    value: WhatsAppWebhookForwardingScope.ALL_STATUSES,
+  },
+  {
+    label: "Full Meta webhook payload",
+    value: WhatsAppWebhookForwardingScope.ALL_EVENTS,
+  },
+];

--- a/packages/scripts/src/updateWhatsAppStatusForwardUrl.ts
+++ b/packages/scripts/src/updateWhatsAppStatusForwardUrl.ts
@@ -1,5 +1,6 @@
 import * as p from "@clack/prompts";
 import prisma from "@typebot.io/prisma";
+import { defaultWhatsAppWebhookForwardingScope } from "@typebot.io/settings/constants";
 import { settingsSchema } from "@typebot.io/settings/schemas";
 import { promptAndSetEnvironment } from "./utils";
 
@@ -44,8 +45,10 @@ const updateWhatsAppStatusForwardUrl = async () => {
   console.log({
     name: typebot.name,
     currentDraftUrl:
+      draftSettings.whatsApp?.webhookForwarding?.url ??
       draftSettings.whatsApp?.errorAndMarketingStatusWebhookForwardUrl,
     currentPublishedUrl:
+      publishedSettings?.whatsApp?.webhookForwarding?.url ??
       publishedSettings?.whatsApp?.errorAndMarketingStatusWebhookForwardUrl,
     newUrl,
   });
@@ -60,7 +63,14 @@ const updateWhatsAppStatusForwardUrl = async () => {
         ...draftSettings,
         whatsApp: {
           ...draftSettings.whatsApp,
-          errorAndMarketingStatusWebhookForwardUrl: newUrl,
+          errorAndMarketingStatusWebhookForwardUrl: undefined,
+          webhookForwarding: {
+            ...draftSettings.whatsApp?.webhookForwarding,
+            url: newUrl,
+            scope:
+              draftSettings.whatsApp?.webhookForwarding?.scope ??
+              defaultWhatsAppWebhookForwardingScope,
+          },
         },
       },
     },
@@ -74,7 +84,14 @@ const updateWhatsAppStatusForwardUrl = async () => {
           ...publishedSettings,
           whatsApp: {
             ...publishedSettings.whatsApp,
-            errorAndMarketingStatusWebhookForwardUrl: newUrl,
+            errorAndMarketingStatusWebhookForwardUrl: undefined,
+            webhookForwarding: {
+              ...publishedSettings.whatsApp?.webhookForwarding,
+              url: newUrl,
+              scope:
+                publishedSettings.whatsApp?.webhookForwarding?.scope ??
+                defaultWhatsAppWebhookForwardingScope,
+            },
           },
         },
       },

--- a/packages/settings/src/constants.ts
+++ b/packages/settings/src/constants.ts
@@ -1,5 +1,14 @@
 import type { Settings } from "./schemas";
 
+export enum WhatsAppWebhookForwardingScope {
+  ERROR_AND_MARKETING_STATUSES = "errorAndMarketingStatuses",
+  ALL_STATUSES = "allStatuses",
+  ALL_EVENTS = "allEvents",
+}
+
+export const defaultWhatsAppWebhookForwardingScope =
+  WhatsAppWebhookForwardingScope.ERROR_AND_MARKETING_STATUSES;
+
 export const defaultSettings = {
   general: {
     isInputPrefillEnabled: false,

--- a/packages/settings/src/schemas.ts
+++ b/packages/settings/src/schemas.ts
@@ -3,7 +3,11 @@ import {
   LogicalOperator,
 } from "@typebot.io/conditions/constants";
 import { z } from "zod";
-import { maxTypingEmulationMaxDelay, rememberUserStorages } from "./constants";
+import {
+  maxTypingEmulationMaxDelay,
+  rememberUserStorages,
+  WhatsAppWebhookForwardingScope,
+} from "./constants";
 
 export const systemMessagesSchema = z.object({
   invalidMessage: z.string().optional(),
@@ -77,6 +81,12 @@ export const whatsAppSettingsSchema = z.object({
     .optional()
     .describe("Expiration delay in hours after latest interaction"),
   errorAndMarketingStatusWebhookForwardUrl: z.string().url().optional(),
+  webhookForwarding: z
+    .object({
+      url: z.string().url().optional(),
+      scope: z.enum(WhatsAppWebhookForwardingScope).optional(),
+    })
+    .optional(),
 });
 
 export const settingsSchema = z.object({

--- a/packages/whatsapp/src/api/handleProductionWebhookRequest.ts
+++ b/packages/whatsapp/src/api/handleProductionWebhookRequest.ts
@@ -69,7 +69,10 @@ export const handleProductionWebhookRequest = async ({
       message: "Invalid WhatsApp webhook signature",
     });
 
-  const { entry } = parseWebhookBody(body);
+  const {
+    parsedBody: { entry },
+    webhookRequestBody,
+  } = parseWebhookBody(body);
 
   if (!entry) return WEBHOOK_SUCCESS_MESSAGE;
 
@@ -87,6 +90,7 @@ export const handleProductionWebhookRequest = async ({
     const [forwardingResult, resumingResult] = await Promise.allSettled([
       forwardStatusWebhooks({
         entry,
+        webhookRequestBody,
         workspaceId,
         credentialsId,
       }),
@@ -167,13 +171,24 @@ const getWhatsAppCredentialsData = async ({
 
 const parseWebhookBody = (body: string) => {
   try {
-    return whatsAppWebhookRequestBodySchema.parse(JSON.parse(body));
+    const rawBody: unknown = JSON.parse(body);
+    const parsedBody = whatsAppWebhookRequestBodySchema.parse(rawBody);
+
+    return {
+      parsedBody,
+      webhookRequestBody: isRecord(rawBody)
+        ? rawBody
+        : { entry: parsedBody.entry },
+    };
   } catch {
     throw new ORPCError("BAD_REQUEST", {
       message: "Invalid WhatsApp webhook payload",
     });
   }
 };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const safeJsonParse = (value: string | undefined): unknown => {
   if (!value) return value;

--- a/packages/whatsapp/src/forwardStatusWebhooks.test.ts
+++ b/packages/whatsapp/src/forwardStatusWebhooks.test.ts
@@ -1,0 +1,319 @@
+import { WhatsAppWebhookForwardingScope } from "@typebot.io/settings/constants";
+import { describe, expect, it } from "vitest";
+import {
+  buildWebhookForwardingPayload,
+  getForwardingRoutesFromPublicTypebots,
+} from "./forwardStatusWebhooks";
+import type { WhatsAppWebhookRequestBody } from "./schemas";
+
+describe("getForwardingRoutesFromPublicTypebots", () => {
+  it("keeps legacy forwarding URLs on the default scope", () => {
+    expect(
+      getForwardingRoutesFromPublicTypebots([
+        {
+          settings: {
+            whatsApp: {
+              isEnabled: true,
+              errorAndMarketingStatusWebhookForwardUrl:
+                "https://example.com/legacy-webhook",
+            },
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        url: "https://example.com/legacy-webhook",
+        scope: WhatsAppWebhookForwardingScope.ERROR_AND_MARKETING_STATUSES,
+      },
+    ]);
+  });
+
+  it("uses the new forwarding config before the legacy URL", () => {
+    expect(
+      getForwardingRoutesFromPublicTypebots([
+        {
+          settings: {
+            whatsApp: {
+              isEnabled: true,
+              errorAndMarketingStatusWebhookForwardUrl:
+                "https://example.com/legacy-webhook",
+              webhookForwarding: {
+                url: "https://example.com/new-webhook",
+                scope: WhatsAppWebhookForwardingScope.ALL_EVENTS,
+              },
+            },
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        url: "https://example.com/new-webhook",
+        scope: WhatsAppWebhookForwardingScope.ALL_EVENTS,
+      },
+    ]);
+  });
+
+  it("defaults new forwarding config without a scope to the legacy behavior", () => {
+    expect(
+      getForwardingRoutesFromPublicTypebots([
+        {
+          settings: {
+            whatsApp: {
+              isEnabled: true,
+              webhookForwarding: {
+                url: "https://example.com/new-webhook",
+              },
+            },
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        url: "https://example.com/new-webhook",
+        scope: WhatsAppWebhookForwardingScope.ERROR_AND_MARKETING_STATUSES,
+      },
+    ]);
+  });
+
+  it("ignores disabled WhatsApp typebots even with a legacy forwarding URL", () => {
+    expect(
+      getForwardingRoutesFromPublicTypebots([
+        {
+          settings: {
+            whatsApp: {
+              isEnabled: false,
+              errorAndMarketingStatusWebhookForwardUrl:
+                "https://example.com/disabled-webhook",
+            },
+          },
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("keeps the most inclusive scope when multiple typebots use the same URL", () => {
+    expect(
+      getForwardingRoutesFromPublicTypebots([
+        {
+          settings: {
+            whatsApp: {
+              isEnabled: true,
+              errorAndMarketingStatusWebhookForwardUrl:
+                "https://example.com/shared-webhook",
+            },
+          },
+        },
+        {
+          settings: {
+            whatsApp: {
+              isEnabled: true,
+              webhookForwarding: {
+                url: "https://example.com/shared-webhook",
+                scope: WhatsAppWebhookForwardingScope.ALL_EVENTS,
+              },
+            },
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        url: "https://example.com/shared-webhook",
+        scope: WhatsAppWebhookForwardingScope.ALL_EVENTS,
+      },
+    ]);
+  });
+});
+
+describe("buildWebhookForwardingPayload", () => {
+  it("keeps the legacy marketing and failed status filter", () => {
+    const payload = buildWebhookForwardingPayload({
+      entry: incomingWebhookEntry,
+      webhookRequestBody: incomingWebhookRequestBody,
+      scope: WhatsAppWebhookForwardingScope.ERROR_AND_MARKETING_STATUSES,
+    });
+
+    expect(payload).toMatchObject({
+      entry: [
+        {
+          changes: [
+            {
+              value: {
+                messages: incomingWebhookEntry[0]?.changes[0]?.value.messages,
+                statuses: [{ id: "marketing-status" }, { id: "failed-status" }],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("can forward all message statuses", () => {
+    const payload = buildWebhookForwardingPayload({
+      entry: incomingWebhookEntry,
+      webhookRequestBody: incomingWebhookRequestBody,
+      scope: WhatsAppWebhookForwardingScope.ALL_STATUSES,
+    });
+
+    expect(payload).toMatchObject({
+      entry: [
+        {
+          changes: [
+            {
+              value: {
+                messages: incomingWebhookEntry[0]?.changes[0]?.value.messages,
+                statuses: [
+                  { id: "utility-status" },
+                  { id: "marketing-status" },
+                  { id: "failed-status" },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("can forward the full Meta webhook payload", () => {
+    const payload = buildWebhookForwardingPayload({
+      entry: incomingWebhookEntry,
+      webhookRequestBody: incomingWebhookRequestBody,
+      scope: WhatsAppWebhookForwardingScope.ALL_EVENTS,
+    });
+
+    expect(payload).toEqual(incomingWebhookRequestBody);
+  });
+});
+
+const incomingWebhookEntry: WhatsAppWebhookRequestBody["entry"] = [
+  {
+    changes: [
+      {
+        value: {
+          metadata: {
+            phone_number_id: "phone-number-id",
+          },
+          messages: [
+            {
+              id: "incoming-message",
+              from: "33600000000",
+              timestamp: "1700000000",
+              type: "text",
+              text: {
+                body: "Hello",
+              },
+            },
+          ],
+          statuses: [
+            {
+              id: "utility-status",
+              recipient_id: "33600000000",
+              status: "delivered",
+              timestamp: "1700000001",
+              conversation: {
+                id: "utility-conversation",
+                origin: {
+                  type: "utility",
+                },
+              },
+            },
+            {
+              id: "marketing-status",
+              recipient_id: "33600000000",
+              status: "read",
+              timestamp: "1700000002",
+              conversation: {
+                id: "marketing-conversation",
+                origin: {
+                  type: "marketing",
+                },
+              },
+            },
+            {
+              id: "failed-status",
+              recipient_id: "33600000000",
+              status: "failed",
+              timestamp: "1700000003",
+              errors: [
+                {
+                  code: 131026,
+                  title: "Message undeliverable",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  },
+];
+
+const incomingWebhookRequestBody = {
+  object: "whatsapp_business_account",
+  entry: [
+    {
+      id: "whatsapp-business-account-id",
+      changes: [
+        {
+          field: "messages",
+          value: {
+            messaging_product: "whatsapp",
+            metadata: {
+              phone_number_id: "phone-number-id",
+            },
+            messages: [
+              {
+                id: "incoming-message",
+                from: "33600000000",
+                timestamp: "1700000000",
+                type: "text",
+                text: {
+                  body: "Hello",
+                },
+              },
+            ],
+            statuses: [
+              {
+                id: "utility-status",
+                recipient_id: "33600000000",
+                status: "delivered",
+                timestamp: "1700000001",
+                conversation: {
+                  id: "utility-conversation",
+                  origin: {
+                    type: "utility",
+                  },
+                },
+              },
+              {
+                id: "marketing-status",
+                recipient_id: "33600000000",
+                status: "read",
+                timestamp: "1700000002",
+                conversation: {
+                  id: "marketing-conversation",
+                  origin: {
+                    type: "marketing",
+                  },
+                },
+              },
+              {
+                id: "failed-status",
+                recipient_id: "33600000000",
+                status: "failed",
+                timestamp: "1700000003",
+                errors: [
+                  {
+                    code: 131026,
+                    title: "Message undeliverable",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/packages/whatsapp/src/forwardStatusWebhooks.ts
+++ b/packages/whatsapp/src/forwardStatusWebhooks.ts
@@ -1,11 +1,16 @@
 import * as Sentry from "@sentry/nextjs";
 import { safeKy } from "@typebot.io/lib/ky";
 import prisma from "@typebot.io/prisma";
+import {
+  defaultWhatsAppWebhookForwardingScope,
+  WhatsAppWebhookForwardingScope,
+} from "@typebot.io/settings/constants";
 import { settingsSchema } from "@typebot.io/settings/schemas";
 import type { WhatsAppWebhookRequestBody } from "./schemas";
 
 type Props = {
   entry: WhatsAppWebhookRequestBody["entry"];
+  webhookRequestBody: StatusWebhookPayload | Record<string, unknown>;
   workspaceId: string;
   credentialsId: string;
 };
@@ -14,6 +19,12 @@ type IncomingChange =
   WhatsAppWebhookRequestBody["entry"][number]["changes"][number];
 type IncomingStatus = NonNullable<IncomingChange["value"]["statuses"]>[number];
 type StatusWebhookPayload = Pick<WhatsAppWebhookRequestBody, "entry">;
+type WebhookForwardingPayload = StatusWebhookPayload | Record<string, unknown>;
+
+type ForwardingRoute = {
+  url: string;
+  scope: WhatsAppWebhookForwardingScope;
+};
 
 type StatusRouteMatch = {
   entryIndex: number;
@@ -21,81 +32,117 @@ type StatusRouteMatch = {
   status: IncomingStatus;
 };
 
+const forwardingScopePriorities: Record<
+  WhatsAppWebhookForwardingScope,
+  number
+> = {
+  [WhatsAppWebhookForwardingScope.ERROR_AND_MARKETING_STATUSES]: 0,
+  [WhatsAppWebhookForwardingScope.ALL_STATUSES]: 1,
+  [WhatsAppWebhookForwardingScope.ALL_EVENTS]: 2,
+};
+
 export const forwardStatusWebhooks = async ({
   entry,
+  webhookRequestBody,
   workspaceId,
   credentialsId,
 }: Props) => {
   try {
-    const statusesToForward: StatusRouteMatch[] = [];
-
-    for (const [entryIndex, webhookEntry] of entry.entries()) {
-      for (const [changeIndex, change] of webhookEntry.changes.entries()) {
-        for (const status of change.value.statuses ?? []) {
-          if (!shouldForwardStatus(status)) continue;
-
-          statusesToForward.push({
-            entryIndex,
-            changeIndex,
-            status,
-          });
-        }
-      }
-    }
-
-    if (statusesToForward.length === 0) return;
-
-    console.log(`Extracted ${statusesToForward.length} statuses to forward`);
-
-    const forwardingUrls = await getForwardingUrls({
+    const forwardingRoutes = await getForwardingRoutes({
       workspaceId,
       credentialsId,
     });
 
-    console.log(`Extracted ${forwardingUrls.length} forwarding URLs`);
-    if (forwardingUrls.length === 0) return;
+    console.log(`Extracted ${forwardingRoutes.length} forwarding URLs`);
+    if (forwardingRoutes.length === 0) return;
 
-    const payload = buildFilteredStatusPayload({
-      entry,
-      matchedStatuses: statusesToForward,
-    });
-
-    console.log(`Built payload with ${payload.entry.length} entries`);
-    if (payload.entry.length === 0) return;
-
-    for (const url of forwardingUrls) {
+    for (const { url, scope } of forwardingRoutes) {
       try {
+        const payload = buildWebhookForwardingPayload({
+          entry,
+          webhookRequestBody,
+          scope,
+        });
+        if (!payload) continue;
+
         await safeKy.post(url, {
           json: payload,
         });
-        console.log(`Forwarded status to ${url}`);
+        console.log(`Forwarded WhatsApp webhook to ${url}`);
       } catch (error) {
-        console.warn("Failed to forward WhatsApp statuses", { url, error });
+        console.warn("Failed to forward WhatsApp webhook", { url, error });
         Sentry.captureException(error, {
           extra: {
             url,
-            source: "whatsapp-status-forwarding",
+            source: "whatsapp-webhook-forwarding",
           },
         });
       }
     }
   } catch (error) {
-    console.warn("Unexpected error while forwarding WhatsApp statuses", error);
+    console.warn("Unexpected error while forwarding WhatsApp webhook", error);
     Sentry.captureException(error, {
       extra: {
-        source: "whatsapp-status-forwarding",
+        source: "whatsapp-webhook-forwarding",
       },
     });
   }
 };
 
-const getForwardingUrls = async ({
+export const buildWebhookForwardingPayload = ({
+  entry,
+  webhookRequestBody,
+  scope,
+}: {
+  entry: WhatsAppWebhookRequestBody["entry"];
+  webhookRequestBody: StatusWebhookPayload | Record<string, unknown>;
+  scope: WhatsAppWebhookForwardingScope;
+}): WebhookForwardingPayload | undefined => {
+  if (scope === WhatsAppWebhookForwardingScope.ALL_EVENTS)
+    return webhookRequestBody;
+
+  const statusesToForward = extractStatusesToForward({ entry, scope });
+  if (statusesToForward.length === 0) return;
+
+  return buildFilteredStatusPayload({
+    entry,
+    matchedStatuses: statusesToForward,
+  });
+};
+
+const extractStatusesToForward = ({
+  entry,
+  scope,
+}: {
+  entry: WhatsAppWebhookRequestBody["entry"];
+  scope: WhatsAppWebhookForwardingScope;
+}) => {
+  const statusesToForward: StatusRouteMatch[] = [];
+
+  for (const [entryIndex, webhookEntry] of entry.entries()) {
+    for (const [changeIndex, change] of webhookEntry.changes.entries()) {
+      for (const status of change.value.statuses ?? []) {
+        if (!shouldForwardStatus({ status, scope })) continue;
+
+        statusesToForward.push({
+          entryIndex,
+          changeIndex,
+          status,
+        });
+      }
+    }
+  }
+
+  return statusesToForward;
+};
+
+const getForwardingRoutes = async ({
   workspaceId,
   credentialsId,
 }: {
   workspaceId: string;
   credentialsId: string;
-}) => {
+}): Promise<ForwardingRoute[]> => {
   const potentialPublicTypebots = await prisma.publicTypebot.findMany({
     where: {
       typebot: {
@@ -108,9 +155,18 @@ const getForwardingUrls = async ({
     },
   });
 
-  const uniqueUrls = new Set<string>();
+  return getForwardingRoutesFromPublicTypebots(potentialPublicTypebots);
+};
 
-  for (const publicTypebot of potentialPublicTypebots) {
+export const getForwardingRoutesFromPublicTypebots = (
+  publicTypebots: readonly { settings: unknown }[],
+): ForwardingRoute[] => {
+  const forwardingScopesByUrl = new Map<
+    string,
+    WhatsAppWebhookForwardingScope
+  >();
+
+  for (const publicTypebot of publicTypebots) {
     const parsedSettings = settingsSchema.safeParse(publicTypebot.settings);
     if (
       !parsedSettings.success ||
@@ -119,11 +175,26 @@ const getForwardingUrls = async ({
       continue;
 
     const forwardingUrl =
+      parsedSettings.data.whatsApp.webhookForwarding?.url ??
       parsedSettings.data.whatsApp.errorAndMarketingStatusWebhookForwardUrl;
-    if (forwardingUrl) uniqueUrls.add(forwardingUrl);
+    if (!forwardingUrl) continue;
+
+    const forwardingScope =
+      parsedSettings.data.whatsApp.webhookForwarding?.scope ??
+      defaultWhatsAppWebhookForwardingScope;
+    forwardingScopesByUrl.set(
+      forwardingUrl,
+      getMostInclusiveForwardingScope({
+        currentScope: forwardingScopesByUrl.get(forwardingUrl),
+        nextScope: forwardingScope,
+      }),
+    );
   }
 
-  return Array.from(uniqueUrls);
+  return Array.from(forwardingScopesByUrl.entries()).map(([url, scope]) => ({
+    url,
+    scope,
+  }));
 };
 
 const buildFilteredStatusPayload = ({
@@ -178,8 +249,29 @@ const buildFilteredStatusPayload = ({
   };
 };
 
-const shouldForwardStatus = (status: IncomingStatus) => {
+const shouldForwardStatus = ({
+  status,
+  scope,
+}: {
+  status: IncomingStatus;
+  scope: WhatsAppWebhookForwardingScope;
+}) => {
+  if (scope === WhatsAppWebhookForwardingScope.ALL_STATUSES) return true;
   if ((status.errors?.length ?? 0) > 0) return true;
   const originType = status.conversation?.origin?.type;
   return originType === "marketing" || originType === "marketing_lite";
+};
+
+const getMostInclusiveForwardingScope = ({
+  currentScope,
+  nextScope,
+}: {
+  currentScope: WhatsAppWebhookForwardingScope | undefined;
+  nextScope: WhatsAppWebhookForwardingScope;
+}) => {
+  if (!currentScope) return nextScope;
+  return forwardingScopePriorities[nextScope] >
+    forwardingScopePriorities[currentScope]
+    ? nextScope
+    : currentScope;
 };


### PR DESCRIPTION
- Adds a WhatsApp deploy setting to enable webhook forwarding and choose between marketing/failed statuses, all statuses, or full Meta webhook payloads.
- Adds settings schema/constants for the new forwarding config while keeping legacy errorAndMarketingStatusWebhookForwardUrl fallback behavior.
- Updates production forwarding to route by scope and preserve the raw Meta payload for the full-payload option.
- Updates the WhatsApp status forwarding script to read/write the new config shape.
- Adds unit coverage for legacy fallback, scope precedence, disabled bots, duplicate URLs, filtered statuses, and full-payload forwarding.
