### PR TITLE
🐛 Fix Send Email attachment handling

### DIFF
--- a/packages/bot-engine/src/blocks/integrations/sendEmail/executeSendEmailBlock.tsx
+++ b/packages/bot-engine/src/blocks/integrations/sendEmail/executeSendEmailBlock.tsx
@@ -10,7 +10,6 @@ import type { SmtpCredentials } from "@typebot.io/credentials/schemas";
 import { renderDefaultBotNotificationEmail } from "@typebot.io/emails/transactional/DefaultBotNotificationEmail";
 import { env } from "@typebot.io/env";
 import { parseUnknownError } from "@typebot.io/lib/parseUnknownError";
-import { getFileTempUrl } from "@typebot.io/lib/s3/getFileTempUrl";
 import {
   byId,
   isDefined,
@@ -27,9 +26,9 @@ import { parseVariables } from "@typebot.io/variables/parseVariables";
 import type { Variable } from "@typebot.io/variables/schemas";
 import { createTransport } from "nodemailer";
 import type Mail from "nodemailer/lib/mailer/index";
-import { getTypebotWorkspaceId } from "../../../queries/getTypebotWorkspaceId";
 import type { ExecuteIntegrationResponse } from "../../../types";
 import { defaultFrom, defaultTransportOptions } from "./constants";
+import { parseEmailAttachments } from "./parseEmailAttachments";
 
 export const sendEmailSuccessDescription = "Email successfully sent";
 export const sendEmailErrorDescription = "Email not sent";
@@ -214,7 +213,11 @@ const sendEmail = async ({
     to: recipients,
     replyTo,
     subject,
-    attachments: await parseAttachments(fileUrls, typebot.id),
+    attachments: await parseEmailAttachments({
+      fileUrls,
+      typebotId: typebot.id,
+    }),
+    disableFileAccess: true,
     ...emailBody,
   };
 
@@ -344,40 +347,4 @@ const stringifyUniqueVariableValueAsHtml = (
   if (!value) return "";
   if (typeof value === "string") return value.replace(/\n/g, "<br />");
   return value.map(stringifyUniqueVariableValueAsHtml).join("<br />");
-};
-
-const parseAttachments = (
-  fileUrls: string | string[] | undefined,
-  typebotId: string,
-): Promise<{ path: string }[]> | undefined => {
-  if (!fileUrls) return;
-  const urls = Array.isArray(fileUrls) ? fileUrls : fileUrls.split(", ");
-  return Promise.all(
-    urls.map(async (url) => {
-      if (!url.startsWith(env.NEXTAUTH_URL)) return { path: url };
-      const {
-        typebotId: urlTypebotId,
-        resultId,
-        fileName,
-      } = extractDataFromPrivateUrl(url);
-      if (typebotId !== urlTypebotId) return { path: url };
-      const workspaceId = await getTypebotWorkspaceId(typebotId);
-      return {
-        path: await getFileTempUrl({
-          key: `private/workspaces/${workspaceId}/typebots/${typebotId}/results/${resultId}/${fileName}`,
-          expires: 600,
-        }),
-      };
-    }),
-  );
-};
-
-const extractDataFromPrivateUrl = (url: string) => {
-  const pathSegments = url.split("/").filter((segment) => segment !== "");
-
-  const typebotId = pathSegments[4];
-  const resultId = pathSegments[6];
-  const fileName = pathSegments[7];
-
-  return { typebotId, resultId, fileName };
 };

--- a/packages/bot-engine/src/blocks/integrations/sendEmail/executeSendEmailBlock.tsx
+++ b/packages/bot-engine/src/blocks/integrations/sendEmail/executeSendEmailBlock.tsx
@@ -120,6 +120,7 @@ export const executeSendEmailBlock = async ({
       isCustomBody: options.isCustomBody,
       isBodyCode: options.isBodyCode,
       workspaceId: state.workspaceId,
+      resultId,
       sessionStore,
     });
     if (sendEmailLogs) logs.push(...sendEmailLogs);
@@ -146,6 +147,7 @@ const sendEmail = async ({
   isCustomBody,
   fileUrls,
   workspaceId,
+  resultId,
   sessionStore,
 }: {
   credentialsId: string;
@@ -161,6 +163,7 @@ const sendEmail = async ({
   answers: AnswerInSessionState[];
   fileUrls?: string | string[];
   workspaceId: string;
+  resultId: string;
   sessionStore: SessionStore;
 }): Promise<LogInSession[] | undefined> => {
   const logs: LogInSession[] = [];
@@ -216,6 +219,7 @@ const sendEmail = async ({
     attachments: await parseEmailAttachments({
       fileUrls,
       typebotId: typebot.id,
+      resultId,
     }),
     disableFileAccess: true,
     ...emailBody,

--- a/packages/bot-engine/src/blocks/integrations/sendEmail/parseEmailAttachments.test.ts
+++ b/packages/bot-engine/src/blocks/integrations/sendEmail/parseEmailAttachments.test.ts
@@ -37,6 +37,7 @@ describe("parseEmailAttachments", () => {
       parseEmailAttachments({
         fileUrls: "local-attachment.txt",
         typebotId,
+        resultId,
         dependencies: createDependencies().dependencies,
       }),
     ).rejects.toThrow(invalidAttachmentUrlErrorMessage);
@@ -58,6 +59,7 @@ describe("parseEmailAttachments", () => {
         parseEmailAttachments({
           fileUrls: `http://localhost:${server.port}/attachment.txt`,
           typebotId,
+          resultId,
           dependencies: createDependencies().dependencies,
         }),
       ).rejects.toThrow(invalidAttachmentUrlErrorMessage);
@@ -75,9 +77,23 @@ describe("parseEmailAttachments", () => {
       parseEmailAttachments({
         fileUrls: publicFileUrl,
         typebotId,
+        resultId,
         dependencies: createDependencies().dependencies,
       }),
     ).resolves.toEqual([{ path: publicFileUrl }]);
+  });
+
+  it("accepts legacy WhatsApp public Typebot upload attachments", async () => {
+    const legacyPublicFileUrl = `${parseS3PublicBaseUrl()}/public/public/workspaces/${workspaceId}/typebots/${typebotId}/results/${resultId}/${fileName}`;
+
+    await expect(
+      parseEmailAttachments({
+        fileUrls: legacyPublicFileUrl,
+        typebotId,
+        resultId,
+        dependencies: createDependencies().dependencies,
+      }),
+    ).resolves.toEqual([{ path: legacyPublicFileUrl }]);
   });
 
   it("rejects public Typebot upload URLs from another typebot", async () => {
@@ -87,6 +103,18 @@ describe("parseEmailAttachments", () => {
       parseEmailAttachments({
         fileUrls: publicFileUrl,
         typebotId,
+        resultId,
+        dependencies: createDependencies().dependencies,
+      }),
+    ).rejects.toThrow(invalidAttachmentUrlErrorMessage);
+  });
+
+  it("rejects private Typebot upload attachments from another result", async () => {
+    await expect(
+      parseEmailAttachments({
+        fileUrls: `${env.NEXTAUTH_URL}/api/typebots/${typebotId}/results/other-result/${fileName}`,
+        typebotId,
+        resultId,
         dependencies: createDependencies().dependencies,
       }),
     ).rejects.toThrow(invalidAttachmentUrlErrorMessage);
@@ -103,6 +131,7 @@ describe("parseEmailAttachments", () => {
         `${env.NEXTAUTH_URL}/api/typebots/${typebotId}/results/${resultId}/blocks/${blockId}/${fileName}`,
       ],
       typebotId,
+      resultId,
       dependencies,
     });
 

--- a/packages/bot-engine/src/blocks/integrations/sendEmail/parseEmailAttachments.test.ts
+++ b/packages/bot-engine/src/blocks/integrations/sendEmail/parseEmailAttachments.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "bun:test";
+import { env } from "@typebot.io/env";
+import { parseS3PublicBaseUrl } from "@typebot.io/lib/s3/parseS3PublicBaseUrl";
+import { parseEmailAttachments } from "./parseEmailAttachments";
+
+const typebotId = "typebot-1";
+const workspaceId = "workspace-1";
+const resultId = "result-1";
+const blockId = "block-1";
+const fileName = "attachment.txt";
+const invalidAttachmentUrlErrorMessage = "Invalid email attachment URL";
+
+const createDependencies = () => {
+  const getFileTempUrlCalls: { key: string; expires?: number }[] = [];
+
+  return {
+    dependencies: {
+      getTypebotWorkspaceId: async () => workspaceId,
+      getFileTempUrl: async ({
+        key,
+        expires,
+      }: {
+        key: string;
+        expires?: number;
+      }) => {
+        getFileTempUrlCalls.push({ key, expires });
+        return `https://typebot-storage.test/${key}`;
+      },
+    },
+    getFileTempUrlCalls,
+  };
+};
+
+describe("parseEmailAttachments", () => {
+  it("rejects local attachment paths", async () => {
+    await expect(
+      parseEmailAttachments({
+        fileUrls: "local-attachment.txt",
+        typebotId,
+        dependencies: createDependencies().dependencies,
+      }),
+    ).rejects.toThrow(invalidAttachmentUrlErrorMessage);
+  });
+
+  it("rejects untrusted attachment URLs without requesting them", async () => {
+    let requestCount = 0;
+    const server = Bun.serve({
+      hostname: "localhost",
+      port: 0,
+      fetch: () => {
+        requestCount += 1;
+        return new Response("not a Typebot upload");
+      },
+    });
+
+    try {
+      await expect(
+        parseEmailAttachments({
+          fileUrls: `http://localhost:${server.port}/attachment.txt`,
+          typebotId,
+          dependencies: createDependencies().dependencies,
+        }),
+      ).rejects.toThrow(invalidAttachmentUrlErrorMessage);
+
+      expect(requestCount).toBe(0);
+    } finally {
+      server.stop();
+    }
+  });
+
+  it("accepts public Typebot upload attachments", async () => {
+    const publicFileUrl = `${parseS3PublicBaseUrl()}/public/workspaces/${workspaceId}/typebots/${typebotId}/results/${resultId}/${fileName}`;
+
+    await expect(
+      parseEmailAttachments({
+        fileUrls: publicFileUrl,
+        typebotId,
+        dependencies: createDependencies().dependencies,
+      }),
+    ).resolves.toEqual([{ path: publicFileUrl }]);
+  });
+
+  it("rejects public Typebot upload URLs from another typebot", async () => {
+    const publicFileUrl = `${parseS3PublicBaseUrl()}/public/workspaces/${workspaceId}/typebots/other-typebot/results/${resultId}/${fileName}`;
+
+    await expect(
+      parseEmailAttachments({
+        fileUrls: publicFileUrl,
+        typebotId,
+        dependencies: createDependencies().dependencies,
+      }),
+    ).rejects.toThrow(invalidAttachmentUrlErrorMessage);
+  });
+
+  it("resolves private Typebot upload attachments to temporary URLs", async () => {
+    const { dependencies, getFileTempUrlCalls } = createDependencies();
+    const legacyPrivateFileKey = `private/workspaces/${workspaceId}/typebots/${typebotId}/results/${resultId}/${fileName}`;
+    const blockPrivateFileKey = `private/workspaces/${workspaceId}/typebots/${typebotId}/results/${resultId}/blocks/${blockId}/${fileName}`;
+
+    const attachments = await parseEmailAttachments({
+      fileUrls: [
+        `${env.NEXTAUTH_URL}/api/typebots/${typebotId}/results/${resultId}/${fileName}`,
+        `${env.NEXTAUTH_URL}/api/typebots/${typebotId}/results/${resultId}/blocks/${blockId}/${fileName}`,
+      ],
+      typebotId,
+      dependencies,
+    });
+
+    expect(attachments).toEqual([
+      { path: `https://typebot-storage.test/${legacyPrivateFileKey}` },
+      { path: `https://typebot-storage.test/${blockPrivateFileKey}` },
+    ]);
+
+    expect(getFileTempUrlCalls).toEqual([
+      { key: legacyPrivateFileKey, expires: 600 },
+      { key: blockPrivateFileKey, expires: 600 },
+    ]);
+  });
+});

--- a/packages/bot-engine/src/blocks/integrations/sendEmail/parseEmailAttachments.ts
+++ b/packages/bot-engine/src/blocks/integrations/sendEmail/parseEmailAttachments.ts
@@ -1,0 +1,223 @@
+import { env } from "@typebot.io/env";
+import { getFileTempUrl } from "@typebot.io/lib/s3/getFileTempUrl";
+import { parseS3PublicBaseUrl } from "@typebot.io/lib/s3/parseS3PublicBaseUrl";
+import type Mail from "nodemailer/lib/mailer/index";
+import { getTypebotWorkspaceId } from "../../../queries/getTypebotWorkspaceId";
+
+type ParseEmailAttachmentsDependencies = {
+  getFileTempUrl: typeof getFileTempUrl;
+  getTypebotWorkspaceId: typeof getTypebotWorkspaceId;
+};
+
+const defaultDependencies = {
+  getFileTempUrl,
+  getTypebotWorkspaceId,
+};
+
+const invalidAttachmentUrlErrorMessage = "Invalid email attachment URL";
+
+export const parseEmailAttachments = async ({
+  fileUrls,
+  typebotId,
+  dependencies = defaultDependencies,
+}: {
+  fileUrls: string | string[] | undefined;
+  typebotId: string;
+  dependencies?: ParseEmailAttachmentsDependencies;
+}): Promise<Mail.Attachment[] | undefined> => {
+  const urls = parseAttachmentUrls(fileUrls);
+  if (urls.length === 0) return;
+
+  return Promise.all(
+    urls.map((url) => parseEmailAttachment({ url, typebotId, dependencies })),
+  );
+};
+
+const parseEmailAttachment = async ({
+  url,
+  typebotId,
+  dependencies,
+}: {
+  url: string;
+  typebotId: string;
+  dependencies: ParseEmailAttachmentsDependencies;
+}): Promise<Mail.Attachment> => {
+  const parsedUrl = parseHttpUrl(url);
+  const privateUpload = parsePrivateTypebotUploadUrl({
+    url: parsedUrl,
+    typebotId,
+  });
+
+  if (privateUpload) {
+    const workspaceId = await dependencies.getTypebotWorkspaceId(typebotId);
+    if (!workspaceId) throw new Error(invalidAttachmentUrlErrorMessage);
+
+    return {
+      path: await dependencies.getFileTempUrl({
+        key: `private/workspaces/${workspaceId}/typebots/${typebotId}/results/${privateUpload.resultId}/${privateUpload.blockId ? `blocks/${privateUpload.blockId}/` : ""}${privateUpload.fileName}`,
+        expires: 600,
+      }),
+    };
+  }
+
+  if (isPublicTypebotUploadUrl({ url: parsedUrl, typebotId }))
+    return { path: parsedUrl.href };
+
+  throw new Error(invalidAttachmentUrlErrorMessage);
+};
+
+const parseAttachmentUrls = (
+  fileUrls: string | string[] | undefined,
+): string[] => {
+  if (!fileUrls) return [];
+  const urls = Array.isArray(fileUrls) ? fileUrls : fileUrls.split(", ");
+  return urls.map((url) => url.trim()).filter((url) => url.length > 0);
+};
+
+const parseHttpUrl = (url: string): URL => {
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:")
+      throw new Error(invalidAttachmentUrlErrorMessage);
+    return parsedUrl;
+  } catch {
+    throw new Error(invalidAttachmentUrlErrorMessage);
+  }
+};
+
+const parsePrivateTypebotUploadUrl = ({
+  url,
+  typebotId,
+}: {
+  url: URL;
+  typebotId: string;
+}): { resultId: string; blockId?: string; fileName: string } | undefined => {
+  if (url.origin !== new URL(env.NEXTAUTH_URL).origin) return;
+
+  const segments = getPathSegments(url);
+  const [api, typebots, urlTypebotId, results, resultId, nextSegment] =
+    segments;
+
+  if (
+    api !== "api" ||
+    typebots !== "typebots" ||
+    urlTypebotId !== typebotId ||
+    results !== "results" ||
+    !resultId ||
+    !nextSegment
+  )
+    return;
+
+  if (segments.length === 6) {
+    if (!areUploadPathSegmentsValid([urlTypebotId, resultId, nextSegment]))
+      throw new Error(invalidAttachmentUrlErrorMessage);
+
+    return {
+      resultId,
+      fileName: nextSegment,
+    };
+  }
+
+  const [, , , , , blocks, blockId, fileName] = segments;
+
+  if (segments.length !== 8 || blocks !== "blocks" || !blockId || !fileName)
+    return;
+
+  if (!areUploadPathSegmentsValid([urlTypebotId, resultId, blockId, fileName]))
+    throw new Error(invalidAttachmentUrlErrorMessage);
+
+  return {
+    resultId,
+    blockId,
+    fileName,
+  };
+};
+
+const isPublicTypebotUploadUrl = ({
+  url,
+  typebotId,
+}: {
+  url: URL;
+  typebotId: string;
+}): boolean => {
+  const publicBaseUrl = parsePublicBaseUrl();
+  if (!publicBaseUrl || url.origin !== publicBaseUrl.origin) return false;
+
+  const publicBasePathSegments = getPathSegments(publicBaseUrl);
+  const urlPathSegments = getPathSegments(url);
+  if (!startsWithSegments(urlPathSegments, publicBasePathSegments))
+    return false;
+
+  const uploadSegments = urlPathSegments.slice(publicBasePathSegments.length);
+  const [
+    visibility,
+    workspaces,
+    workspaceId,
+    typebots,
+    urlTypebotId,
+    results,
+    resultId,
+    nextSegment,
+  ] = uploadSegments;
+
+  if (
+    visibility !== "public" ||
+    workspaces !== "workspaces" ||
+    !workspaceId ||
+    typebots !== "typebots" ||
+    urlTypebotId !== typebotId ||
+    results !== "results" ||
+    !resultId ||
+    !nextSegment
+  )
+    return false;
+
+  if (uploadSegments.length === 8)
+    return areUploadPathSegmentsValid([
+      workspaceId,
+      urlTypebotId,
+      resultId,
+      nextSegment,
+    ]);
+
+  const [, , , , , , , blocks, blockId, fileName] = uploadSegments;
+
+  return (
+    uploadSegments.length === 10 &&
+    blocks === "blocks" &&
+    !!blockId &&
+    !!fileName &&
+    areUploadPathSegmentsValid([
+      workspaceId,
+      urlTypebotId,
+      resultId,
+      blockId,
+      fileName,
+    ])
+  );
+};
+
+const parsePublicBaseUrl = (): URL | undefined => {
+  try {
+    return new URL(parseS3PublicBaseUrl());
+  } catch {
+    return;
+  }
+};
+
+const getPathSegments = (url: URL): string[] =>
+  url.pathname.split("/").filter((segment) => segment.length > 0);
+
+const startsWithSegments = (
+  segments: string[],
+  expectedPrefix: string[],
+): boolean =>
+  expectedPrefix.every((segment, index) => segments[index] === segment);
+
+const areUploadPathSegmentsValid = (segments: string[]): boolean =>
+  segments.every(
+    (segment) =>
+      /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(segment) &&
+      segment !== "." &&
+      segment !== "..",
+  );

--- a/packages/bot-engine/src/blocks/integrations/sendEmail/parseEmailAttachments.ts
+++ b/packages/bot-engine/src/blocks/integrations/sendEmail/parseEmailAttachments.ts
@@ -19,33 +19,40 @@ const invalidAttachmentUrlErrorMessage = "Invalid email attachment URL";
 export const parseEmailAttachments = async ({
   fileUrls,
   typebotId,
+  resultId,
   dependencies = defaultDependencies,
 }: {
   fileUrls: string | string[] | undefined;
   typebotId: string;
+  resultId: string;
   dependencies?: ParseEmailAttachmentsDependencies;
 }): Promise<Mail.Attachment[] | undefined> => {
   const urls = parseAttachmentUrls(fileUrls);
   if (urls.length === 0) return;
 
   return Promise.all(
-    urls.map((url) => parseEmailAttachment({ url, typebotId, dependencies })),
+    urls.map((url) =>
+      parseEmailAttachment({ url, typebotId, resultId, dependencies }),
+    ),
   );
 };
 
 const parseEmailAttachment = async ({
   url,
   typebotId,
+  resultId,
   dependencies,
 }: {
   url: string;
   typebotId: string;
+  resultId: string;
   dependencies: ParseEmailAttachmentsDependencies;
 }): Promise<Mail.Attachment> => {
   const parsedUrl = parseHttpUrl(url);
   const privateUpload = parsePrivateTypebotUploadUrl({
     url: parsedUrl,
     typebotId,
+    resultId,
   });
 
   if (privateUpload) {
@@ -88,9 +95,11 @@ const parseHttpUrl = (url: string): URL => {
 const parsePrivateTypebotUploadUrl = ({
   url,
   typebotId,
+  resultId: currentResultId,
 }: {
   url: URL;
   typebotId: string;
+  resultId: string;
 }): { resultId: string; blockId?: string; fileName: string } | undefined => {
   if (url.origin !== new URL(env.NEXTAUTH_URL).origin) return;
 
@@ -103,6 +112,7 @@ const parsePrivateTypebotUploadUrl = ({
     typebots !== "typebots" ||
     urlTypebotId !== typebotId ||
     results !== "results" ||
+    resultId !== currentResultId ||
     !resultId ||
     !nextSegment
   )
@@ -148,7 +158,9 @@ const isPublicTypebotUploadUrl = ({
   if (!startsWithSegments(urlPathSegments, publicBasePathSegments))
     return false;
 
-  const uploadSegments = urlPathSegments.slice(publicBasePathSegments.length);
+  const uploadSegments = normalizePublicUploadSegments(
+    urlPathSegments.slice(publicBasePathSegments.length),
+  );
   const [
     visibility,
     workspaces,
@@ -204,6 +216,11 @@ const parsePublicBaseUrl = (): URL | undefined => {
     return;
   }
 };
+
+const normalizePublicUploadSegments = (uploadSegments: string[]): string[] =>
+  uploadSegments[0] === "public" && uploadSegments[1] === "public"
+    ? uploadSegments.slice(1)
+    : uploadSegments;
 
 const getPathSegments = (url: URL): string[] =>
   url.pathname.split("/").filter((segment) => segment.length > 0);

--- a/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.test.ts
+++ b/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.test.ts
@@ -2,9 +2,24 @@ import { InputBlockType } from "@typebot.io/blocks-inputs/constants";
 import type { FileInputBlock } from "@typebot.io/blocks-inputs/file/schema";
 import type { TextInputBlock } from "@typebot.io/blocks-inputs/text/schema";
 import type { WhatsAppCredentials } from "@typebot.io/credentials/schemas";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { convertWhatsAppMessageToTypebotMessage } from "./convertWhatsAppMessageToTypebotMessage";
 import type { WhatsAppIncomingMessage } from "./schemas";
+
+const mocks = vi.hoisted(() => ({
+  downloadMedia: vi.fn(),
+  uploadFileToBucket: vi.fn(
+    ({ key }: { key: string }) => `https://s3.typebot.test/public/${key}`,
+  ),
+}));
+
+vi.mock("./downloadMedia", () => ({
+  downloadMedia: mocks.downloadMedia,
+}));
+
+vi.mock("@typebot.io/lib/s3/uploadFileToBucket", () => ({
+  uploadFileToBucket: mocks.uploadFileToBucket,
+}));
 
 const credentials = {
   provider: "meta",
@@ -13,6 +28,14 @@ const credentials = {
 } satisfies WhatsAppCredentials["data"];
 
 describe("convertWhatsAppMessageToTypebotMessage", () => {
+  beforeEach(() => {
+    mocks.downloadMedia.mockResolvedValue({
+      file: Buffer.from("audio"),
+      mimeType: "audio/ogg",
+    });
+    mocks.uploadFileToBucket.mockClear();
+  });
+
   it("converts audio messages to text URLs for file input blocks", async () => {
     const block = {
       id: "file-input",
@@ -131,6 +154,38 @@ describe("convertWhatsAppMessageToTypebotMessage", () => {
       text: "http://localhost:3000/api/typebots/typebot-id/whatsapp/media/audio-media-id.ogg",
       attachedFileUrls: [],
       metadata: { replyId: undefined },
+    });
+  });
+
+  it("stores public file input media under a single public prefix", async () => {
+    const block = {
+      id: "file-input",
+      type: InputBlockType.FILE,
+      options: {
+        variableId: "file-variable",
+        visibility: "Public",
+      },
+    } satisfies FileInputBlock;
+
+    const result = await convertWhatsAppMessageToTypebotMessage({
+      messages: [createAudioMessage("audio-media-id")],
+      workspaceId: "workspace-id",
+      credentials,
+      typebotId: "typebot-id",
+      resultId: "result-id",
+      block,
+    });
+
+    expect(result).toEqual({
+      type: "text",
+      text: "https://s3.typebot.test/public/workspaces/workspace-id/typebots/typebot-id/results/result-id/audio-media-id.ogg",
+      attachedFileUrls: [],
+      metadata: { replyId: undefined },
+    });
+    expect(mocks.uploadFileToBucket).toHaveBeenCalledWith({
+      file: Buffer.from("audio"),
+      key: "workspaces/workspace-id/typebots/typebot-id/results/result-id/audio-media-id.ogg",
+      mimeType: "audio/ogg",
     });
   });
 });

--- a/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.ts
+++ b/packages/whatsapp/src/convertWhatsAppMessageToTypebotMessage.ts
@@ -112,7 +112,7 @@ export const convertWhatsAppMessageToTypebotMessage = async ({
             file,
             key:
               resultId && workspaceId && typebotId
-                ? `public/workspaces/${workspaceId}/typebots/${typebotId}/results/${resultId}/${mediaId}${extension ? `.${extension}` : ""}`
+                ? `workspaces/${workspaceId}/typebots/${typebotId}/results/${resultId}/${mediaId}${extension ? `.${extension}` : ""}`
                 : `tmp/whatsapp/media/${mediaId}${extension ? `.${extension}` : ""}`,
             mimeType,
           });


### PR DESCRIPTION
- Restrict Send Email attachments to valid Typebot upload URLs.
- Resolve private Typebot upload URLs to short-lived storage URLs before sending.
- Enable Nodemailer local file access protection for Send Email messages.
- Fix WhatsApp public media upload keys to avoid a duplicated public prefix.
- Add regression tests for rejected attachment origins and valid Typebot uploads.