### PR TITLE
🔧 Add manual Vercel preview deployments

### DIFF
--- a/.github/workflows/deploy-vercel-preview.yml
+++ b/.github/workflows/deploy-vercel-preview.yml
@@ -1,0 +1,79 @@
+name: Deploy Vercel Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      project:
+        description: "Vercel project to deploy"
+        required: true
+        default: "both"
+        type: choice
+        options:
+          - both
+          - builder
+          - viewer
+      ref:
+        description: "Git ref to deploy. Leave empty to use the selected workflow branch."
+        required: false
+        type: string
+      alias:
+        description: "Branch name used for preview aliases. Leave empty to use the deployed ref."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.alias || inputs.ref || github.ref_name }}-${{ inputs.project }}
+  cancel-in-progress: false
+
+env:
+  BUILDER_PROJECT_ID: prj_wrL6oQ73LsDKbNSq2ZxgnaYKlCHf
+  BUILDER_PROJECT_NAME: builder-v2
+  VIEWER_PROJECT_ID: prj_LPsimKxRQU4ek8KPaqyMEGCiaeOR
+  VIEWER_PROJECT_NAME: viewer-v2
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_TEAM_ID }}
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  VERCEL_CLI_VERSION: 54.18.2
+
+jobs:
+  deploy-builder:
+    if: ${{ inputs.project == 'both' || inputs.project == 'builder' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 1
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: "package.json"
+      - name: Deploy builder preview
+        run: |
+          set -euo pipefail
+          source .github/workflows/scripts/deploy-vercel-preview.sh
+          deploy_vercel_preview builder "${BUILDER_PROJECT_ID}" "${BUILDER_PROJECT_NAME}"
+        env:
+          PREVIEW_ALIAS_INPUT: ${{ inputs.alias }}
+          PREVIEW_REF_INPUT: ${{ inputs.ref }}
+
+  deploy-viewer:
+    if: ${{ inputs.project == 'both' || inputs.project == 'viewer' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 1
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: "package.json"
+      - name: Deploy viewer preview
+        run: |
+          set -euo pipefail
+          source .github/workflows/scripts/deploy-vercel-preview.sh
+          deploy_vercel_preview viewer "${VIEWER_PROJECT_ID}" "${VIEWER_PROJECT_NAME}"
+        env:
+          PREVIEW_ALIAS_INPUT: ${{ inputs.alias }}
+          PREVIEW_REF_INPUT: ${{ inputs.ref }}

--- a/.github/workflows/scripts/deploy-vercel-preview.sh
+++ b/.github/workflows/scripts/deploy-vercel-preview.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+branch_slug() {
+  printf "%s" "$1" |
+    tr "[:upper:]" "[:lower:]" |
+    sed -E "s/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g" |
+    cut -c 1-60
+}
+
+deploy_vercel_preview() {
+  local app="$1"
+  local project_id="$2"
+  local project_name="$3"
+  local alias_source="${PREVIEW_ALIAS_INPUT:-${PREVIEW_REF_INPUT:-${GITHUB_REF_NAME}}}"
+  local slug
+  local builder_host
+  local viewer_host
+  local deployment_url
+  local deployment_json
+  local alias_host
+
+  slug="$(branch_slug "$alias_source")"
+
+  if [ -z "$slug" ]; then
+    echo "Could not derive a preview alias from '${alias_source}'" >&2
+    exit 1
+  fi
+
+  builder_host="${BUILDER_PROJECT_NAME}-git-${slug}-typebot-io.vercel.app"
+  viewer_host="${VIEWER_PROJECT_NAME}-git-${slug}-typebot-io.vercel.app"
+
+  if [ "$app" = "builder" ]; then
+    alias_host="$builder_host"
+  else
+    alias_host="$viewer_host"
+  fi
+
+  echo "Deploying ${app} preview for '${alias_source}'"
+  echo "Builder URL: https://${builder_host}"
+  echo "Viewer URL: https://${viewer_host}"
+
+  export VERCEL_PROJECT_ID="$project_id"
+
+  deployment_json="$(
+    bunx "vercel@${VERCEL_CLI_VERSION:-54.18.2}" deploy \
+      --yes \
+      --force \
+      --with-cache \
+      --archive=tgz \
+      --target=preview \
+      --format=json \
+      --token="$VERCEL_TOKEN" \
+      --build-env="NEXTAUTH_URL=https://${builder_host}" \
+      --env="NEXTAUTH_URL=https://${builder_host}" \
+      --build-env="NEXT_PUBLIC_VIEWER_URL=https://${viewer_host}" \
+      --env="NEXT_PUBLIC_VIEWER_URL=https://${viewer_host}" \
+      --build-env="VERCEL_BUILDER_PROJECT_NAME=${BUILDER_PROJECT_NAME}" \
+      --env="VERCEL_BUILDER_PROJECT_NAME=${BUILDER_PROJECT_NAME}" \
+      --build-env="NEXT_PUBLIC_VERCEL_VIEWER_PROJECT_NAME=${VIEWER_PROJECT_NAME}" \
+      --env="NEXT_PUBLIC_VERCEL_VIEWER_PROJECT_NAME=${VIEWER_PROJECT_NAME}" \
+      --meta="manualPreviewAlias=${alias_source}" \
+      --meta="manualPreviewApp=${app}"
+  )"
+
+  deployment_url="$(printf "%s" "$deployment_json" | jq -r ".url")"
+
+  if [ -z "$deployment_url" ] || [ "$deployment_url" = "null" ]; then
+    echo "Could not read deployment URL from Vercel response:" >&2
+    printf "%s\n" "$deployment_json" >&2
+    exit 1
+  fi
+
+  bunx "vercel@${VERCEL_CLI_VERSION:-54.18.2}" alias set "$deployment_url" "$alias_host" --token="$VERCEL_TOKEN"
+
+  {
+    echo "### ${app} preview"
+    echo
+    echo "- Deployment: ${deployment_url}"
+    echo "- Alias: https://${alias_host}"
+  } >>"$GITHUB_STEP_SUMMARY"
+}

--- a/apps/builder/vercel.json
+++ b/apps/builder/vercel.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "github": {
-    "silent": true
-  },
   "git": {
     "deploymentEnabled": {
       "main": true,


### PR DESCRIPTION
## What changed
- Add manual `workflow_dispatch` GitHub Action for Vercel preview deployments.
- The workflow can deploy `builder`, `viewer`, or both.
- The workflow uses Vercel CLI source deployments, so it bypasses the Git ignored-build step intentionally.
- Add per-app Vercel Git config so `main` still auto-deploys, while non-main branches do not create automatic Git preview deployments.

## How to use
After this is merged to `main`, open Actions → Deploy Vercel Preview → Run workflow. Select the branch/ref and choose `builder`, `viewer`, or `both`.

## Validation
- `bash -n .github/workflows/scripts/deploy-vercel-preview.sh`
- YAML parsed successfully with Ruby
- `jq empty apps/builder/vercel.json apps/viewer/vercel.json`
- `bunx nx format-and-lint`
- Pre-commit affected checks passed
- Confirmed pushing this branch did not create automatic builder/viewer Vercel deployments