### PR TITLE
🐛 Fix WhatsApp audio file upload URLs

### DIFF
--- a/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.test.ts
+++ b/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.test.ts
@@ -1,0 +1,104 @@
+import { InputBlockType } from "@typebot.io/blocks-inputs/constants";
+import type { FileInputBlock } from "@typebot.io/blocks-inputs/file/schema";
+import type { TextInputBlock } from "@typebot.io/blocks-inputs/text/schema";
+import type { WhatsAppCredentials } from "@typebot.io/credentials/schemas";
+import { describe, expect, it } from "vitest";
+import { convertWhatsAppMessageToTypebotMessage } from "./convertWhatsAppMessageToTypebotMessage";
+import type { WhatsAppIncomingMessage } from "./schemas";
+
+const credentials = {
+  provider: "meta",
+  systemUserAccessToken: "token",
+  phoneNumberId: "phone-number-id",
+} satisfies WhatsAppCredentials["data"];
+
+describe("convertWhatsAppMessageToTypebotMessage", () => {
+  it("converts audio messages to text URLs for file input blocks", async () => {
+    const block = {
+      id: "file-input",
+      type: InputBlockType.FILE,
+      options: {
+        variableId: "file-variable",
+        visibility: "Auto",
+      },
+    } satisfies FileInputBlock;
+
+    const result = await convertWhatsAppMessageToTypebotMessage({
+      messages: [createAudioMessage("audio-media-id")],
+      workspaceId: "workspace-id",
+      credentials,
+      typebotId: "typebot-id",
+      resultId: "result-id",
+      block,
+    });
+
+    expect(result).toEqual({
+      type: "text",
+      text: "http://localhost:3000/api/typebots/typebot-id/whatsapp/media/audio-media-id.ogg",
+      attachedFileUrls: [],
+      metadata: { replyId: undefined },
+    });
+  });
+
+  it("keeps audio messages as audio replies for text input audio clips", async () => {
+    const block = {
+      id: "text-input",
+      type: InputBlockType.TEXT,
+      options: {
+        audioClip: {
+          isEnabled: true,
+          saveVariableId: "audio-variable",
+          visibility: "Auto",
+        },
+      },
+    } satisfies TextInputBlock;
+
+    const result = await convertWhatsAppMessageToTypebotMessage({
+      messages: [createAudioMessage("audio-media-id")],
+      workspaceId: "workspace-id",
+      credentials,
+      typebotId: "typebot-id",
+      resultId: "result-id",
+      block,
+    });
+
+    expect(result).toEqual({
+      type: "audio",
+      url: "http://localhost:3000/api/typebots/typebot-id/whatsapp/media/audio-media-id.ogg",
+    });
+  });
+
+  it("keeps audio messages as audio replies for other input blocks", async () => {
+    const block = {
+      id: "text-input",
+      type: InputBlockType.TEXT,
+      options: {},
+    } satisfies TextInputBlock;
+
+    const result = await convertWhatsAppMessageToTypebotMessage({
+      messages: [createAudioMessage("audio-media-id")],
+      workspaceId: "workspace-id",
+      credentials,
+      typebotId: "typebot-id",
+      resultId: "result-id",
+      block,
+    });
+
+    expect(result).toEqual({
+      type: "audio",
+      url: "http://localhost:3000/api/typebots/typebot-id/whatsapp/media/audio-media-id.ogg",
+    });
+  });
+});
+
+const createAudioMessage = (mediaId: string) =>
+  ({
+    id: "message-id",
+    from: "33612345678",
+    timestamp: "1767225600",
+    type: "audio",
+    audio: {
+      id: mediaId,
+      mime_type: "audio/ogg",
+    },
+  }) satisfies WhatsAppIncomingMessage;

--- a/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.test.ts
+++ b/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.test.ts
@@ -90,6 +90,21 @@ describe("convertWhatsAppMessageToTypebotMessage", () => {
     });
   });
 
+  it("keeps usable audio URLs when no current block is provided", async () => {
+    const result = await convertWhatsAppMessageToTypebotMessage({
+      messages: [createAudioMessage("audio-media-id")],
+      workspaceId: "workspace-id",
+      credentials,
+      typebotId: "typebot-id",
+      resultId: "result-id",
+    });
+
+    expect(result).toEqual({
+      type: "audio",
+      url: "http://localhost:3000/api/typebots/typebot-id/whatsapp/media/audio-media-id.ogg",
+    });
+  });
+
   it("uses the base MIME type to derive the proxied audio extension", async () => {
     const block = {
       id: "file-input",

--- a/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.test.ts
+++ b/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.test.ts
@@ -89,9 +89,38 @@ describe("convertWhatsAppMessageToTypebotMessage", () => {
       url: "http://localhost:3000/api/typebots/typebot-id/whatsapp/media/audio-media-id.ogg",
     });
   });
+
+  it("uses the base MIME type to derive the proxied audio extension", async () => {
+    const block = {
+      id: "file-input",
+      type: InputBlockType.FILE,
+      options: {
+        variableId: "file-variable",
+        visibility: "Auto",
+      },
+    } satisfies FileInputBlock;
+
+    const result = await convertWhatsAppMessageToTypebotMessage({
+      messages: [
+        createAudioMessage("audio-media-id", "audio/ogg; codecs=opus"),
+      ],
+      workspaceId: "workspace-id",
+      credentials,
+      typebotId: "typebot-id",
+      resultId: "result-id",
+      block,
+    });
+
+    expect(result).toEqual({
+      type: "text",
+      text: "http://localhost:3000/api/typebots/typebot-id/whatsapp/media/audio-media-id.ogg",
+      attachedFileUrls: [],
+      metadata: { replyId: undefined },
+    });
+  });
 });
 
-const createAudioMessage = (mediaId: string) =>
+const createAudioMessage = (mediaId: string, mimeType = "audio/ogg") =>
   ({
     id: "message-id",
     from: "33612345678",
@@ -99,6 +128,6 @@ const createAudioMessage = (mediaId: string) =>
     type: "audio",
     audio: {
       id: mediaId,
-      mime_type: "audio/ogg",
+      mime_type: mimeType,
     },
   }) satisfies WhatsAppIncomingMessage;

--- a/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.ts
+++ b/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.ts
@@ -96,9 +96,7 @@ export const convertWhatsAppMessageToTypebotMessage = async ({
               : undefined;
         let fileUrl: string;
         if (fileVisibility !== "Public") {
-          const extension = mimeType
-            ? extensionFromMimeType[mimeType]
-            : undefined;
+          const extension = getExtensionFromMimeType(mimeType);
           fileUrl =
             env.NEXTAUTH_URL +
             `/api/typebots/${typebotId}/whatsapp/media/${
@@ -109,7 +107,7 @@ export const convertWhatsAppMessageToTypebotMessage = async ({
             mediaId,
             credentials,
           });
-          const extension = extensionFromMimeType[mimeType];
+          const extension = getExtensionFromMimeType(mimeType);
           const url = await uploadFileToBucket({
             file,
             key:
@@ -160,4 +158,9 @@ export const convertWhatsAppMessageToTypebotMessage = async ({
     attachedFileUrls,
     metadata: { replyId },
   };
+};
+
+const getExtensionFromMimeType = (mimeType: string | undefined) => {
+  if (!mimeType) return;
+  return extensionFromMimeType[mimeType.split(";")[0].trim().toLowerCase()];
 };

--- a/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.ts
+++ b/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.ts
@@ -1,0 +1,163 @@
+import type { Block } from "@typebot.io/blocks-core/schemas/schema";
+import { InputBlockType } from "@typebot.io/blocks-inputs/constants";
+import type { Message } from "@typebot.io/chat-api/schemas";
+import type { WhatsAppCredentials } from "@typebot.io/credentials/schemas";
+import { env } from "@typebot.io/env";
+import { extensionFromMimeType } from "@typebot.io/lib/extensionFromMimeType";
+import { uploadFileToBucket } from "@typebot.io/lib/s3/uploadFileToBucket";
+import { downloadMedia } from "./downloadMedia";
+import type { WhatsAppIncomingMessage } from "./schemas";
+
+export const convertWhatsAppMessageToTypebotMessage = async ({
+  messages,
+  workspaceId,
+  credentials,
+  typebotId,
+  resultId,
+  block,
+}: {
+  messages: WhatsAppIncomingMessage[];
+  workspaceId?: string;
+  credentials: WhatsAppCredentials["data"];
+  typebotId?: string;
+  resultId?: string;
+  block?: Block;
+}): Promise<Message | undefined> => {
+  let text = "";
+  const append = (s: string) => {
+    text = text !== "" ? `${text}\n\n${s}` : s;
+  };
+  let replyId: string | undefined;
+  const attachedFileUrls: string[] = [];
+  for (const message of messages) {
+    switch (message.type) {
+      case "text": {
+        append(message.text.body);
+        break;
+      }
+      case "button": {
+        append(message.button.text);
+        break;
+      }
+      case "interactive": {
+        switch (message.interactive?.type) {
+          case "button_reply": {
+            replyId = message.interactive.button_reply.id;
+            append(message.interactive.button_reply.title);
+            break;
+          }
+          case "list_reply": {
+            replyId = message.interactive.list_reply.id;
+            append(message.interactive.list_reply.title);
+            break;
+          }
+        }
+        break;
+      }
+      case "document":
+      case "audio":
+      case "video":
+      case "sticker":
+      case "image": {
+        let mediaId: string | undefined;
+        let mimeType: string | undefined;
+        if (message.type === "video") {
+          mediaId = message.video.id;
+          mimeType = message.video.mime_type;
+        }
+        if (message.type === "image") {
+          mediaId = message.image.id;
+          mimeType = message.image.mime_type;
+        }
+        if (message.type === "audio") {
+          mediaId = message.audio.id;
+          mimeType = message.audio.mime_type;
+        }
+        if (message.type === "document") {
+          mediaId = message.document.id;
+          mimeType = message.document.mime_type;
+        }
+        if (message.type === "sticker") {
+          mediaId = message.sticker.id;
+          mimeType = message.sticker.mime_type;
+        }
+        if (!mediaId) continue;
+
+        const isAudioClipInput =
+          block?.type === InputBlockType.TEXT &&
+          block.options?.audioClip?.isEnabled &&
+          message.type === "audio";
+        const fileVisibility = isAudioClipInput
+          ? block.options?.audioClip?.visibility
+          : block?.type === InputBlockType.FILE
+            ? block.options?.visibility
+            : block?.type === InputBlockType.TEXT
+              ? block.options?.attachments?.visibility
+              : undefined;
+        let fileUrl: string;
+        if (fileVisibility !== "Public") {
+          const extension = mimeType
+            ? extensionFromMimeType[mimeType]
+            : undefined;
+          fileUrl =
+            env.NEXTAUTH_URL +
+            `/api/typebots/${typebotId}/whatsapp/media/${
+              workspaceId ? "" : "preview/"
+            }${mediaId}${extension ? `.${extension}` : ""}`;
+        } else {
+          const { file, mimeType } = await downloadMedia({
+            mediaId,
+            credentials,
+          });
+          const extension = extensionFromMimeType[mimeType];
+          const url = await uploadFileToBucket({
+            file,
+            key:
+              resultId && workspaceId && typebotId
+                ? `public/workspaces/${workspaceId}/typebots/${typebotId}/results/${resultId}/${mediaId}${extension ? `.${extension}` : ""}`
+                : `tmp/whatsapp/media/${mediaId}${extension ? `.${extension}` : ""}`,
+            mimeType,
+          });
+          fileUrl = url;
+        }
+        if (message.type === "audio" && block?.type !== InputBlockType.FILE)
+          return {
+            type: "audio",
+            url: fileUrl,
+          };
+        if (block?.type === InputBlockType.FILE) {
+          append(fileUrl);
+        } else if (block?.type === InputBlockType.TEXT) {
+          let caption: string | undefined;
+          if (message.type === "document" && message.document.caption) {
+            const looksLikeFilename = /^[\w,\s-]+\.[A-Za-z0-9]{1,10}$/;
+            if (!looksLikeFilename.test(message.document.caption))
+              caption = message.document.caption;
+          } else if (message.type === "image" && message.image.caption)
+            caption = message.image.caption;
+          else if (message.type === "video" && message.video.caption)
+            caption = message.video.caption;
+          if (caption) text = text === "" ? caption : `${text}\n\n${caption}`;
+          attachedFileUrls.push(fileUrl);
+        }
+        break;
+      }
+      case "location": {
+        const location = `${message.location.latitude}, ${message.location.longitude}`;
+        append(location);
+        break;
+      }
+      case "webhook": {
+        if (!message.webhook.data) return;
+        text = message.webhook.data;
+      }
+    }
+  }
+
+  return {
+    type: "text",
+    text,
+    attachedFileUrls,
+    metadata: { replyId },
+  };
+};

--- a/packages/whatsapp/src/resumeWhatsAppFlow.ts
+++ b/packages/whatsapp/src/resumeWhatsAppFlow.ts
@@ -126,7 +126,9 @@ export const resumeWhatsAppFlow = async ({
     });
   }
 
-  const currentTypebot = session?.state?.typebotsQueue[0].typebot;
+  const currentTypebot = isSessionExpired
+    ? undefined
+    : session?.state?.typebotsQueue[0].typebot;
   const { block } =
     (currentTypebot && session?.state?.currentBlockId
       ? getBlockById(session.state.currentBlockId, currentTypebot.groups)

--- a/packages/whatsapp/src/resumeWhatsAppFlow.ts
+++ b/packages/whatsapp/src/resumeWhatsAppFlow.ts
@@ -1,5 +1,3 @@
-import type { Block } from "@typebot.io/blocks-core/schemas/schema";
-import { InputBlockType } from "@typebot.io/blocks-inputs/constants";
 import { continueBotFlow } from "@typebot.io/bot-engine/continueBotFlow";
 import { saveStateToDatabase } from "@typebot.io/bot-engine/saveStateToDatabase";
 import type { Message } from "@typebot.io/chat-api/schemas";
@@ -11,15 +9,13 @@ import { getCredentials } from "@typebot.io/credentials/getCredentials";
 import type { WhatsAppCredentials } from "@typebot.io/credentials/schemas";
 import { env } from "@typebot.io/env";
 import { getBlockById } from "@typebot.io/groups/helpers/getBlockById";
-import { extensionFromMimeType } from "@typebot.io/lib/extensionFromMimeType";
 import redis from "@typebot.io/lib/redis";
-import { uploadFileToBucket } from "@typebot.io/lib/s3/uploadFileToBucket";
 import { isDefined } from "@typebot.io/lib/utils";
 import {
   type SessionStore,
   withSessionStore,
 } from "@typebot.io/runtime-session-store";
-import { downloadMedia } from "./downloadMedia";
+import { convertWhatsAppMessageToTypebotMessage } from "./convertWhatsAppMessageToTypebotMessage";
 import type {
   WhatsAppIncomingMessage,
   WhatsAppMessageReferral,
@@ -188,159 +184,6 @@ export const resumeWhatsAppFlow = async ({
       setVariableHistory,
     });
   });
-};
-
-const convertWhatsAppMessageToTypebotMessage = async ({
-  messages,
-  workspaceId,
-  credentials,
-  typebotId,
-  resultId,
-  block,
-}: {
-  messages: WhatsAppIncomingMessage[];
-  workspaceId?: string;
-  credentials: WhatsAppCredentials["data"];
-  typebotId?: string;
-  resultId?: string;
-  block?: Block;
-}): Promise<Message | undefined> => {
-  let text = "";
-  const append = (s: string) => {
-    text = text !== "" ? `${text}\n\n${s}` : s;
-  };
-  let replyId: string | undefined;
-  const attachedFileUrls: string[] = [];
-  for (const message of messages) {
-    switch (message.type) {
-      case "text": {
-        append(message.text.body);
-        break;
-      }
-      case "button": {
-        append(message.button.text);
-        break;
-      }
-      case "interactive": {
-        switch (message.interactive?.type) {
-          case "button_reply": {
-            replyId = message.interactive.button_reply.id;
-            append(message.interactive.button_reply.title);
-            break;
-          }
-          case "list_reply": {
-            replyId = message.interactive.list_reply.id;
-            append(message.interactive.list_reply.title);
-            break;
-          }
-        }
-        break;
-      }
-      case "document":
-      case "audio":
-      case "video":
-      case "sticker":
-      case "image": {
-        let mediaId: string | undefined;
-        let mimeType: string | undefined;
-        if (message.type === "video") {
-          mediaId = message.video.id;
-          mimeType = message.video.mime_type;
-        }
-        if (message.type === "image") {
-          mediaId = message.image.id;
-          mimeType = message.image.mime_type;
-        }
-        if (message.type === "audio") {
-          mediaId = message.audio.id;
-          mimeType = message.audio.mime_type;
-        }
-        if (message.type === "document") {
-          mediaId = message.document.id;
-          mimeType = message.document.mime_type;
-        }
-        if (message.type === "sticker") {
-          mediaId = message.sticker.id;
-          mimeType = message.sticker.mime_type;
-        }
-        if (!mediaId) continue;
-
-        const fileVisibility =
-          block?.type === InputBlockType.TEXT &&
-          block.options?.audioClip?.isEnabled &&
-          message.type === "audio"
-            ? block.options?.audioClip.visibility
-            : block?.type === InputBlockType.FILE
-              ? block.options?.visibility
-              : block?.type === InputBlockType.TEXT
-                ? block.options?.attachments?.visibility
-                : undefined;
-        let fileUrl: string;
-        if (fileVisibility !== "Public") {
-          const extension = mimeType
-            ? extensionFromMimeType[mimeType]
-            : undefined;
-          fileUrl =
-            env.NEXTAUTH_URL +
-            `/api/typebots/${typebotId}/whatsapp/media/${
-              workspaceId ? "" : "preview/"
-            }${mediaId}${extension ? `.${extension}` : ""}`;
-        } else {
-          const { file, mimeType } = await downloadMedia({
-            mediaId,
-            credentials,
-          });
-          const extension = extensionFromMimeType[mimeType];
-          const url = await uploadFileToBucket({
-            file,
-            key:
-              resultId && workspaceId && typebotId
-                ? `public/workspaces/${workspaceId}/typebots/${typebotId}/results/${resultId}/${mediaId}${extension ? `.${extension}` : ""}`
-                : `tmp/whatsapp/media/${mediaId}${extension ? `.${extension}` : ""}`,
-            mimeType,
-          });
-          fileUrl = url;
-        }
-        if (message.type === "audio")
-          return {
-            type: "audio",
-            url: fileUrl,
-          };
-        if (block?.type === InputBlockType.FILE) {
-          append(fileUrl);
-        } else if (block?.type === InputBlockType.TEXT) {
-          let caption: string | undefined;
-          if (message.type === "document" && message.document.caption) {
-            const looksLikeFilename = /^[\w,\s-]+\.[A-Za-z0-9]{1,10}$/;
-            if (!looksLikeFilename.test(message.document.caption))
-              caption = message.document.caption;
-          } else if (message.type === "image" && message.image.caption)
-            caption = message.image.caption;
-          else if (message.type === "video" && message.video.caption)
-            caption = message.video.caption;
-          if (caption) text = text === "" ? caption : `${text}\n\n${caption}`;
-          attachedFileUrls.push(fileUrl);
-        }
-        break;
-      }
-      case "location": {
-        const location = `${message.location.latitude}, ${message.location.longitude}`;
-        append(location);
-        break;
-      }
-      case "webhook": {
-        if (!message.webhook.data) return;
-        text = message.webhook.data;
-      }
-    }
-  }
-
-  return {
-    type: "text",
-    text,
-    attachedFileUrls,
-    metadata: { replyId },
-  };
 };
 
 const getWhatsAppCredentials = async ({

--- a/packages/whatsapp/src/resumeWhatsAppFlow.ts
+++ b/packages/whatsapp/src/resumeWhatsAppFlow.ts
@@ -126,11 +126,9 @@ export const resumeWhatsAppFlow = async ({
     });
   }
 
-  const currentTypebot = isSessionExpired
-    ? undefined
-    : session?.state?.typebotsQueue[0].typebot;
+  const currentTypebot = session?.state?.typebotsQueue[0].typebot;
   const { block } =
-    (currentTypebot && session?.state?.currentBlockId
+    (!isSessionExpired && currentTypebot && session?.state?.currentBlockId
       ? getBlockById(session.state.currentBlockId, currentTypebot.groups)
       : undefined) ?? {};
   const reply = await convertWhatsAppMessageToTypebotMessage({


### PR DESCRIPTION
- Fix WhatsApp audio media conversion for file upload inputs so saved variables receive the uploaded file URL.
- Keep existing audio reply behavior for text input audio clips and other non-file inputs.
- Add focused WhatsApp conversion tests for file-upload audio and preserved audio responses.