### PR TITLE
🐛 Fix Sentry quick-win errors

### DIFF
--- a/apps/builder/src/features/typebot/api/handleImportTypebot.ts
+++ b/apps/builder/src/features/typebot/api/handleImportTypebot.ts
@@ -79,7 +79,19 @@ const migrateImportingTypebot = async (
     riskLevel: null,
     spaceId: null,
   } satisfies Partial<Typebot>;
-  return (await migrateTypebot(fullTypebot)).typebot;
+  try {
+    return (await migrateTypebot(fullTypebot)).typebot;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.message === "Start group not found" ||
+        error.message === "Start block not found")
+    )
+      throw new ORPCError("BAD_REQUEST", {
+        message: "Invalid typebot file: start event is missing",
+      });
+    throw error;
+  }
 };
 
 export const importTypebotInputSchema = z.object({

--- a/apps/builder/src/features/user/server/handleUpdateUser.ts
+++ b/apps/builder/src/features/user/server/handleUpdateUser.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 
 const defaultMySqlStringMaxLength = 191;
 
-const updateUserInputFieldsSchema = updateUserSchema.extend({
+const mysqlUpdateUserInputFieldsSchema = updateUserSchema.extend({
   name: z.string().max(255).nullable(),
   image: z.string().max(1000).nullable(),
   company: z.string().max(defaultMySqlStringMaxLength).nullable(),
@@ -21,7 +21,10 @@ const updateUserInputFieldsSchema = updateUserSchema.extend({
 });
 
 export const updateUserInputSchema = z.object({
-  updates: updateUserInputFieldsSchema.partial(),
+  updates: (process.env.DATABASE_URL?.startsWith("mysql://")
+    ? mysqlUpdateUserInputFieldsSchema
+    : updateUserSchema
+  ).partial(),
 });
 
 export const handleUpdateUser = async ({

--- a/apps/builder/src/features/user/server/handleUpdateUser.ts
+++ b/apps/builder/src/features/user/server/handleUpdateUser.ts
@@ -6,8 +6,22 @@ import {
 } from "@typebot.io/user/schemas";
 import { z } from "zod";
 
+const defaultMySqlStringMaxLength = 191;
+
+const updateUserInputFieldsSchema = updateUserSchema.extend({
+  name: z.string().max(255).nullable(),
+  image: z.string().max(1000).nullable(),
+  company: z.string().max(defaultMySqlStringMaxLength).nullable(),
+  referral: z.string().max(defaultMySqlStringMaxLength).nullable(),
+  preferredAppAppearance: z
+    .string()
+    .max(defaultMySqlStringMaxLength)
+    .nullable(),
+  preferredLanguage: z.string().max(10).nullable(),
+});
+
 export const updateUserInputSchema = z.object({
-  updates: updateUserSchema.partial(),
+  updates: updateUserInputFieldsSchema.partial(),
 });
 
 export const handleUpdateUser = async ({

--- a/packages/billing/src/api/handleStripeWebhook.ts
+++ b/packages/billing/src/api/handleStripeWebhook.ts
@@ -153,7 +153,8 @@ export const handleStripeWebhook = async ({
           },
         },
       });
-      if (!existingWorkspace) throw new Error("Workspace not found");
+      if (!existingWorkspace)
+        return { message: "Workspace not found, skipping..." };
 
       if (
         subscription.cancel_at_period_end &&

--- a/packages/bot-engine/src/queries/saveAnswer.ts
+++ b/packages/bot-engine/src/queries/saveAnswer.ts
@@ -14,7 +14,10 @@ export const saveAnswer = async ({ answer, state }: Props) => {
   const textEncoder = new TextEncoder();
   let content = answer.content;
 
-  if (textEncoder.encode(content).length > maxAnswerContentByteLength) {
+  if (
+    process.env.DATABASE_URL?.startsWith("mysql://") &&
+    textEncoder.encode(content).length > maxAnswerContentByteLength
+  ) {
     let byteLength = 0;
     let contentEndIndex = 0;
 

--- a/packages/bot-engine/src/queries/saveAnswer.ts
+++ b/packages/bot-engine/src/queries/saveAnswer.ts
@@ -6,10 +6,29 @@ type Props = {
   answer: Omit<Prisma.Prisma.AnswerV2CreateManyInput, "resultId">;
   state: SessionState;
 };
+const maxAnswerContentByteLength = 65_535;
+
 export const saveAnswer = async ({ answer, state }: Props) => {
   const resultId = state.typebotsQueue[0].resultId;
   if (!resultId) return;
+  const textEncoder = new TextEncoder();
+  let content = answer.content;
+
+  if (textEncoder.encode(content).length > maxAnswerContentByteLength) {
+    let byteLength = 0;
+    let contentEndIndex = 0;
+
+    for (const character of content) {
+      const characterByteLength = textEncoder.encode(character).length;
+      if (byteLength + characterByteLength > maxAnswerContentByteLength) break;
+      byteLength += characterByteLength;
+      contentEndIndex += character.length;
+    }
+
+    content = content.slice(0, contentEndIndex);
+  }
+
   return prisma.answerV2.createMany({
-    data: [{ ...answer, resultId }],
+    data: [{ ...answer, content, resultId }],
   });
 };

--- a/packages/user/src/schemas.ts
+++ b/packages/user/src/schemas.ts
@@ -3,7 +3,6 @@ import type { Prisma } from "@typebot.io/prisma/types";
 import { z } from "zod";
 
 const displayedInAppNotificationsSchema = z.record(z.string(), z.boolean());
-const defaultMySqlStringMaxLength = 191;
 
 export const groupTitlesAutoGenerationSchema = z.object({
   isEnabled: z.boolean().optional(),
@@ -21,21 +20,18 @@ export const userSchema = z.object({
   createdAt: z.date(),
   updatedAt: z.date(),
   lastActivityAt: z.date(),
-  name: z.string().max(255).nullable(),
+  name: z.string().nullable(),
   email: z.string(),
   emailVerified: z.date().nullable(),
-  image: z.string().max(1000).nullable(),
-  company: z.string().max(defaultMySqlStringMaxLength).nullable(),
+  image: z.string().nullable(),
+  company: z.string().nullable(),
   onboardingCategories: z.array(z.string()),
-  referral: z.string().max(defaultMySqlStringMaxLength).nullable(),
+  referral: z.string().nullable(),
   graphNavigation: z.nativeEnum(GraphNavigation).nullable(),
-  preferredAppAppearance: z
-    .string()
-    .max(defaultMySqlStringMaxLength)
-    .nullable(),
+  preferredAppAppearance: z.string().nullable(),
   displayedInAppNotifications: displayedInAppNotificationsSchema.nullable(),
   groupTitlesAutoGeneration: groupTitlesAutoGenerationSchema.nullable(),
-  preferredLanguage: z.string().max(10).nullable(),
+  preferredLanguage: z.string().nullable(),
   termsAcceptedAt: z.date().nullable(),
 }) satisfies z.ZodType<Prisma.User>;
 export type User = z.infer<typeof userSchema>;

--- a/packages/user/src/schemas.ts
+++ b/packages/user/src/schemas.ts
@@ -3,6 +3,7 @@ import type { Prisma } from "@typebot.io/prisma/types";
 import { z } from "zod";
 
 const displayedInAppNotificationsSchema = z.record(z.string(), z.boolean());
+const defaultMySqlStringMaxLength = 191;
 
 export const groupTitlesAutoGenerationSchema = z.object({
   isEnabled: z.boolean().optional(),
@@ -20,18 +21,21 @@ export const userSchema = z.object({
   createdAt: z.date(),
   updatedAt: z.date(),
   lastActivityAt: z.date(),
-  name: z.string().nullable(),
+  name: z.string().max(255).nullable(),
   email: z.string(),
   emailVerified: z.date().nullable(),
-  image: z.string().nullable(),
-  company: z.string().nullable(),
+  image: z.string().max(1000).nullable(),
+  company: z.string().max(defaultMySqlStringMaxLength).nullable(),
   onboardingCategories: z.array(z.string()),
-  referral: z.string().nullable(),
+  referral: z.string().max(defaultMySqlStringMaxLength).nullable(),
   graphNavigation: z.nativeEnum(GraphNavigation).nullable(),
-  preferredAppAppearance: z.string().nullable(),
+  preferredAppAppearance: z
+    .string()
+    .max(defaultMySqlStringMaxLength)
+    .nullable(),
   displayedInAppNotifications: displayedInAppNotificationsSchema.nullable(),
   groupTitlesAutoGeneration: groupTitlesAutoGenerationSchema.nullable(),
-  preferredLanguage: z.string().nullable(),
+  preferredLanguage: z.string().max(10).nullable(),
   termsAcceptedAt: z.date().nullable(),
 }) satisfies z.ZodType<Prisma.User>;
 export type User = z.infer<typeof userSchema>;

--- a/packages/whatsapp/src/convertInputToWhatsAppMessage.test.ts
+++ b/packages/whatsapp/src/convertInputToWhatsAppMessage.test.ts
@@ -165,6 +165,16 @@ describe("Choice input", async () => {
     expect(secondMessage.interactive.body?.text).toBe("―");
   });
 
+  it("should truncate long interactive button body text", async () => {
+    const input = createMockButtonsInput([{ id: "choice1", content: "Yes" }]);
+    const lastMessage = createMockTextMessage("a".repeat(1025));
+
+    const result = await convertInputToWhatsAppMessages({ input, lastMessage });
+
+    const interactiveMessage = expectInteractiveMessage(result[0]);
+    expect(interactiveMessage.interactive.body?.text).toHaveLength(1024);
+  });
+
   it("should filter out items with no content", async () => {
     const input = createMockButtonsInput([
       { id: "choice1", content: "Option 1" },
@@ -324,6 +334,24 @@ describe("Picture choice input", async () => {
     const interactiveMessage = expectInteractiveMessage(result[0]);
     expect(interactiveMessage.interactive.body).toBeUndefined();
   });
+
+  it("should truncate long interactive picture choice body text", async () => {
+    const input = createMockPictureChoiceInput([
+      {
+        id: "pic1",
+        title: "Picture 1",
+        description: "a".repeat(1025),
+      },
+    ]);
+
+    const result = await convertInputToWhatsAppMessages({
+      input,
+      lastMessage: undefined,
+    });
+
+    const interactiveMessage = expectInteractiveMessage(result[0]);
+    expect(interactiveMessage.interactive.body?.text).toHaveLength(1024);
+  });
 });
 
 describe("Cards input", async () => {
@@ -423,6 +451,25 @@ describe("Cards input", async () => {
 
     const interactiveMessage = expectInteractiveMessage(result[0]);
     expect(interactiveMessage.interactive.header).toBeUndefined();
+  });
+
+  it("should truncate long interactive card body text", async () => {
+    const input = createMockCardsInput([
+      {
+        id: "card1",
+        title: "Card 1",
+        description: "a".repeat(1025),
+        paths: [{ id: "path1", text: "Action 1" }],
+      },
+    ]);
+
+    const result = await convertInputToWhatsAppMessages({
+      input,
+      lastMessage: undefined,
+    });
+
+    const interactiveMessage = expectInteractiveMessage(result[0]);
+    expect(interactiveMessage.interactive.body?.text).toHaveLength(1024);
   });
 
   it("should handle empty paths array", async () => {

--- a/packages/whatsapp/src/convertInputToWhatsAppMessage.test.ts
+++ b/packages/whatsapp/src/convertInputToWhatsAppMessage.test.ts
@@ -175,6 +175,19 @@ describe("Choice input", async () => {
     expect(interactiveMessage.interactive.body?.text).toHaveLength(1024);
   });
 
+  it("should not split emoji when truncating long interactive button body text", async () => {
+    const input = createMockButtonsInput([{ id: "choice1", content: "Yes" }]);
+    const lastMessage = createMockTextMessage(`${"a".repeat(1023)}😀b`);
+
+    const result = await convertInputToWhatsAppMessages({ input, lastMessage });
+
+    const interactiveMessage = expectInteractiveMessage(result[0]);
+    expect(
+      Array.from(interactiveMessage.interactive.body?.text ?? ""),
+    ).toHaveLength(1024);
+    expect(interactiveMessage.interactive.body?.text.endsWith("😀")).toBe(true);
+  });
+
   it("should filter out items with no content", async () => {
     const input = createMockButtonsInput([
       { id: "choice1", content: "Option 1" },

--- a/packages/whatsapp/src/convertInputToWhatsAppMessage.ts
+++ b/packages/whatsapp/src/convertInputToWhatsAppMessage.ts
@@ -12,6 +12,8 @@ import type { SystemMessages } from "@typebot.io/settings/schemas";
 import { getOrUploadMedia, type UploadMediaCache } from "./getOrUploadMedia";
 import type { WhatsAppSendingMessage } from "./schemas";
 
+const whatsAppInteractiveBodyMaxLength = 1024;
+
 type Props = {
   input: NonNullable<ContinueChatResponse["input"]>;
   lastMessage: ContinueChatResponse["messages"][number] | undefined;
@@ -123,7 +125,9 @@ export const convertInputToWhatsAppMessages = async ({
           interactive: {
             type: "button" as const,
             header,
-            body: isEmpty(bodyText) ? undefined : { text: bodyText },
+            body: isEmpty(bodyText)
+              ? undefined
+              : { text: truncateWhatsAppInteractiveBody(bodyText) },
             action: {
               buttons: [
                 {
@@ -171,7 +175,9 @@ export const convertInputToWhatsAppMessages = async ({
         interactive: {
           type: "button",
           body: {
-            text: idx === 0 ? lastMessageText || "―" : "―",
+            text: truncateWhatsAppInteractiveBody(
+              idx === 0 ? lastMessageText || "―" : "―",
+            ),
           },
           action: {
             buttons: (() => {
@@ -230,7 +236,9 @@ export const convertInputToWhatsAppMessages = async ({
           interactive: {
             type: "button" as const,
             header,
-            body: isEmpty(bodyText) ? undefined : { text: bodyText },
+            body: isEmpty(bodyText)
+              ? undefined
+              : { text: truncateWhatsAppInteractiveBody(bodyText) },
             action: {
               buttons: (() => {
                 const paths = (item.paths ?? []).slice(0, 3);
@@ -253,6 +261,11 @@ export const convertInputToWhatsAppMessages = async ({
     }
   }
 };
+
+const truncateWhatsAppInteractiveBody = (text: string) =>
+  text.length > whatsAppInteractiveBodyMaxLength
+    ? text.slice(0, whatsAppInteractiveBodyMaxLength)
+    : text;
 
 const trimTextTo20Chars = (
   text: string,

--- a/packages/whatsapp/src/convertInputToWhatsAppMessage.ts
+++ b/packages/whatsapp/src/convertInputToWhatsAppMessage.ts
@@ -262,10 +262,12 @@ export const convertInputToWhatsAppMessages = async ({
   }
 };
 
-const truncateWhatsAppInteractiveBody = (text: string) =>
-  text.length > whatsAppInteractiveBodyMaxLength
-    ? text.slice(0, whatsAppInteractiveBodyMaxLength)
+const truncateWhatsAppInteractiveBody = (text: string) => {
+  const characters = Array.from(text);
+  return characters.length > whatsAppInteractiveBodyMaxLength
+    ? characters.slice(0, whatsAppInteractiveBodyMaxLength).join("")
     : text;
+};
 
 const trimTextTo20Chars = (
   text: string,


### PR DESCRIPTION
- Return a no-op response for Stripe subscription updates when the customer is no longer tied to a workspace.
- Validate user profile string fields against database limits before Prisma updates.
- Return a bad request for imported typebots missing the legacy start block or group.
- Truncate saved answer content to the MySQL TEXT byte limit before persisting.
- Cap WhatsApp interactive body text at Meta's 1024-character limit and add conversion tests.