### PR TITLE
refactor(bot-engine): reorder updateVariablesInSession params

### DIFF
--- a/packages/bot-engine/src/updateVariablesInSession.ts
+++ b/packages/bot-engine/src/updateVariablesInSession.ts
@@ -7,14 +7,14 @@ import type {
 } from "@typebot.io/variables/schemas";
 
 type Props = {
-  state: SessionState;
   newVariables: VariableWithUnknowValue[];
+  state: SessionState;
   currentBlockId: string | undefined;
 };
-// TODO: Refacto newVariables param first, other in second
+
 export const updateVariablesInSession = ({
-  state,
   newVariables,
+  state,
   currentBlockId,
 }: Props): {
   updatedState: SessionState;


### PR DESCRIPTION
## Summary
Resolves an open TODO in `updateVariablesInSession.ts` by reordering the parameters to place `newVariables` first for better API ergonomics.
