### PR TITLE
👌 Configure WhatsApp webhook forwarding URL

### DIFF
--- a/apps/builder/src/features/publish/components/deploy/dialogs/whatsApp/WhatsAppDeployDialog.tsx
+++ b/apps/builder/src/features/publish/components/deploy/dialogs/whatsApp/WhatsAppDeployDialog.tsx
@@ -3,11 +3,15 @@ import { LogicalOperator } from "@typebot.io/conditions/constants";
 import type { Comparison } from "@typebot.io/conditions/schemas";
 import { isDefined } from "@typebot.io/lib/utils";
 import { defaultSessionExpiryTimeout } from "@typebot.io/settings/constants";
-import type { WhatsAppWebhookForwardingEventType } from "@typebot.io/settings/schemas";
+import {
+  type WhatsAppWebhookForwardingEventType,
+  whatsAppWebhookForwardingUrlSchema,
+} from "@typebot.io/settings/schemas";
 import { Accordion } from "@typebot.io/ui/components/Accordion";
 import { Alert } from "@typebot.io/ui/components/Alert";
 import { Button } from "@typebot.io/ui/components/Button";
 import { Checkbox } from "@typebot.io/ui/components/Checkbox";
+import { DebouncedTextInput } from "@typebot.io/ui/components/DebouncedTextInput";
 import { Dialog } from "@typebot.io/ui/components/Dialog";
 import { Field } from "@typebot.io/ui/components/Field";
 import { MoreInfoTooltip } from "@typebot.io/ui/components/MoreInfoTooltip";
@@ -15,7 +19,7 @@ import { Select } from "@typebot.io/ui/components/Select";
 import { Switch } from "@typebot.io/ui/components/Switch";
 import { useOpenControls } from "@typebot.io/ui/hooks/useOpenControls";
 import { InformationSquareIcon } from "@typebot.io/ui/icons/InformationSquareIcon";
-import type { JSX } from "react";
+import { type JSX, useState } from "react";
 import { BasicNumberInput } from "@/components/inputs/BasicNumberInput";
 import { BasicSelect } from "@/components/inputs/BasicSelect";
 import { TableList } from "@/components/TableList";
@@ -65,6 +69,8 @@ export const WhatsAppDeployDialog = ({
     onOpen: onChangePlanDialogOpen,
     onClose: onChangePlanDialogClose,
   } = useOpenControls();
+  const [isWebhookForwardingUrlInvalid, setIsWebhookForwardingUrlInvalid] =
+    useState(false);
 
   const whatsAppSettings = typebot?.settings.whatsApp;
   const whatsAppCredentialsId = typebot?.whatsAppCredentialsId;
@@ -199,6 +205,52 @@ export const WhatsAppDeployDialog = ({
     });
   };
 
+  const updateWebhookForwardingUrl = (webhookForwardingUrl: string) => {
+    if (!typebot) return;
+
+    const trimmedWebhookForwardingUrl = webhookForwardingUrl.trim();
+    if (trimmedWebhookForwardingUrl === "") {
+      setIsWebhookForwardingUrlInvalid(false);
+      updateTypebot({
+        updates: {
+          settings: {
+            ...typebot.settings,
+            whatsApp: {
+              ...typebot.settings.whatsApp,
+              errorAndMarketingStatusWebhookForwardUrl: undefined,
+            },
+          },
+        },
+      });
+      return;
+    }
+
+    if (
+      !whatsAppWebhookForwardingUrlSchema.safeParse(trimmedWebhookForwardingUrl)
+        .success
+    ) {
+      setIsWebhookForwardingUrlInvalid(true);
+      return;
+    }
+
+    setIsWebhookForwardingUrlInvalid(false);
+    updateTypebot({
+      updates: {
+        settings: {
+          ...typebot.settings,
+          whatsApp: {
+            ...typebot.settings.whatsApp,
+            errorAndMarketingStatusWebhookForwardUrl:
+              trimmedWebhookForwardingUrl,
+            webhookForwardingEventTypes:
+              typebot.settings.whatsApp?.webhookForwardingEventTypes ??
+              defaultWebhookForwardingEventTypes,
+          },
+        },
+      },
+    });
+  };
+
   const updateIsWebhookForwardingEnabled = (
     isWebhookForwardingEnabled: boolean,
   ) => {
@@ -244,17 +296,15 @@ export const WhatsAppDeployDialog = ({
           ...typebot.settings,
           whatsApp: {
             ...typebot.settings.whatsApp,
-            isWebhookForwardingEnabled: webhookForwardingEventTypes.length > 0,
-            webhookForwardingEventTypes:
-              webhookForwardingEventTypes.length > 0
-                ? webhookForwardingEventTypes
-                : undefined,
+            webhookForwardingEventTypes,
           },
         },
       },
     });
   };
 
+  const webhookForwardingUrl =
+    whatsAppSettings?.errorAndMarketingStatusWebhookForwardUrl;
   const isWebhookForwardingEnabled =
     whatsAppSettings?.isWebhookForwardingEnabled === true;
   const selectedWebhookForwardingEventTypes =
@@ -269,7 +319,7 @@ export const WhatsAppDeployDialog = ({
           )?.label,
       )
       .filter(isDefined)
-      .join(", ");
+      .join(", ") || "No events selected";
 
   return (
     <Dialog.Root isOpen={isOpen} onClose={onClose}>
@@ -391,15 +441,18 @@ export const WhatsAppDeployDialog = ({
                           </TableList>
                         )}
                       </Field.Container>
-                      {whatsAppSettings?.errorAndMarketingStatusWebhookForwardUrl && (
-                        <Field.Container>
-                          <Field.Root className="flex-row flex-wrap items-center">
-                            <Switch
-                              checked={isWebhookForwardingEnabled}
-                              onCheckedChange={updateIsWebhookForwardingEnabled}
-                            />
-                            <Field.Label>Forward events</Field.Label>
-                            {isWebhookForwardingEnabled && (
+                      <Field.Container>
+                        <Field.Root className="flex-row items-center">
+                          <Switch
+                            checked={isWebhookForwardingEnabled}
+                            onCheckedChange={updateIsWebhookForwardingEnabled}
+                          />
+                          <Field.Label>Forward webhooks</Field.Label>
+                        </Field.Root>
+                        {isWebhookForwardingEnabled && (
+                          <>
+                            <Field.Root>
+                              <Field.Label>Forwarded events</Field.Label>
                               <Select.Root
                                 multiple
                                 value={selectedWebhookForwardingEventTypes}
@@ -437,10 +490,31 @@ export const WhatsAppDeployDialog = ({
                                   </Select.Group>
                                 </Select.Content>
                               </Select.Root>
-                            )}
-                          </Field.Root>
-                        </Field.Container>
-                      )}
+                            </Field.Root>
+                            <Field.Root>
+                              <Field.Label>
+                                URL
+                                <MoreInfoTooltip>
+                                  The selected WhatsApp webhook events will be
+                                  forwarded to this URL.
+                                </MoreInfoTooltip>
+                              </Field.Label>
+                              <DebouncedTextInput
+                                type="url"
+                                inputMode="url"
+                                defaultValue={webhookForwardingUrl}
+                                placeholder="https://example.com/whatsapp-webhook"
+                                onValueChange={updateWebhookForwardingUrl}
+                              />
+                              <Field.Error
+                                match={isWebhookForwardingUrlInvalid}
+                              >
+                                Enter a valid HTTP(S) URL.
+                              </Field.Error>
+                            </Field.Root>
+                          </>
+                        )}
+                      </Field.Container>
                     </Accordion.Panel>
                   </Accordion.Item>
                 </Accordion.Root>

--- a/packages/scripts/src/updateWhatsAppStatusForwardUrl.ts
+++ b/packages/scripts/src/updateWhatsAppStatusForwardUrl.ts
@@ -1,6 +1,9 @@
 import * as p from "@clack/prompts";
 import prisma from "@typebot.io/prisma";
-import { settingsSchema } from "@typebot.io/settings/schemas";
+import {
+  settingsSchema,
+  whatsAppWebhookForwardingUrlSchema,
+} from "@typebot.io/settings/schemas";
 import { promptAndSetEnvironment } from "./utils";
 
 const updateWhatsAppStatusForwardUrl = async () => {
@@ -12,11 +15,8 @@ const updateWhatsAppStatusForwardUrl = async () => {
   const newUrl = await p.text({
     message: "New forward URL?",
     validate: (value) => {
-      try {
-        new URL(value);
-      } catch {
+      if (!whatsAppWebhookForwardingUrlSchema.safeParse(value).success)
         return "Invalid URL";
-      }
     },
   });
   if (!newUrl || p.isCancel(newUrl)) process.exit();

--- a/packages/settings/src/schemas.ts
+++ b/packages/settings/src/schemas.ts
@@ -75,22 +75,36 @@ export const whatsAppWebhookForwardingEventTypeSchema = z.enum([
 export type WhatsAppWebhookForwardingEventType = z.infer<
   typeof whatsAppWebhookForwardingEventTypeSchema
 >;
-
-export const whatsAppSettingsSchema = z.object({
-  isEnabled: z.boolean().optional(),
-  startCondition: startConditionSchema.optional(),
-  sessionExpiryTimeout: z
-    .number()
-    .max(48)
-    .min(0.01)
-    .optional()
-    .describe("Expiration delay in hours after latest interaction"),
-  errorAndMarketingStatusWebhookForwardUrl: z.string().url().optional(),
-  isWebhookForwardingEnabled: z.boolean().optional(),
-  webhookForwardingEventTypes: z
-    .array(whatsAppWebhookForwardingEventTypeSchema)
-    .optional(),
+export const whatsAppWebhookForwardingUrlSchema = z.url({
+  protocol: /^https?$/,
 });
+
+export const whatsAppSettingsSchema = z
+  .object({
+    isEnabled: z.boolean().optional(),
+    startCondition: startConditionSchema.optional(),
+    sessionExpiryTimeout: z
+      .number()
+      .max(48)
+      .min(0.01)
+      .optional()
+      .describe("Expiration delay in hours after latest interaction"),
+    errorAndMarketingStatusWebhookForwardUrl:
+      whatsAppWebhookForwardingUrlSchema.optional(),
+    isWebhookForwardingEnabled: z.boolean().optional(),
+    webhookForwardingEventTypes: z
+      .array(whatsAppWebhookForwardingEventTypeSchema)
+      .optional(),
+  })
+  .transform((whatsAppSettings) =>
+    whatsAppSettings.isWebhookForwardingEnabled !== undefined ||
+    !whatsAppSettings.errorAndMarketingStatusWebhookForwardUrl
+      ? whatsAppSettings
+      : {
+          ...whatsAppSettings,
+          isWebhookForwardingEnabled: true,
+        },
+  );
 
 export const settingsSchema = z.object({
   general: generalSettings.optional(),

--- a/packages/ui/src/components/DebouncedTextInput.tsx
+++ b/packages/ui/src/components/DebouncedTextInput.tsx
@@ -27,6 +27,10 @@ export const DebouncedTextInput = ({
       onValueChange={(value, eventDetails) => {
         commitValue(value, eventDetails);
       }}
+      onBlur={(event) => {
+        props.onBlur?.(event);
+        commitValue.flush();
+      }}
     />
   );
 };

--- a/packages/whatsapp/src/forwardWhatsAppWebhooks.test.ts
+++ b/packages/whatsapp/src/forwardWhatsAppWebhooks.test.ts
@@ -1,3 +1,4 @@
+import { settingsSchema } from "@typebot.io/settings/schemas";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildWhatsAppWebhookForwardingPayload,
@@ -179,22 +180,45 @@ describe("buildWhatsAppWebhookForwardingPayload", () => {
       "marketing-lite-status",
     ]);
   });
+});
 
-  it("keeps failure and marketing statuses for legacy forward URLs", () => {
+describe("settingsSchema", () => {
+  it("enables webhook forwarding for legacy URL-only configs", () => {
     expect(
-      getForwardedStatusIds(
-        buildWhatsAppWebhookForwardingPayload({
-          entry: rawPayload.entry,
-          rawPayload,
-          eventTypes: ["failedAndMarketingStatuses"],
-        }),
-      ),
-    ).toEqual([
-      "failed-status",
-      "errored-status",
-      "marketing-status",
-      "marketing-lite-status",
-    ]);
+      settingsSchema.parse({
+        whatsApp: {
+          errorAndMarketingStatusWebhookForwardUrl: "https://example.com",
+        },
+      }).whatsApp?.isWebhookForwardingEnabled,
+    ).toBe(true);
+  });
+
+  it("keeps webhook forwarding disabled when explicitly disabled", () => {
+    expect(
+      settingsSchema.parse({
+        whatsApp: {
+          errorAndMarketingStatusWebhookForwardUrl: "https://example.com",
+          isWebhookForwardingEnabled: false,
+        },
+      }).whatsApp?.isWebhookForwardingEnabled,
+    ).toBe(false);
+  });
+
+  it("rejects non HTTP(S) webhook forwarding URLs", () => {
+    expect(
+      settingsSchema.safeParse({
+        whatsApp: {
+          errorAndMarketingStatusWebhookForwardUrl: "ftp://example.com",
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      settingsSchema.safeParse({
+        whatsApp: {
+          errorAndMarketingStatusWebhookForwardUrl: "javascript:alert(1)",
+        },
+      }).success,
+    ).toBe(false);
   });
 });
 
@@ -296,6 +320,30 @@ describe("forwardWhatsAppWebhooks", () => {
     expect(mocks.safeKyPost).toHaveBeenCalledWith("https://example.com", {
       json: rawPayload,
     });
+  });
+
+  it("does not forward when webhook forwarding is enabled with no selected events", async () => {
+    mocks.publicTypebotFindMany.mockResolvedValue([
+      {
+        settings: {
+          whatsApp: {
+            isEnabled: true,
+            errorAndMarketingStatusWebhookForwardUrl: "https://example.com",
+            isWebhookForwardingEnabled: true,
+            webhookForwardingEventTypes: [],
+          },
+        },
+      },
+    ]);
+
+    await forwardWhatsAppWebhooks({
+      credentialsId: "credentials-id",
+      entry: rawPayload.entry,
+      rawPayload,
+      workspaceId: "workspace-id",
+    });
+
+    expect(mocks.safeKyPost).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/whatsapp/src/forwardWhatsAppWebhooks.ts
+++ b/packages/whatsapp/src/forwardWhatsAppWebhooks.ts
@@ -18,10 +18,7 @@ type IncomingChange =
   WhatsAppWebhookRequestBody["entry"][number]["changes"][number];
 type IncomingStatus = NonNullable<IncomingChange["value"]["statuses"]>[number];
 type StatusWebhookPayload = Pick<WhatsAppWebhookRequestBody, "entry">;
-type LegacyWebhookForwardingEventType = "failedAndMarketingStatuses";
-type WebhookForwardingEventType =
-  | WhatsAppWebhookForwardingEventType
-  | LegacyWebhookForwardingEventType;
+type WebhookForwardingEventType = WhatsAppWebhookForwardingEventType;
 
 type StatusRouteMatch = {
   entryIndex: number;
@@ -29,8 +26,6 @@ type StatusRouteMatch = {
   status: IncomingStatus;
 };
 
-const legacyWebhookForwardingEventType: LegacyWebhookForwardingEventType =
-  "failedAndMarketingStatuses";
 const defaultWebhookForwardingEventTypes = [
   "errorStatuses",
   "marketingStatuses",
@@ -120,14 +115,12 @@ const getForwardingConfigs = async ({
     const forwardingUrl =
       parsedSettings.data.whatsApp.errorAndMarketingStatusWebhookForwardUrl;
     if (!forwardingUrl) continue;
-    if (parsedSettings.data.whatsApp.isWebhookForwardingEnabled === false)
+    if (parsedSettings.data.whatsApp.isWebhookForwardingEnabled !== true)
       continue;
 
     const webhookForwardingEventTypes =
-      parsedSettings.data.whatsApp.isWebhookForwardingEnabled === true
-        ? (parsedSettings.data.whatsApp.webhookForwardingEventTypes ??
-          defaultWebhookForwardingEventTypes)
-        : [legacyWebhookForwardingEventType];
+      parsedSettings.data.whatsApp.webhookForwardingEventTypes ??
+      defaultWebhookForwardingEventTypes;
 
     const existingEventTypes = forwardingEventTypesByUrl.get(forwardingUrl);
     if (existingEventTypes) {
@@ -253,18 +246,9 @@ const shouldForwardStatus = ({
   status: IncomingStatus;
   eventTypes: WebhookForwardingEventType[];
 }) => {
-  const includesLegacyEventType = eventTypes.includes(
-    legacyWebhookForwardingEventType,
-  );
-  if (
-    (includesLegacyEventType || eventTypes.includes("errorStatuses")) &&
-    isFailedStatus(status)
-  )
+  if (eventTypes.includes("errorStatuses") && isFailedStatus(status))
     return true;
-  if (
-    (includesLegacyEventType || eventTypes.includes("marketingStatuses")) &&
-    isMarketingStatus(status)
-  )
+  if (eventTypes.includes("marketingStatuses") && isMarketingStatus(status))
     return true;
   return false;
 };


### PR DESCRIPTION
- Adds a WhatsApp webhook forwarding URL field directly in the deploy UI.
- Moves forwarding enablement to an explicit "Forward webhooks" switch and keeps forwarded events independent from that switch.
- Normalizes legacy URL-only settings through Zod while preserving explicit disabled configs.
- Restricts forwarding URLs to HTTP(S) and aligns the production update script with the shared schema.
- Flushes debounced URL inputs on blur and covers legacy, disabled, empty-event, and invalid-protocol cases in tests.
