### PR TITLE
[codex] fix blog canonical URLs

### DIFF
--- a/apps/landing-page/src/routes/_layout/$slug.tsx
+++ b/apps/landing-page/src/routes/_layout/$slug.tsx
@@ -1,24 +1,39 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
 import codeSnippetsCssUrl from "@/assets/code-snippet.css?url";
 import { ContentPageWrapper } from "@/components/ContentPageWrapper";
+import { currentBaseUrl } from "@/constants";
 import { Mdx } from "@/features/blog/components/mdx";
 import { createMetaTags } from "@/lib/createMetaTags";
 
 export const Route = createFileRoute("/_layout/$slug")({
   loader: async ({ params }) => {
     const { allPosts } = await import("@/content-collections");
-    const post = allPosts.find((post) => post._meta.path.endsWith(params.slug));
+    const post = allPosts.find((post) => post._meta.path === params.slug);
 
-    if (!post) {
+    if (post) return { post };
+
+    if (
+      allPosts.some((post) => post._meta.path === `blog/${params.slug}`)
+    ) {
       throw redirect({
-        to: "/",
+        to: "/blog/$slug",
+        params: { slug: params.slug },
+        statusCode: 301,
       });
     }
 
-    return { post };
+    throw notFound();
   },
   head: ({ loaderData }) => ({
-    links: [{ rel: "stylesheet", href: codeSnippetsCssUrl }],
+    links: loaderData
+      ? [
+          { rel: "stylesheet", href: codeSnippetsCssUrl },
+          {
+            rel: "canonical",
+            href: `${currentBaseUrl}/${loaderData.post._meta.path}`,
+          },
+        ]
+      : [],
     meta: loaderData
       ? [
           ...createMetaTags({

--- a/apps/landing-page/src/routes/_layout/$slug.tsx
+++ b/apps/landing-page/src/routes/_layout/$slug.tsx
@@ -12,9 +12,7 @@ export const Route = createFileRoute("/_layout/$slug")({
 
     if (post) return { post };
 
-    if (
-      allPosts.some((post) => post._meta.path === `blog/${params.slug}`)
-    ) {
+    if (allPosts.some((post) => post._meta.path === `blog/${params.slug}`)) {
       throw redirect({
         to: "/blog/$slug",
         params: { slug: params.slug },

--- a/apps/landing-page/src/routes/_layout/blog/$slug.tsx
+++ b/apps/landing-page/src/routes/_layout/blog/$slug.tsx
@@ -1,8 +1,9 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, notFound } from "@tanstack/react-router";
 import { cx } from "@typebot.io/ui/lib/cva";
 import codeSnippetsCssUrl from "@/assets/code-snippet.css?url";
 import { ContentPageWrapper } from "@/components/ContentPageWrapper";
 import { TextLink } from "@/components/link";
+import { currentBaseUrl } from "@/constants";
 import { Mdx } from "@/features/blog/components/mdx";
 import { authors } from "@/features/blog/data/authors";
 import { formatDate } from "@/features/blog/helpers";
@@ -11,18 +12,26 @@ import { createMetaTags } from "@/lib/createMetaTags";
 export const Route = createFileRoute("/_layout/blog/$slug")({
   loader: async ({ params }) => {
     const { allPosts } = await import("@/content-collections");
-    const post = allPosts.find((post) => post._meta.path.endsWith(params.slug));
+    const post = allPosts.find(
+      (post) => post._meta.path === `blog/${params.slug}`,
+    );
 
     if (!post) {
-      throw redirect({
-        to: "/blog",
-      });
+      throw notFound();
     }
 
     return { post, author: authors[post.author as keyof typeof authors] };
   },
   head: ({ loaderData }) => ({
-    links: [{ rel: "stylesheet", href: codeSnippetsCssUrl }],
+    links: loaderData
+      ? [
+          { rel: "stylesheet", href: codeSnippetsCssUrl },
+          {
+            rel: "canonical",
+            href: `${currentBaseUrl}/${loaderData.post._meta.path}`,
+          },
+        ]
+      : [],
     meta: loaderData
       ? [
           ...createMetaTags({

--- a/apps/landing-page/src/routes/_layout/blog/index.tsx
+++ b/apps/landing-page/src/routes/_layout/blog/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { isDefined } from "@typebot.io/lib/utils";
 import { Card } from "@/components/Card";
 import { ContentPageWrapper } from "@/components/ContentPageWrapper";
+import { currentBaseUrl } from "@/constants";
 import { formatDate } from "@/features/blog/helpers";
 import { createMetaTags } from "@/lib/createMetaTags";
 
@@ -18,6 +19,7 @@ export const Route = createFileRoute("/_layout/blog/")({
     };
   },
   head: () => ({
+    links: [{ rel: "canonical", href: `${currentBaseUrl}/blog` }],
     meta: createMetaTags({
       title: "Typebot Blog",
       description:


### PR DESCRIPTION
## What changed

- add self-referencing apex canonical URLs to blog articles and the `/blog` index
- add canonical URLs to root-level content pages
- permanently redirect legacy root-level blog URLs to `/blog/<slug>`
- match content paths exactly instead of by suffix
- return real 404 responses for unknown root, blog, and nested legacy URLs

## Why

Blog content was available at both `/<slug>` and `/blog/<slug>` without a user-selected canonical. Google Search Console consequently reported duplicate `www` and apex URLs and selected canonicals itself.

The canonical blog URLs are now `https://typebot.com/blog` and `https://typebot.com/blog/<slug>`. Duplicate root article URLs consolidate through a permanent redirect, while removed or unknown URLs no longer redirect to unrelated pages and create soft-404 signals.

## Validation

- `bunx nx format-and-lint`
- `bunx nx build landing-page`
- commit hook passed affected formatting, repository lint, broken-link, and test targets
- GitHub typecheck and CodeQL checks passed
- locally verified:
  - `/blog` and article pages render apex self-canonicals
  - `/<article-slug>` returns a 301 to `/blog/<article-slug>`
  - unknown root, blog, and nested legacy URLs return HTTP 404
