### PR TITLE
🐛 Fix WhatsApp audio upload URLs

### DIFF
--- a/packages/bot-engine/src/continueBotFlow.ts
+++ b/packages/bot-engine/src/continueBotFlow.ts
@@ -27,7 +27,7 @@ import type { ForgedBlock } from "@typebot.io/forge-repository/schemas";
 import { getBlockById } from "@typebot.io/groups/helpers/getBlockById";
 import type { Group } from "@typebot.io/groups/schemas";
 import { parseUnknownError } from "@typebot.io/lib/parseUnknownError";
-import { byId, isDefined, isNotDefined } from "@typebot.io/lib/utils";
+import { byId, isNotDefined } from "@typebot.io/lib/utils";
 import type { AnswerInSessionState } from "@typebot.io/results/schemas/answers";
 import type { SessionStore } from "@typebot.io/runtime-session-store";
 import { defaultSystemMessages } from "@typebot.io/settings/constants";
@@ -198,16 +198,17 @@ export const continueBotFlow = async (
 
     const formattedReply =
       "content" in parsedReplyResult && reply?.type === "text"
-        ? parsedReplyResult.content
+        ? {
+            ...reply,
+            text: parsedReplyResult.content,
+            attachedFileUrls:
+              parsedReplyResult.attachedFileUrls ?? reply.attachedFileUrls,
+          }
         : undefined;
     newSessionState = await processAndSaveAnswer(
       newSessionState,
       block,
-    )(
-      isDefined(formattedReply)
-        ? { ...reply, type: "text", text: formattedReply }
-        : reply,
-    );
+    )(formattedReply ?? reply);
     continueReply = parsedReplyResult;
   }
 

--- a/packages/bot-engine/src/types.ts
+++ b/packages/bot-engine/src/types.ts
@@ -26,6 +26,7 @@ export type ExecuteIntegrationResponse = {
 export type SuccessReply = {
   status: "success";
   content: string;
+  attachedFileUrls?: string[];
   outgoingEdgeId?: string;
   variablesToUpdate?: VariableWithUnknowValue[];
 };

--- a/packages/bot-engine/src/validateAndParseInputMessage.test.ts
+++ b/packages/bot-engine/src/validateAndParseInputMessage.test.ts
@@ -34,6 +34,63 @@ describe("validateAndParseInputMessage", () => {
       status: "success",
       content:
         "https://files.example.com/audio-media-id.ogg, https://files.example.com/second-audio-media-id.ogg",
+      attachedFileUrls: [
+        "https://files.example.com/audio-media-id.ogg",
+        "https://files.example.com/second-audio-media-id.ogg",
+      ],
+    });
+  });
+
+  it("preserves commas inside file input text URLs", () => {
+    const block = {
+      id: "file-input",
+      type: InputBlockType.FILE,
+    } satisfies InputBlock;
+
+    const result = validateAndParseInputMessage(
+      {
+        type: "text",
+        text: "https://files.example.com/a,b.pdf",
+      },
+      {
+        block,
+        sessionStore: new SessionStore(),
+        variables: [],
+      },
+    );
+
+    expect(result).toEqual({
+      status: "success",
+      content: "https://files.example.com/a,b.pdf",
+    });
+  });
+
+  it("only keeps the first structured attachment for single file inputs", () => {
+    const block = {
+      id: "file-input",
+      type: InputBlockType.FILE,
+    } satisfies InputBlock;
+
+    const result = validateAndParseInputMessage(
+      {
+        type: "text",
+        text: "",
+        attachedFileUrls: [
+          "https://files.example.com/audio-media-id.ogg",
+          "https://files.example.com/second-audio-media-id.ogg",
+        ],
+      },
+      {
+        block,
+        sessionStore: new SessionStore(),
+        variables: [],
+      },
+    );
+
+    expect(result).toEqual({
+      status: "success",
+      content: "https://files.example.com/audio-media-id.ogg",
+      attachedFileUrls: ["https://files.example.com/audio-media-id.ogg"],
     });
   });
 });

--- a/packages/bot-engine/src/validateAndParseInputMessage.test.ts
+++ b/packages/bot-engine/src/validateAndParseInputMessage.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { InputBlockType } from "@typebot.io/blocks-inputs/constants";
+import type { InputBlock } from "@typebot.io/blocks-inputs/schema";
+import { SessionStore } from "@typebot.io/runtime-session-store";
+import { validateAndParseInputMessage } from "./validateAndParseInputMessage";
+
+describe("validateAndParseInputMessage", () => {
+  it("prefers structured attached file URLs for file inputs", () => {
+    const block = {
+      id: "file-input",
+      type: InputBlockType.FILE,
+      options: {
+        isMultipleAllowed: true,
+      },
+    } satisfies InputBlock;
+
+    const result = validateAndParseInputMessage(
+      {
+        type: "text",
+        text: "",
+        attachedFileUrls: [
+          "https://files.example.com/audio-media-id.ogg",
+          "https://files.example.com/second-audio-media-id.ogg",
+        ],
+      },
+      {
+        block,
+        sessionStore: new SessionStore(),
+        variables: [],
+      },
+    );
+
+    expect(result).toEqual({
+      status: "success",
+      content:
+        "https://files.example.com/audio-media-id.ogg, https://files.example.com/second-audio-media-id.ogg",
+    });
+  });
+});

--- a/packages/bot-engine/src/validateAndParseInputMessage.ts
+++ b/packages/bot-engine/src/validateAndParseInputMessage.ts
@@ -100,16 +100,21 @@ export const validateAndParseInputMessage = (
           ? { status: "fail" }
           : { status: "skip" };
 
+      const hasStructuredAttachedFileUrls =
+        message.type === "text" && (message.attachedFileUrls?.length ?? 0) > 0;
       const urls =
         message.type === "text" &&
         message.attachedFileUrls &&
         message.attachedFileUrls.length > 0
           ? message.attachedFileUrls
           : (message.type === "audio" ? message.url : message.text)
-              .split(/,\s*|\n+/)
+              .split(/,\s+|\n+/)
               .map((url) => url.trim())
               .filter((url) => url !== "");
-      const replyValue = urls.join(", ");
+      const acceptedUrls = block.options?.isMultipleAllowed
+        ? urls
+        : urls.slice(0, 1);
+      const replyValue = acceptedUrls.join(", ");
       const isTrustedHost = (url: string) => {
         try {
           const { hostname } = new URL(url);
@@ -129,7 +134,7 @@ export const validateAndParseInputMessage = (
           return false;
         }
       };
-      const hasValidUrls = urls.some((url) =>
+      const hasValidUrls = acceptedUrls.some((url) =>
         isURL(url, { require_tld: !isTrustedHost(url) }),
       );
 
@@ -140,7 +145,7 @@ export const validateAndParseInputMessage = (
           ? parseAllowedFileTypesMetadata(block.options.allowedFileTypes.types)
           : undefined;
       const allFilesAreAllowed = allowedFileTypesMetadata
-        ? urls.every((url) => {
+        ? acceptedUrls.every((url) => {
             const extension = url.split(".").pop();
             if (!extension) return false;
             return allowedFileTypesMetadata.some(
@@ -151,9 +156,16 @@ export const validateAndParseInputMessage = (
         : true;
 
       const status = hasValidUrls && allFilesAreAllowed ? "success" : "fail";
-      if (!block.options?.isMultipleAllowed && urls.length > 1)
-        return { status, content: urls[0] };
-      return { status, content: replyValue };
+      if (!hasStructuredAttachedFileUrls)
+        return {
+          status,
+          content: replyValue,
+        };
+      return {
+        status,
+        content: replyValue,
+        attachedFileUrls: acceptedUrls,
+      };
     }
     case InputBlockType.PAYMENT: {
       if (!message || message.type !== "text") return { status: "fail" };

--- a/packages/bot-engine/src/validateAndParseInputMessage.ts
+++ b/packages/bot-engine/src/validateAndParseInputMessage.ts
@@ -100,8 +100,16 @@ export const validateAndParseInputMessage = (
           ? { status: "fail" }
           : { status: "skip" };
 
-      const replyValue = message.type === "audio" ? message.url : message.text;
-      const urls = replyValue.split(", ");
+      const urls =
+        message.type === "text" &&
+        message.attachedFileUrls &&
+        message.attachedFileUrls.length > 0
+          ? message.attachedFileUrls
+          : (message.type === "audio" ? message.url : message.text)
+              .split(/,\s*|\n+/)
+              .map((url) => url.trim())
+              .filter((url) => url !== "");
+      const replyValue = urls.join(", ");
       const isTrustedHost = (url: string) => {
         try {
           const { hostname } = new URL(url);
@@ -144,7 +152,7 @@ export const validateAndParseInputMessage = (
 
       const status = hasValidUrls && allFilesAreAllowed ? "success" : "fail";
       if (!block.options?.isMultipleAllowed && urls.length > 1)
-        return { status, content: replyValue.split(",")[0] };
+        return { status, content: urls[0] };
       return { status, content: replyValue };
     }
     case InputBlockType.PAYMENT: {

--- a/packages/chat-api/src/schemas.ts
+++ b/packages/chat-api/src/schemas.ts
@@ -38,7 +38,7 @@ export const textMessageSchema = z.object({
     .array(z.string())
     .optional()
     .describe(
-      "Can only be provided if current input block is a text input block that allows attachments",
+      "Can only be provided if current input block is a file input block or a text input block that allows attachments",
     ),
 });
 

--- a/packages/whatsapp/src/resumeWhatsAppFlow.test.ts
+++ b/packages/whatsapp/src/resumeWhatsAppFlow.test.ts
@@ -68,6 +68,16 @@ const textInputWithAudioClipBlock = {
   },
 } satisfies Block;
 
+const textInputWithPrivateAudioClipBlock = {
+  id: "text-input",
+  type: InputBlockType.TEXT,
+  options: {
+    audioClip: {
+      isEnabled: true,
+    },
+  },
+} satisfies Block;
+
 const textInputWithAttachmentsBlock = {
   id: "text-input",
   type: InputBlockType.TEXT,
@@ -230,6 +240,50 @@ describe("convertWhatsAppMessageToTypebotMessage", () => {
     expect(result).toEqual({
       type: "audio",
       url: "https://files.example.com/audio-media-id.ogg",
+    });
+  });
+
+  it("builds private WhatsApp audio clip URLs with the provided typebot id", async () => {
+    const result = await convertWhatsAppMessageToTypebotMessage({
+      messages: [audioMessage],
+      credentials,
+      workspaceId: "workspace-id",
+      typebotId: "typebot-id",
+      resultId: "result-id",
+      block: textInputWithPrivateAudioClipBlock,
+    });
+
+    expect(result).toEqual({
+      type: "audio",
+      url: expect.stringContaining(
+        "/api/typebots/typebot-id/whatsapp/media/audio-media-id.ogg",
+      ),
+    });
+    expect(mocks.downloadMedia).not.toHaveBeenCalled();
+    expect(mocks.uploadFileToBucket).not.toHaveBeenCalled();
+  });
+
+  it("uploads private WhatsApp audio clips when no typebot id is available", async () => {
+    mocks.uploadFileToBucket.mockResolvedValue(
+      "https://app.example.com/api/s3/private/tmp/whatsapp/media/audio-media-id.ogg",
+    );
+
+    const result = await convertWhatsAppMessageToTypebotMessage({
+      messages: [audioMessage],
+      credentials,
+      workspaceId: "workspace-id",
+      block: textInputWithPrivateAudioClipBlock,
+    });
+
+    expect(result).toEqual({
+      type: "audio",
+      url: "https://app.example.com/api/s3/private/tmp/whatsapp/media/audio-media-id.ogg",
+    });
+    expect(mocks.uploadFileToBucket).toHaveBeenCalledWith({
+      file: Buffer.from("audio"),
+      key: "tmp/whatsapp/media/audio-media-id.ogg",
+      mimeType: "audio/ogg",
+      visibility: "private",
     });
   });
 

--- a/packages/whatsapp/src/resumeWhatsAppFlow.test.ts
+++ b/packages/whatsapp/src/resumeWhatsAppFlow.test.ts
@@ -1,0 +1,253 @@
+import type { Block } from "@typebot.io/blocks-core/schemas/schema";
+import { InputBlockType } from "@typebot.io/blocks-inputs/constants";
+import type { WhatsAppCredentials } from "@typebot.io/credentials/schemas";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  convertWhatsAppMessageToTypebotMessage,
+  getIncomingMediaReplyTarget,
+  shouldAggregateIncomingMediaMessages,
+} from "./resumeWhatsAppFlow";
+import type { WhatsAppIncomingMessage } from "./schemas";
+
+const mocks = vi.hoisted(() => ({
+  downloadMedia: vi.fn(),
+  uploadFileToBucket: vi.fn(),
+}));
+
+vi.mock("./downloadMedia", () => ({
+  downloadMedia: mocks.downloadMedia,
+}));
+
+vi.mock("@typebot.io/lib/s3/uploadFileToBucket", () => ({
+  uploadFileToBucket: mocks.uploadFileToBucket,
+}));
+
+const credentials = {
+  provider: "meta",
+  systemUserAccessToken: "token",
+  phoneNumberId: "phone-number-id",
+} satisfies WhatsAppCredentials["data"];
+
+const audioMessage = {
+  from: "33612345678",
+  id: "whatsapp-message-id",
+  timestamp: "1710000000",
+  type: "audio",
+  audio: {
+    id: "audio-media-id",
+    mime_type: "audio/ogg",
+  },
+} satisfies WhatsAppIncomingMessage;
+
+const secondAudioMessage = {
+  ...audioMessage,
+  id: "second-whatsapp-message-id",
+  audio: {
+    id: "second-audio-media-id",
+    mime_type: "audio/ogg",
+  },
+} satisfies WhatsAppIncomingMessage;
+
+const fileInputBlock = {
+  id: "file-input",
+  type: InputBlockType.FILE,
+  options: {
+    variableId: "file-variable-id",
+    visibility: "Public",
+  },
+} satisfies Block;
+
+const textInputWithAudioClipBlock = {
+  id: "text-input",
+  type: InputBlockType.TEXT,
+  options: {
+    audioClip: {
+      isEnabled: true,
+      visibility: "Public",
+    },
+  },
+} satisfies Block;
+
+const textInputWithAttachmentsBlock = {
+  id: "text-input",
+  type: InputBlockType.TEXT,
+  options: {
+    attachments: {
+      isEnabled: true,
+      visibility: "Public",
+    },
+  },
+} satisfies Block;
+
+describe("getIncomingMediaReplyTarget", () => {
+  it("routes WhatsApp audio from file inputs to the file upload path", () => {
+    expect(
+      getIncomingMediaReplyTarget({
+        block: fileInputBlock,
+        messageType: "audio",
+      }),
+    ).toEqual({ kind: "fileInput", visibility: "Public" });
+  });
+
+  it("routes WhatsApp audio from text inputs to audio clips when enabled", () => {
+    expect(
+      getIncomingMediaReplyTarget({
+        block: textInputWithAudioClipBlock,
+        messageType: "audio",
+      }),
+    ).toEqual({ kind: "audioClip", visibility: "Public" });
+  });
+
+  it("routes WhatsApp audio from text inputs to attachments when only attachments are enabled", () => {
+    expect(
+      getIncomingMediaReplyTarget({
+        block: textInputWithAttachmentsBlock,
+        messageType: "audio",
+      }),
+    ).toEqual({ kind: "textAttachment", visibility: "Public" });
+  });
+});
+
+describe("shouldAggregateIncomingMediaMessages", () => {
+  it("aggregates WhatsApp audio only when the current input will keep it as uploaded media", () => {
+    expect(
+      shouldAggregateIncomingMediaMessages({
+        block: fileInputBlock,
+        messageType: "audio",
+      }),
+    ).toBe(true);
+    expect(
+      shouldAggregateIncomingMediaMessages({
+        block: textInputWithAttachmentsBlock,
+        messageType: "audio",
+      }),
+    ).toBe(true);
+    expect(
+      shouldAggregateIncomingMediaMessages({
+        block: textInputWithAudioClipBlock,
+        messageType: "audio",
+      }),
+    ).toBe(false);
+  });
+
+  it("aggregates all non-audio WhatsApp media types", () => {
+    expect(
+      shouldAggregateIncomingMediaMessages({
+        messageType: "document",
+      }),
+    ).toBe(true);
+    expect(
+      shouldAggregateIncomingMediaMessages({
+        messageType: "image",
+      }),
+    ).toBe(true);
+    expect(
+      shouldAggregateIncomingMediaMessages({
+        messageType: "sticker",
+      }),
+    ).toBe(true);
+    expect(
+      shouldAggregateIncomingMediaMessages({
+        messageType: "video",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("convertWhatsAppMessageToTypebotMessage", () => {
+  beforeEach(() => {
+    mocks.downloadMedia.mockReset();
+    mocks.uploadFileToBucket.mockReset();
+    mocks.downloadMedia.mockResolvedValue({
+      file: Buffer.from("audio"),
+      mimeType: "audio/ogg",
+    });
+    mocks.uploadFileToBucket.mockResolvedValue(
+      "https://files.example.com/audio-media-id.ogg",
+    );
+  });
+
+  it("converts WhatsApp audio to a public file URL for file upload inputs", async () => {
+    const result = await convertWhatsAppMessageToTypebotMessage({
+      messages: [audioMessage],
+      credentials,
+      workspaceId: "workspace-id",
+      typebotId: "typebot-id",
+      resultId: "result-id",
+      block: fileInputBlock,
+    });
+
+    expect(result).toEqual({
+      type: "text",
+      text: "",
+      attachedFileUrls: ["https://files.example.com/audio-media-id.ogg"],
+      metadata: { replyId: undefined },
+    });
+    expect(mocks.uploadFileToBucket).toHaveBeenCalledWith({
+      file: Buffer.from("audio"),
+      key: "public/workspaces/workspace-id/typebots/typebot-id/results/result-id/audio-media-id.ogg",
+      mimeType: "audio/ogg",
+    });
+  });
+
+  it("keeps multiple WhatsApp audio uploads as structured file URLs for file upload inputs", async () => {
+    mocks.uploadFileToBucket
+      .mockResolvedValueOnce("https://files.example.com/audio-media-id.ogg")
+      .mockResolvedValueOnce(
+        "https://files.example.com/second-audio-media-id.ogg",
+      );
+
+    const result = await convertWhatsAppMessageToTypebotMessage({
+      messages: [audioMessage, secondAudioMessage],
+      credentials,
+      workspaceId: "workspace-id",
+      typebotId: "typebot-id",
+      resultId: "result-id",
+      block: fileInputBlock,
+    });
+
+    expect(result).toEqual({
+      type: "text",
+      text: "",
+      attachedFileUrls: [
+        "https://files.example.com/audio-media-id.ogg",
+        "https://files.example.com/second-audio-media-id.ogg",
+      ],
+      metadata: { replyId: undefined },
+    });
+  });
+
+  it("keeps WhatsApp audio as an audio reply for text inputs allowing audio clips", async () => {
+    const result = await convertWhatsAppMessageToTypebotMessage({
+      messages: [audioMessage],
+      credentials,
+      workspaceId: "workspace-id",
+      typebotId: "typebot-id",
+      resultId: "result-id",
+      block: textInputWithAudioClipBlock,
+    });
+
+    expect(result).toEqual({
+      type: "audio",
+      url: "https://files.example.com/audio-media-id.ogg",
+    });
+  });
+
+  it("converts WhatsApp audio to an attachment for text inputs allowing attachments", async () => {
+    const result = await convertWhatsAppMessageToTypebotMessage({
+      messages: [audioMessage],
+      credentials,
+      workspaceId: "workspace-id",
+      typebotId: "typebot-id",
+      resultId: "result-id",
+      block: textInputWithAttachmentsBlock,
+    });
+
+    expect(result).toEqual({
+      type: "text",
+      text: "",
+      attachedFileUrls: ["https://files.example.com/audio-media-id.ogg"],
+      metadata: { replyId: undefined },
+    });
+  });
+});

--- a/packages/whatsapp/src/resumeWhatsAppFlow.ts
+++ b/packages/whatsapp/src/resumeWhatsAppFlow.ts
@@ -131,8 +131,10 @@ export const resumeWhatsAppFlow = async ({
     isDefined(session.state.expiryTimeout) &&
     session?.updatedAt.getTime() + session.state.expiryTimeout < Date.now();
 
-  const currentTypebot = !isSessionExpired
-    ? session?.state?.typebotsQueue[0].typebot
+  const sessionTypebot = session?.state?.typebotsQueue[0].typebot;
+  const currentTypebot = !isSessionExpired ? sessionTypebot : undefined;
+  const currentResultId = !isSessionExpired
+    ? session?.state?.typebotsQueue[0].resultId
     : undefined;
   const { block } =
     (currentTypebot && session?.state?.currentBlockId
@@ -161,8 +163,8 @@ export const resumeWhatsAppFlow = async ({
     messages: aggregationResponse.incomingMessages,
     workspaceId,
     credentials,
-    typebotId: currentTypebot?.id,
-    resultId: session?.state?.typebotsQueue[0].resultId,
+    typebotId: sessionTypebot?.id,
+    resultId: currentResultId,
     block,
   });
 
@@ -291,8 +293,9 @@ export const convertWhatsAppMessageToTypebotMessage = async ({
           block,
           messageType: message.type,
         });
+        if (mediaReplyTarget.kind === "ignored") break;
         let fileUrl: string;
-        if (mediaReplyTarget.visibility !== "Public") {
+        if (mediaReplyTarget.visibility !== "Public" && typebotId) {
           const extension = mimeType
             ? extensionFromMimeType[mimeType]
             : undefined;
@@ -307,14 +310,23 @@ export const convertWhatsAppMessageToTypebotMessage = async ({
             credentials,
           });
           const extension = extensionFromMimeType[mimeType];
-          const url = await uploadFileToBucket({
-            file,
-            key:
-              resultId && workspaceId && typebotId
-                ? `public/workspaces/${workspaceId}/typebots/${typebotId}/results/${resultId}/${mediaId}${extension ? `.${extension}` : ""}`
-                : `tmp/whatsapp/media/${mediaId}${extension ? `.${extension}` : ""}`,
-            mimeType,
-          });
+          const key =
+            resultId && workspaceId && typebotId
+              ? `public/workspaces/${workspaceId}/typebots/${typebotId}/results/${resultId}/${mediaId}${extension ? `.${extension}` : ""}`
+              : `tmp/whatsapp/media/${mediaId}${extension ? `.${extension}` : ""}`;
+          const url =
+            mediaReplyTarget.visibility === "Public"
+              ? await uploadFileToBucket({
+                  file,
+                  key,
+                  mimeType,
+                })
+              : await uploadFileToBucket({
+                  file,
+                  key,
+                  mimeType,
+                  visibility: "private",
+                });
           fileUrl = url;
         }
 

--- a/packages/whatsapp/src/resumeWhatsAppFlow.ts
+++ b/packages/whatsapp/src/resumeWhatsAppFlow.ts
@@ -1,5 +1,6 @@
 import type { Block } from "@typebot.io/blocks-core/schemas/schema";
 import { InputBlockType } from "@typebot.io/blocks-inputs/constants";
+import type { FileInputBlock } from "@typebot.io/blocks-inputs/file/schema";
 import { continueBotFlow } from "@typebot.io/bot-engine/continueBotFlow";
 import { saveStateToDatabase } from "@typebot.io/bot-engine/saveStateToDatabase";
 import type { Message } from "@typebot.io/chat-api/schemas";
@@ -44,6 +45,23 @@ type Props = {
   referral?: WhatsAppMessageReferral;
   callFrom?: "webhook";
 };
+
+type IncomingMediaMessage = Extract<
+  WhatsAppIncomingMessage,
+  { type: "audio" | "document" | "image" | "sticker" | "video" }
+>;
+
+type IncomingMediaType = IncomingMediaMessage["type"];
+
+type FileVisibility = NonNullable<
+  NonNullable<FileInputBlock["options"]>["visibility"]
+>;
+
+type IncomingMediaReplyTarget =
+  | { kind: "audioClip"; visibility?: FileVisibility }
+  | { kind: "fileInput"; visibility?: FileVisibility }
+  | { kind: "ignored"; visibility?: undefined }
+  | { kind: "textAttachment"; visibility?: FileVisibility };
 
 const areMessagesTooOld = (receivedMessages: WhatsAppIncomingMessage[]) => {
   return receivedMessages.every(
@@ -108,19 +126,28 @@ export const resumeWhatsAppFlow = async ({
     }
   }
 
-  const aggregationResponse =
-    await aggregateParallelMediaMessagesIfRedisEnabled({
-      receivedMessages,
-      sessionId,
-    });
-
-  if (aggregationResponse.status === "found newer message")
-    throw new WhatsAppError("Found newer message, skipping this one");
-
   const isSessionExpired =
     isDefined(session?.state) &&
     isDefined(session.state.expiryTimeout) &&
     session?.updatedAt.getTime() + session.state.expiryTimeout < Date.now();
+
+  const currentTypebot = !isSessionExpired
+    ? session?.state?.typebotsQueue[0].typebot
+    : undefined;
+  const { block } =
+    (currentTypebot && session?.state?.currentBlockId
+      ? getBlockById(session.state.currentBlockId, currentTypebot.groups)
+      : undefined) ?? {};
+
+  const aggregationResponse =
+    await aggregateParallelMediaMessagesIfRedisEnabled({
+      receivedMessages,
+      sessionId,
+      block,
+    });
+
+  if (aggregationResponse.status === "found newer message")
+    throw new WhatsAppError("Found newer message, skipping this one");
 
   if (!isSessionExpired && session?.isReplying && callFrom !== "webhook")
     throw new WhatsAppError("Is in reply state");
@@ -130,11 +157,6 @@ export const resumeWhatsAppFlow = async ({
     });
   }
 
-  const currentTypebot = session?.state?.typebotsQueue[0].typebot;
-  const { block } =
-    (currentTypebot && session?.state?.currentBlockId
-      ? getBlockById(session.state.currentBlockId, currentTypebot.groups)
-      : undefined) ?? {};
   const reply = await convertWhatsAppMessageToTypebotMessage({
     messages: aggregationResponse.incomingMessages,
     workspaceId,
@@ -190,7 +212,7 @@ export const resumeWhatsAppFlow = async ({
   });
 };
 
-const convertWhatsAppMessageToTypebotMessage = async ({
+export const convertWhatsAppMessageToTypebotMessage = async ({
   messages,
   workspaceId,
   credentials,
@@ -265,18 +287,12 @@ const convertWhatsAppMessageToTypebotMessage = async ({
         }
         if (!mediaId) continue;
 
-        const fileVisibility =
-          block?.type === InputBlockType.TEXT &&
-          block.options?.audioClip?.isEnabled &&
-          message.type === "audio"
-            ? block.options?.audioClip.visibility
-            : block?.type === InputBlockType.FILE
-              ? block.options?.visibility
-              : block?.type === InputBlockType.TEXT
-                ? block.options?.attachments?.visibility
-                : undefined;
+        const mediaReplyTarget = getIncomingMediaReplyTarget({
+          block,
+          messageType: message.type,
+        });
         let fileUrl: string;
-        if (fileVisibility !== "Public") {
+        if (mediaReplyTarget.visibility !== "Public") {
           const extension = mimeType
             ? extensionFromMimeType[mimeType]
             : undefined;
@@ -301,14 +317,15 @@ const convertWhatsAppMessageToTypebotMessage = async ({
           });
           fileUrl = url;
         }
-        if (message.type === "audio")
+
+        if (mediaReplyTarget.kind === "audioClip")
           return {
             type: "audio",
             url: fileUrl,
           };
-        if (block?.type === InputBlockType.FILE) {
-          append(fileUrl);
-        } else if (block?.type === InputBlockType.TEXT) {
+        if (mediaReplyTarget.kind === "fileInput") {
+          attachedFileUrls.push(fileUrl);
+        } else if (mediaReplyTarget.kind === "textAttachment") {
           let caption: string | undefined;
           if (message.type === "document" && message.document.caption) {
             const looksLikeFilename = /^[\w,\s-]+\.[A-Za-z0-9]{1,10}$/;
@@ -340,6 +357,36 @@ const convertWhatsAppMessageToTypebotMessage = async ({
     text,
     attachedFileUrls,
     metadata: { replyId },
+  };
+};
+
+export const getIncomingMediaReplyTarget = ({
+  block,
+  messageType,
+}: {
+  block?: Block;
+  messageType: IncomingMediaType;
+}): IncomingMediaReplyTarget => {
+  if (block?.type === InputBlockType.FILE)
+    return { kind: "fileInput", visibility: block.options?.visibility };
+
+  if (block?.type !== InputBlockType.TEXT)
+    return messageType === "audio"
+      ? { kind: "audioClip" }
+      : { kind: "ignored" };
+
+  if (messageType === "audio" && block.options?.audioClip?.isEnabled === true)
+    return {
+      kind: "audioClip",
+      visibility: block.options.audioClip.visibility,
+    };
+
+  if (messageType === "audio" && block.options?.attachments?.isEnabled !== true)
+    return { kind: "audioClip" };
+
+  return {
+    kind: "textAttachment",
+    visibility: block.options?.attachments?.visibility,
   };
 };
 
@@ -383,9 +430,11 @@ const getWhatsAppCredentials = async ({
 const aggregateParallelMediaMessagesIfRedisEnabled = async ({
   receivedMessages,
   sessionId,
+  block,
 }: {
   receivedMessages: WhatsAppIncomingMessage[];
   sessionId: string;
+  block?: Block;
 }): Promise<
   | {
       status: "treat as unique message";
@@ -401,7 +450,10 @@ const aggregateParallelMediaMessagesIfRedisEnabled = async ({
 > => {
   if (
     redis &&
-    ["document", "video", "image"].includes(receivedMessages[0].type)
+    shouldAggregateIncomingMediaMessages({
+      block,
+      messageType: receivedMessages[0].type,
+    })
   ) {
     const redisKey = `wasession:${sessionId}`;
     try {
@@ -447,6 +499,30 @@ const aggregateParallelMediaMessagesIfRedisEnabled = async ({
     incomingMessages: receivedMessages,
   };
 };
+
+export const shouldAggregateIncomingMediaMessages = ({
+  block,
+  messageType,
+}: {
+  block?: Block;
+  messageType: WhatsAppIncomingMessage["type"];
+}) => {
+  if (!isIncomingMediaType(messageType)) return false;
+  if (messageType !== "audio") return true;
+
+  return (
+    getIncomingMediaReplyTarget({ block, messageType }).kind !== "audioClip"
+  );
+};
+
+const isIncomingMediaType = (
+  messageType: WhatsAppIncomingMessage["type"],
+): messageType is IncomingMediaType =>
+  messageType === "audio" ||
+  messageType === "document" ||
+  messageType === "image" ||
+  messageType === "sticker" ||
+  messageType === "video";
 
 const resumeFlowAndSendWhatsAppMessages = async (props: {
   to: string;


### PR DESCRIPTION
- Route incoming WhatsApp media by the active input block so audio can be handled as a File Upload, text attachment, or audio clip.
- Save WhatsApp File Upload media through structured `attachedFileUrls` instead of newline-delimited text.
- Teach File Input validation to prefer structured attached file URLs while preserving legacy text/audio URL parsing.
- Add WhatsApp and bot-engine regression tests for single and multiple audio uploads.