### PR TITLE
🐛 Harden email login codes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -327,6 +327,9 @@
         "effect": "4.0.0-beta.38",
         "next-auth": "^5.0.0-beta.30",
       },
+      "devDependencies": {
+        "vitest": "^4.0.18",
+      },
     },
     "packages/billing": {
       "name": "@typebot.io/billing",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -11,6 +11,21 @@
     },
     "./package.json": "./package.json"
   },
+  "nx": {
+    "targets": {
+      "test": {
+        "executor": "@nx/vitest:test",
+        "outputs": [
+          "{options.reportsDirectory}"
+        ],
+        "options": {
+          "configFile": "{projectRoot}/vitest.config.ts",
+          "project": "@typebot.io/auth",
+          "reportsDirectory": "../../coverage/packages/auth"
+        }
+      }
+    }
+  },
   "dependencies": {
     "effect": "4.0.0-beta.38",
     "@typebot.io/env": "workspace:*",
@@ -21,5 +36,8 @@
     "@typebot.io/prisma": "workspace:*",
     "@typebot.io/telemetry": "workspace:*",
     "@typebot.io/config": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/auth/src/helpers/createAuthPrismaAdapter.ts
+++ b/packages/auth/src/helpers/createAuthPrismaAdapter.ts
@@ -24,6 +24,10 @@ import { Effect, Layer } from "effect";
 import { convertInvitationsToCollaborations } from "./convertInvitationsToCollaborations";
 import { getNewUserInvitations } from "./getNewUserInvitations";
 import { joinWorkspaces } from "./joinWorkspaces";
+import {
+  EMAIL_SIGN_IN_VERIFICATION_TOKEN_VALUE,
+  recordFailedEmailSignInAttempt,
+} from "./recordFailedEmailSignInAttempt";
 
 const MainLayer = Layer.provideMerge(
   Layer.provide(UsersWorkflowsRpcClient.layer, WorkflowsRpcClientConfig.layer),
@@ -173,9 +177,12 @@ export const createAuthPrismaAdapter = (p: Prisma.PrismaClient): Adapter => ({
   deleteSession: (sessionToken) =>
     p.session.delete({ where: { sessionToken } }),
   async createVerificationToken(data) {
-    const verificationToken = await p.verificationToken.create(
-      stripUndefined(data),
-    );
+    const verificationToken = await p.verificationToken.create({
+      data: {
+        ...stripUndefined(data).data,
+        value: EMAIL_SIGN_IN_VERIFICATION_TOKEN_VALUE,
+      },
+    });
     if ("id" in verificationToken && verificationToken.id) {
       return omit(verificationToken, "id");
     }
@@ -195,8 +202,12 @@ export const createAuthPrismaAdapter = (p: Prisma.PrismaClient): Adapter => ({
       if (
         error instanceof PrismaClientKnownRequestError &&
         error.code === "P2025"
-      )
+      ) {
+        await p.$transaction((tx) =>
+          recordFailedEmailSignInAttempt(tx, identifier_token.identifier),
+        );
         return null;
+      }
       throw error;
     }
   },

--- a/packages/auth/src/helpers/recordFailedEmailSignInAttempt.test.ts
+++ b/packages/auth/src/helpers/recordFailedEmailSignInAttempt.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import {
+  EMAIL_SIGN_IN_VERIFICATION_TOKEN_VALUE,
+  INITIAL_EMAIL_SIGN_IN_FAILED_ATTEMPTS,
+  recordFailedEmailSignInAttempt,
+} from "./recordFailedEmailSignInAttempt";
+
+type StoredVerificationToken = {
+  identifier: string;
+  token: string;
+  value: string | null;
+  failedAttempts: number;
+  expires: Date;
+};
+
+type VerificationTokenStore = Parameters<
+  typeof recordFailedEmailSignInAttempt
+>[0];
+
+type VerificationTokenWhere = Parameters<
+  VerificationTokenStore["verificationToken"]["updateMany"]
+>[0]["where"];
+
+describe("recordFailedEmailSignInAttempt", () => {
+  it("removes outstanding email login tokens after repeated failed attempts", async () => {
+    const store = createVerificationTokenStore([
+      {
+        identifier: "user@example.com",
+        token: "valid-token",
+        value: INITIAL_EMAIL_SIGN_IN_FAILED_ATTEMPTS,
+        failedAttempts: 0,
+        expires: new Date(Date.now() + 60_000),
+      },
+    ]);
+
+    await recordFailedEmailSignInAttempt(store, "user@example.com");
+    await recordFailedEmailSignInAttempt(store, "user@example.com");
+    await recordFailedEmailSignInAttempt(store, "user@example.com");
+    await recordFailedEmailSignInAttempt(store, "user@example.com");
+
+    expect(store.rows).toHaveLength(1);
+
+    await recordFailedEmailSignInAttempt(store, "user@example.com");
+
+    expect(store.rows).toHaveLength(0);
+  });
+
+  it("also retires legacy unmarked email login tokens", async () => {
+    const store = createVerificationTokenStore([
+      {
+        identifier: "user@example.com",
+        token: "valid-token",
+        value: null,
+        failedAttempts: 0,
+        expires: new Date(Date.now() + 60_000),
+      },
+    ]);
+
+    await recordFailedEmailSignInAttempt(store, "user@example.com");
+    await recordFailedEmailSignInAttempt(store, "user@example.com");
+    await recordFailedEmailSignInAttempt(store, "user@example.com");
+    await recordFailedEmailSignInAttempt(store, "user@example.com");
+    await recordFailedEmailSignInAttempt(store, "user@example.com");
+
+    expect(store.rows).toHaveLength(0);
+  });
+
+  it("leaves non-login verification rows untouched", async () => {
+    const store = createVerificationTokenStore([
+      {
+        identifier: "whatsapp webhook",
+        token: "other-token",
+        value: null,
+        failedAttempts: 0,
+        expires: new Date(Date.now() + 60_000),
+      },
+      {
+        identifier: "user-id-changeEmail",
+        token: "change-email-token",
+        value: "new@example.com",
+        failedAttempts: 0,
+        expires: new Date(Date.now() + 60_000),
+      },
+    ]);
+
+    await recordFailedEmailSignInAttempt(store, "whatsapp webhook");
+    await recordFailedEmailSignInAttempt(store, "user-id-changeEmail");
+
+    expect(store.rows).toHaveLength(2);
+  });
+
+  it("counts parallel failed attempts independently", async () => {
+    const store = createVerificationTokenStore([
+      {
+        identifier: "user@example.com",
+        token: "valid-token",
+        value: EMAIL_SIGN_IN_VERIFICATION_TOKEN_VALUE,
+        failedAttempts: 0,
+        expires: new Date(Date.now() + 60_000),
+      },
+    ]);
+
+    await Promise.all(
+      Array.from({ length: 5 }, () =>
+        recordFailedEmailSignInAttempt(store, "user@example.com"),
+      ),
+    );
+
+    expect(store.rows).toHaveLength(0);
+  });
+});
+
+const createVerificationTokenStore = (
+  initialRows: StoredVerificationToken[],
+) => {
+  const rows = [...initialRows];
+
+  const store = {
+    rows,
+    verificationToken: {
+      updateMany: ({
+        where,
+        data,
+      }: Parameters<
+        VerificationTokenStore["verificationToken"]["updateMany"]
+      >[0]) => {
+        const matchingRows = rows.filter((row) => matchesWhere(row, where));
+
+        for (const row of matchingRows)
+          row.failedAttempts += data.failedAttempts.increment;
+
+        return Promise.resolve({ count: matchingRows.length });
+      },
+      deleteMany: ({
+        where,
+      }: Parameters<
+        VerificationTokenStore["verificationToken"]["deleteMany"]
+      >[0]) => {
+        const remainingRows = rows.filter((row) => !matchesWhere(row, where));
+        const deletedCount = rows.length - remainingRows.length;
+
+        rows.splice(0, rows.length, ...remainingRows);
+
+        return Promise.resolve({ count: deletedCount });
+      },
+    },
+  };
+
+  return store;
+};
+
+const matchesWhere = (
+  row: StoredVerificationToken,
+  where: VerificationTokenWhere,
+) => {
+  if (row.identifier !== where.identifier) return false;
+  if (where.expires && row.expires <= where.expires.gt) return false;
+  if (
+    where.failedAttempts?.lt !== undefined &&
+    row.failedAttempts >= where.failedAttempts.lt
+  )
+    return false;
+  if (
+    where.failedAttempts?.gte !== undefined &&
+    row.failedAttempts < where.failedAttempts.gte
+  )
+    return false;
+  return where.OR.some((clause) => {
+    if (clause.value === null) return row.value === null;
+    if (typeof clause.value === "string") return row.value === clause.value;
+    return row.value?.startsWith(clause.value.startsWith) ?? false;
+  });
+};

--- a/packages/auth/src/helpers/recordFailedEmailSignInAttempt.ts
+++ b/packages/auth/src/helpers/recordFailedEmailSignInAttempt.ts
@@ -1,0 +1,70 @@
+const EMAIL_SIGN_IN_FAILED_ATTEMPTS_PREFIX = "email-sign-in-failed-attempts:";
+
+export const INITIAL_EMAIL_SIGN_IN_FAILED_ATTEMPTS = `${EMAIL_SIGN_IN_FAILED_ATTEMPTS_PREFIX}0`;
+
+export const EMAIL_SIGN_IN_VERIFICATION_TOKEN_VALUE = "email-sign-in";
+
+const MAX_EMAIL_SIGN_IN_FAILED_ATTEMPTS = 5;
+
+type VerificationTokenWhere = {
+  identifier: string;
+  expires?: { gt: Date };
+  failedAttempts?: { lt?: number; gte?: number };
+  OR: (
+    | { value: string | null }
+    | { value: { startsWith: typeof EMAIL_SIGN_IN_FAILED_ATTEMPTS_PREFIX } }
+  )[];
+};
+
+type VerificationTokenStore = {
+  verificationToken: {
+    updateMany: (args: {
+      where: VerificationTokenWhere;
+      data: { failedAttempts: { increment: number } };
+    }) => PromiseLike<{ count: number }>;
+    deleteMany: (args: {
+      where: VerificationTokenWhere;
+    }) => PromiseLike<{ count: number }>;
+  };
+};
+
+export const recordFailedEmailSignInAttempt = async (
+  p: VerificationTokenStore,
+  identifier: string,
+) => {
+  if (!isEmailIdentifier(identifier)) return;
+
+  const { count } = await p.verificationToken.updateMany({
+    where: {
+      ...getEmailSignInVerificationTokenWhere(identifier),
+      expires: { gt: new Date() },
+      failedAttempts: { lt: MAX_EMAIL_SIGN_IN_FAILED_ATTEMPTS },
+    },
+    data: { failedAttempts: { increment: 1 } },
+  });
+
+  if (count === 0) return;
+
+  await p.verificationToken.deleteMany({
+    where: {
+      ...getEmailSignInVerificationTokenWhere(identifier),
+      failedAttempts: { gte: MAX_EMAIL_SIGN_IN_FAILED_ATTEMPTS },
+    },
+  });
+};
+
+const getEmailSignInVerificationTokenWhere = (
+  identifier: string,
+): VerificationTokenWhere => ({
+  identifier,
+  OR: [
+    { value: null },
+    { value: EMAIL_SIGN_IN_VERIFICATION_TOKEN_VALUE },
+    { value: { startsWith: EMAIL_SIGN_IN_FAILED_ATTEMPTS_PREFIX } },
+  ],
+});
+
+const isEmailIdentifier = (identifier: string) => {
+  const parts = identifier.split("@");
+  return parts.length === 2 && parts.every(Boolean);
+};

--- a/packages/auth/src/lib/providers.ts
+++ b/packages/auth/src/lib/providers.ts
@@ -1,3 +1,4 @@
+import { randomInt } from "node:crypto";
 import { env } from "@typebot.io/env";
 import { getAtPath } from "@typebot.io/lib/utils";
 import { userSchema } from "@typebot.io/user/schemas";
@@ -40,8 +41,7 @@ if (env.NEXT_PUBLIC_SMTP_FROM && !env.SMTP_AUTH_DISABLED)
       },
       maxAge: 10 * 60,
       from: env.NEXT_PUBLIC_SMTP_FROM,
-      generateVerificationToken: () =>
-        Math.floor(100000 + Math.random() * 900000).toString(),
+      generateVerificationToken: () => randomInt(100000, 1000000).toString(),
       sendVerificationRequest,
     }),
   );

--- a/packages/auth/vitest.config.ts
+++ b/packages/auth/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: "../../node_modules/.vite/packages/auth",
+  test: {
+    name: "@typebot.io/auth",
+    watch: false,
+    globals: true,
+    environment: "node",
+    include: ["{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
+    reporters: ["default"],
+    coverage: {
+      reportsDirectory: "./test-output/vitest/coverage",
+      provider: "v8",
+    },
+  },
+}));

--- a/packages/prisma/mysql/schema.prisma
+++ b/packages/prisma/mysql/schema.prisma
@@ -197,10 +197,11 @@ model UserCredentials {
 }
 
 model VerificationToken {
-  identifier String
-  token      String   @unique
-  value      String?  @db.Text
-  expires    DateTime
+  identifier     String
+  token          String   @unique
+  value          String?  @db.Text
+  failedAttempts Int      @default(0)
+  expires        DateTime
 
   @@unique([identifier, token])
 }

--- a/packages/prisma/postgresql/migrations/20260627151525_add_failed_attempts_to_verification_token/migration.sql
+++ b/packages/prisma/postgresql/migrations/20260627151525_add_failed_attempts_to_verification_token/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "VerificationToken" ADD COLUMN     "failedAttempts" INTEGER NOT NULL DEFAULT 0;

--- a/packages/prisma/postgresql/schema.prisma
+++ b/packages/prisma/postgresql/schema.prisma
@@ -181,10 +181,11 @@ model UserCredentials {
 }
 
 model VerificationToken {
-  identifier String
-  token      String   @unique
-  value      String?
-  expires    DateTime
+  identifier     String
+  token          String   @unique
+  value          String?
+  failedAttempts Int      @default(0)
+  expires        DateTime
 
   @@unique([identifier, token])
 }


### PR DESCRIPTION
- Add failed-attempt tracking to verification tokens in Prisma schemas and the PostgreSQL migration.
- Record invalid email login code attempts with an atomic counter and retire active login tokens after five failures.
- Mark Auth.js email login verification tokens separately from other verification-token flows.
- Use cryptographically secure random six-digit email login codes.
- Add auth package Vitest coverage, including parallel failed-attempt handling.