### PR TITLE
fix: restore automatic database sync in dev

### DIFF
--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -8,6 +8,8 @@
     "targets": {
       "dev": {
         "dependsOn": [
+          "^db:generate",
+          "^db:push",
           {
             "projects": [
               "@typebot.io/react"

--- a/apps/docs/contribute/guides/local-installation.mdx
+++ b/apps/docs/contribute/guides/local-installation.mdx
@@ -36,7 +36,17 @@ icon: "laptop"
 
    This will also create a minio instance to enable file uploads.
 
-5. Start the builder and viewer
+5. Initialize the database
+
+   Before starting the application, sync the Prisma schema with the local database
+
+    ```sh
+   bunx nx run @typebot.io/prisma:db:push
+   ```
+   
+   You only need to run this when setting up a new local database or after resetting it.
+
+6. Start the builder and viewer
 
    ```sh
    bun dev
@@ -48,7 +58,7 @@ icon: "laptop"
 
    By default, you can easily authenticate in the builder using the "Github Sign In" button. For other options, check out the [Configuration guide](https://docs.typebot.io/self-hosting/configuration).
 
-6. Optionnally you can also run the other available apps:
+7. Optionnally you can also run the other available apps:
 
    For the landing page:
 

--- a/apps/docs/contribute/guides/local-installation.mdx
+++ b/apps/docs/contribute/guides/local-installation.mdx
@@ -36,17 +36,7 @@ icon: "laptop"
 
    This will also create a minio instance to enable file uploads.
 
-5. Initialize the database
-
-   Before starting the application, sync the Prisma schema with the local database
-
-    ```sh
-   bunx nx run @typebot.io/prisma:db:push
-   ```
-   
-   You only need to run this when setting up a new local database or after resetting it.
-
-6. Start the builder and viewer
+5. Start the builder and viewer
 
    ```sh
    bun dev
@@ -58,7 +48,7 @@ icon: "laptop"
 
    By default, you can easily authenticate in the builder using the "Github Sign In" button. For other options, check out the [Configuration guide](https://docs.typebot.io/self-hosting/configuration).
 
-7. Optionnally you can also run the other available apps:
+6. Optionnally you can also run the other available apps:
 
    For the landing page:
 

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -8,6 +8,8 @@
     "targets": {
       "dev": {
         "dependsOn": [
+          "^db:generate",
+          "^db:push",
           {
             "projects": [
               "@typebot.io/react"

--- a/nx.json
+++ b/nx.json
@@ -15,6 +15,9 @@
     }
   ],
   "targetDefaults": {
+    "dev": {
+      "dependsOn": ["^db:generate", "^db:push"]
+    },
     "@nx/esbuild:esbuild": {
       "cache": true,
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

Restores automatic Prisma client generation and database schema synchronization before local development servers start.

## Root cause

Before the Nx migration, the Turbo `dev` task depended on `^db:generate` and `^db:push`. Those dependencies were lost during the migration, leaving fresh local PostgreSQL databases without the required schema.

## Changes

- Add Prisma generation and schema push as defaults for Nx `dev` targets.
- Preserve those dependencies explicitly for builder and viewer, whose project-level `dependsOn` configuration overrides target defaults.
- Keep the local installation guide unchanged because `bun dev` once again initializes the database automatically.

## Validation

- Verified the generated Nx task graph: builder, viewer, and workflows all depend on the deduplicated Prisma `db:generate` and `db:push` tasks.
- Ran `bunx nx format-and-lint`.
- Passed the full affected pre-commit suite: formatting, repository lint, broken-link checks, and tests.