### PR TITLE
🐛 Fix S3 operations without full config

### DIFF
--- a/apps/builder/src/features/typebot/api/handleDeleteTypebot.ts
+++ b/apps/builder/src/features/typebot/api/handleDeleteTypebot.ts
@@ -1,5 +1,4 @@
 import { ORPCError } from "@orpc/server";
-import { env } from "@typebot.io/env";
 import { removeObjectsFromTypebot } from "@typebot.io/lib/s3/removeObjectsRecursively";
 import prisma from "@typebot.io/prisma";
 import { archiveResults } from "@typebot.io/results/archiveResults";
@@ -76,11 +75,10 @@ export const handleDeleteTypebot = async ({
     where: { id: typebotId },
     data: { isArchived: true, publicId: null, customDomain: null },
   });
-  if (env.S3_BUCKET)
-    await removeObjectsFromTypebot({
-      workspaceId: existingTypebot.workspace.id,
-      typebotId,
-    });
+  await removeObjectsFromTypebot({
+    workspaceId: existingTypebot.workspace.id,
+    typebotId,
+  });
   return {
     message: "success" as const,
   };

--- a/apps/builder/src/features/workspace/api/handleDeleteWorkspace.ts
+++ b/apps/builder/src/features/workspace/api/handleDeleteWorkspace.ts
@@ -35,7 +35,7 @@ export const handleDeleteWorkspace = async ({
     where: { id: workspaceId },
   });
 
-  if (env.S3_BUCKET) await removeObjectsFromWorkspace(workspaceId);
+  await removeObjectsFromWorkspace(workspaceId);
 
   if (isNotEmpty(workspace.stripeId) && env.STRIPE_SECRET_KEY) {
     const stripe = new Stripe(env.STRIPE_SECRET_KEY, {

--- a/packages/lib/src/s3/copyObjects.ts
+++ b/packages/lib/src/s3/copyObjects.ts
@@ -1,11 +1,13 @@
 import { env } from "@typebot.io/env";
 import { CopyConditions } from "minio";
 import { initClient } from "./initClient";
+import { isS3Configured } from "./isS3Configured";
 
 export const copyObjects = async (
   filesToCopy: { oldName: string; newName: string }[],
 ) => {
-  if (filesToCopy.length === 0) return;
+  if (filesToCopy.length === 0 || !isS3Configured()) return;
+
   const minioClient = initClient();
 
   const conds = new CopyConditions();

--- a/packages/lib/src/s3/isS3Configured.test.ts
+++ b/packages/lib/src/s3/isS3Configured.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { hasS3Config } from "./isS3Configured";
+
+describe("hasS3Config", () => {
+  it("does not treat the default bucket name as a complete S3 config", () => {
+    expect(hasS3Config({ S3_BUCKET: "typebot" })).toBe(false);
+  });
+
+  it("does not treat the endpoint as a complete S3 config", () => {
+    expect(hasS3Config({ S3_ENDPOINT: "localhost" })).toBe(false);
+  });
+
+  it("requires the bucket, endpoint, access key, and secret key", () => {
+    const config = {
+      S3_BUCKET: "typebot",
+      S3_ENDPOINT: "localhost",
+      S3_ACCESS_KEY: "minio",
+      S3_SECRET_KEY: "minio123",
+    };
+
+    expect(hasS3Config(config)).toBe(true);
+    expect(hasS3Config({ ...config, S3_BUCKET: "" })).toBe(false);
+    expect(hasS3Config({ ...config, S3_ENDPOINT: "" })).toBe(false);
+    expect(hasS3Config({ ...config, S3_ACCESS_KEY: "" })).toBe(false);
+    expect(hasS3Config({ ...config, S3_SECRET_KEY: "" })).toBe(false);
+  });
+});

--- a/packages/lib/src/s3/isS3Configured.ts
+++ b/packages/lib/src/s3/isS3Configured.ts
@@ -1,0 +1,23 @@
+import { env } from "@typebot.io/env";
+import { isNotEmpty } from "../utils";
+
+type S3Config = {
+  S3_BUCKET?: string;
+  S3_ENDPOINT?: string;
+  S3_ACCESS_KEY?: string;
+  S3_SECRET_KEY?: string;
+};
+
+export const hasS3Config = (config: S3Config) =>
+  isNotEmpty(config.S3_BUCKET) &&
+  isNotEmpty(config.S3_ENDPOINT) &&
+  isNotEmpty(config.S3_ACCESS_KEY) &&
+  isNotEmpty(config.S3_SECRET_KEY);
+
+export const isS3Configured = () =>
+  hasS3Config({
+    S3_BUCKET: env.S3_BUCKET,
+    S3_ENDPOINT: env.S3_ENDPOINT,
+    S3_ACCESS_KEY: env.S3_ACCESS_KEY,
+    S3_SECRET_KEY: env.S3_SECRET_KEY,
+  });

--- a/packages/lib/src/s3/removeObjectsRecursively.ts
+++ b/packages/lib/src/s3/removeObjectsRecursively.ts
@@ -1,7 +1,10 @@
 import { env } from "@typebot.io/env";
 import { initClient } from "./initClient";
+import { isS3Configured } from "./isS3Configured";
 
 const removeObjectsRecursively = async (prefix: string) => {
+  if (!isS3Configured()) return;
+
   const minioClient = initClient();
 
   const bucketName = env.S3_BUCKET;

--- a/packages/lib/src/s3/replaceTypebotUploadUrlsWithNewIds.ts
+++ b/packages/lib/src/s3/replaceTypebotUploadUrlsWithNewIds.ts
@@ -1,5 +1,6 @@
 import { env } from "@typebot.io/env";
 import { initClient } from "./initClient";
+import { isS3Configured } from "./isS3Configured";
 
 export const replaceTypebotUploadUrlsWithNewIds = async <
   T extends Partial<{
@@ -18,7 +19,7 @@ export const replaceTypebotUploadUrlsWithNewIds = async <
   typebot: T;
   filesToCopy: { oldName: string; newName: string }[];
 }> => {
-  if (!typebot.id || !typebot.workspaceId || !env.S3_ENDPOINT)
+  if (!typebot.id || !typebot.workspaceId || !isS3Configured())
     return {
       typebot,
       filesToCopy: [],

--- a/packages/results/src/archiveResults.ts
+++ b/packages/results/src/archiveResults.ts
@@ -1,4 +1,3 @@
-import { env } from "@typebot.io/env";
 import type { Group } from "@typebot.io/groups/schemas";
 import {
   removeAllObjectsFromResult,
@@ -104,7 +103,7 @@ export const archiveResults =
           },
         }),
       ]);
-      if (!isDeletingAllResults && env.S3_BUCKET) {
+      if (!isDeletingAllResults) {
         await removeObjectsFromResult({
           workspaceId: typebot.workspaceId,
           resultIds: resultIds,
@@ -113,7 +112,7 @@ export const archiveResults =
       }
     } while (currentTotalResults >= batchSize);
 
-    if (isDeletingAllResults && env.S3_BUCKET) {
+    if (isDeletingAllResults) {
       await removeAllObjectsFromResult({
         workspaceId: typebot.workspaceId,
         typebotId: typebot.id,


### PR DESCRIPTION
- Added a shared S3 config guard that requires bucket, endpoint, access key, and secret key.
- Skipped S3 copy, delete, and URL replacement operations when storage is not fully configured.
- Moved typebot, workspace, and results cleanup callers to rely on guarded S3 helpers.
- Added tests for incomplete and complete S3 config detection.