### PR TITLE
🐛 Fix embed video overlay in preview

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -601,7 +601,7 @@
     },
     "packages/embeds/js": {
       "name": "@typebot.io/js",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "devDependencies": {
         "@ai-sdk/ui-utils": "^1.2.11",
         "@ark-ui/solid": "^5.19.0",
@@ -636,7 +636,7 @@
     },
     "packages/embeds/react": {
       "name": "@typebot.io/react",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "dependencies": {
         "@typebot.io/js": "workspace:*",
         "react": "^19.2.4",

--- a/packages/embeds/js/package.json
+++ b/packages/embeds/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/js",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Javascript library to display typebots on your website",
   "license": "FSL-1.1-ALv2",
   "type": "module",

--- a/packages/embeds/js/src/features/blocks/bubbles/video/components/VideoBubble.tsx
+++ b/packages/embeds/js/src/features/blocks/bubbles/video/components/VideoBubble.tsx
@@ -88,7 +88,7 @@ export const VideoBubble = (props: Props) => {
                   defaultVideoBubbleContent.areControlsDisplayed
                 }
                 class={cx(
-                  "p-4 focus:outline-none w-full z-10 text-fade-in rounded-md",
+                  "p-4 focus:outline-none w-full relative z-20 text-fade-in rounded-md",
                   isTyping() ? "opacity-0 h-8 @xs:h-9" : "opacity-100 h-auto",
                 )}
                 style={{
@@ -109,7 +109,7 @@ export const VideoBubble = (props: Props) => {
             >
               <div
                 class={cx(
-                  "p-4 z-10 text-fade-in w-full aspect-(--aspect-ratio)",
+                  "p-4 relative z-20 text-fade-in w-full aspect-(--aspect-ratio)",
                   isTyping() ? "opacity-0 h-8 @xs:h-9" : "opacity-100",
                   !props.content?.aspectRatio && "h-(--height)",
                 )}

--- a/packages/embeds/react/package.json
+++ b/packages/embeds/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/react",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Convenient library to display typebots on your React app",
   "license": "FSL-1.1-ALv2",
   "type": "module",


### PR DESCRIPTION
## Summary
- Keeps video bubbles above the absolute typing/background layer in the embedded chat renderer.
- Applies the same stacking approach to direct video URLs and embedded video iframes.
- Bumps `@typebot.io/js` and `@typebot.io/react` from `0.10.4` to `0.10.5`.

## Root cause
Chrome could place the full-size absolute `bubble-typing` layer over video bubbles because the media content shared the same stacking level. That made the overlay sit above the HTML video element in builder embed preview.

## Validation
- `bunx nx typecheck @typebot.io/react`
- `bunx nx build @typebot.io/react --configuration=development`
- `bunx nx format-and-lint`
- Commit hook: `nx affected -t format-and-lint,lint-repo,check-broken-links,test --parallel=4`

Note: I could not visually verify the exact provided local typebot URL in this workspace because it returns `Typebot not found` locally.