### PR TITLE
Fix Android camera for image extension uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ content-collections.d.ts
 **/next-env.d.ts
 
 .pi
+.revue/comments.json
 
 .agents/skills/typebot-customer-support
 .agents/skills/typebot-discord-bot

--- a/packages/embeds/js/package.json
+++ b/packages/embeds/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/js",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Javascript library to display typebots on your website",
   "license": "FSL-1.1-ALv2",
   "type": "module",
@@ -19,6 +19,9 @@
       "import": "./dist/web.js",
       "default": "./dist/web.js"
     }
+  },
+  "scripts": {
+    "test": "bun test"
   },
   "devDependencies": {
     "@ai-sdk/ui-utils": "^1.2.11",

--- a/packages/embeds/js/src/features/blocks/inputs/fileUpload/helpers/injectAndroidCameraCaptureToMimeTypes.test.ts
+++ b/packages/embeds/js/src/features/blocks/inputs/fileUpload/helpers/injectAndroidCameraCaptureToMimeTypes.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { injectAndroidCameraCaptureToMimeTypes } from "./injectAndroidCameraCaptureToMimeTypes";
+
+describe("injectAndroidCameraCaptureToMimeTypes", () => {
+  it("returns an empty accept value when no file types are configured", () => {
+    expect(injectAndroidCameraCaptureToMimeTypes()).toBe("");
+    expect(injectAndroidCameraCaptureToMimeTypes([])).toBe("");
+  });
+
+  it("keeps the existing workaround for image MIME types", () => {
+    expect(
+      injectAndroidCameraCaptureToMimeTypes(["IMAGE/PNG", "image/*"]),
+    ).toBe("IMAGE/PNG, image/*, capture=camera");
+  });
+
+  it("adds matching image MIME types for image extensions", () => {
+    expect(
+      injectAndroidCameraCaptureToMimeTypes([".JPG", ".jpeg", "png"]),
+    ).toBe(
+      ".JPG, .jpeg, png, image/jpg, image/jpeg, image/png, capture=camera",
+    );
+  });
+
+  it("does not duplicate extensions, MIME types, or the workaround", () => {
+    expect(
+      injectAndroidCameraCaptureToMimeTypes([
+        " .PNG ",
+        "png",
+        "image/png",
+        "IMAGE/PNG",
+        "capture=camera",
+        "CAPTURE=CAMERA",
+      ]),
+    ).toBe(".PNG, image/png, capture=camera");
+  });
+
+  it("prefers dotted extensions when removing duplicates", () => {
+    expect(injectAndroidCameraCaptureToMimeTypes(["pdf", ".PDF"])).toBe(".PDF");
+    expect(injectAndroidCameraCaptureToMimeTypes(["png", ".PNG"])).toBe(
+      ".PNG, image/png, capture=camera",
+    );
+  });
+
+  it("does not change non-image lists beyond removing duplicates", () => {
+    expect(
+      injectAndroidCameraCaptureToMimeTypes([".PDF", "pdf", "application/pdf"]),
+    ).toBe(".PDF, application/pdf");
+  });
+
+  it("enriches mixed lists while preserving non-image types", () => {
+    expect(
+      injectAndroidCameraCaptureToMimeTypes([".pdf", ".PnG", "video/mp4"]),
+    ).toBe(".pdf, .PnG, video/mp4, image/png, capture=camera");
+  });
+});

--- a/packages/embeds/js/src/features/blocks/inputs/fileUpload/helpers/injectAndroidCameraCaptureToMimeTypes.ts
+++ b/packages/embeds/js/src/features/blocks/inputs/fileUpload/helpers/injectAndroidCameraCaptureToMimeTypes.ts
@@ -1,21 +1,72 @@
+import { extensionFromMimeType } from "@typebot.io/lib/extensionFromMimeType";
+
 /**
  * Adds Android camera workaround to file types to ensure camera option appears on Android devices.
- * This addresses an issue in Android 14+ where the camera option doesn't appear for image/* accept types.
+ * This addresses an issue in Android 14+ where the camera option doesn't appear for image accept types.
  */
 export const injectAndroidCameraCaptureToMimeTypes = (
   types?: string[],
 ): string => {
   if (!types || types.length === 0) return "";
 
-  const typesString = types.join(", ");
+  const fileTypeIndexFromNormalizedFileType = new Map<string, number>();
+  const uniqueFileTypes = types.reduce<string[]>((uniqueFileTypes, type) => {
+    const trimmedType = type.trim();
+    const normalizedFileType = normalizeFileType(trimmedType);
+    const existingFileTypeIndex =
+      fileTypeIndexFromNormalizedFileType.get(normalizedFileType);
 
-  const hasImageTypes = types.some(
-    (type) => type.startsWith("image/") || type === "image/*",
+    if (!normalizedFileType) return uniqueFileTypes;
+
+    if (existingFileTypeIndex === undefined) {
+      fileTypeIndexFromNormalizedFileType.set(
+        normalizedFileType,
+        uniqueFileTypes.length,
+      );
+      uniqueFileTypes.push(trimmedType);
+      return uniqueFileTypes;
+    }
+
+    if (
+      trimmedType.startsWith(".") &&
+      uniqueFileTypes[existingFileTypeIndex]?.startsWith(".") === false
+    )
+      uniqueFileTypes[existingFileTypeIndex] = trimmedType;
+
+    return uniqueFileTypes;
+  }, []);
+  const normalizedFileTypes = new Set(
+    fileTypeIndexFromNormalizedFileType.keys(),
   );
 
-  if (hasImageTypes) {
-    return `${typesString}, capture=camera`;
-  }
+  const imageMimeTypesFromExtensions = uniqueFileTypes.flatMap((fileType) =>
+    Object.entries(extensionFromMimeType).flatMap(([mimeType, extension]) => {
+      const normalizedMimeType = normalizeFileType(mimeType);
 
-  return typesString;
+      if (
+        !normalizedMimeType.startsWith("image/") ||
+        normalizeFileType(fileType) !== normalizeFileType(extension) ||
+        normalizedFileTypes.has(normalizedMimeType)
+      )
+        return [];
+
+      normalizedFileTypes.add(normalizedMimeType);
+      return [mimeType];
+    }),
+  );
+
+  if (![...normalizedFileTypes].some((type) => type.startsWith("image/")))
+    return uniqueFileTypes.join(", ");
+
+  if (normalizedFileTypes.has("capture=camera"))
+    return [...uniqueFileTypes, ...imageMimeTypesFromExtensions].join(", ");
+
+  return [
+    ...uniqueFileTypes,
+    ...imageMimeTypesFromExtensions,
+    "capture=camera",
+  ].join(", ");
 };
+
+const normalizeFileType = (fileType: string) =>
+  fileType.trim().toLowerCase().replace(/^\./, "");

--- a/packages/embeds/react/package.json
+++ b/packages/embeds/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/react",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Convenient library to display typebots on your React app",
   "license": "FSL-1.1-ALv2",
   "type": "module",


### PR DESCRIPTION
## What changed

- Detect image extensions in file upload allowlists using the shared `extensionFromMimeType` table.
- Add the corresponding image MIME hints while preserving the original extensions and the existing `capture=camera` Android workaround.
- Normalize casing and leading dots, deduplicate equivalent entries, and prefer valid dotted extensions regardless of input order.
- Add focused unit coverage for image-only, mixed, non-image, duplicate, and casing scenarios.
- Bump the JavaScript and React embed packages to `0.10.6` and ignore local Revue comments.

## Why

The Android camera workaround was only enabled when the configured allowlist already contained an `image/*` MIME type. Bots configured with image extensions such as `.jpg`, `.jpeg`, and `.png` therefore never received the workaround.

## Impact

Android users can access the existing camera option when a file upload block is configured with image extensions. Browser hints are enriched only on the client; server-side validation remains based on the block's original options.

The `capture=camera` token remains a non-standard Android-specific workaround and may continue to vary across browsers.

## Validation

- `bunx nx test @typebot.io/js` — 7 tests passed
- `bunx nx typecheck @typebot.io/js`
- `bunx nx format-and-lint`
- `git diff --check`

The repository-wide pre-commit affected test suite could not complete locally because unrelated packages required missing environment variables and existing SSRF tests failed. The targeted package tests, typecheck, and repository formatting checks passed.
