### PR TITLE
perf(analytics): run in-depth analytics aggregations concurrently

### DIFF
--- a/apps/builder/src/features/analytics/api/handleGetInDepthAnalyticsData.ts
+++ b/apps/builder/src/features/analytics/api/handleGetInDepthAnalyticsData.ts
@@ -47,67 +47,52 @@ export const handleGetInDepthAnalyticsData = async ({
   const fromDate = parseFromDateFromTimeFilter(timeFilter, timeZone);
   const toDate = parseToDateFromTimeFilter(timeFilter, timeZone);
 
-  const totalAnswersPerBlock = await prisma.answer.groupBy({
-    by: ["blockId"],
-    where: {
-      result: {
-        typebotId,
-        createdAt: fromDate
-          ? {
-              gte: fromDate,
-              lte: toDate ?? undefined,
-            }
-          : undefined,
-      },
-      blockId: {
-        in: parseGroups(typebot.publishedTypebot.groups, {
-          typebotVersion: typebot.publishedTypebot.version,
-        }).flatMap((group) =>
-          group.blocks.filter(isInputBlock).map((block) => block.id),
-        ),
-      },
-    },
-    _count: { resultId: true },
-  });
+  // Shared by all three aggregations, so parse the published groups once instead of
+  // rebuilding the same block id list for every query.
+  const resultFilter = {
+    typebotId,
+    createdAt: fromDate
+      ? {
+          gte: fromDate,
+          lte: toDate ?? undefined,
+        }
+      : undefined,
+  };
 
-  const totalAnswersV2PerBlock = await prisma.answerV2.groupBy({
-    by: ["blockId"],
-    where: {
-      result: {
-        typebotId,
-        createdAt: fromDate
-          ? {
-              gte: fromDate,
-              lte: toDate ?? undefined,
-            }
-          : undefined,
-      },
-      blockId: {
-        in: parseGroups(typebot.publishedTypebot.groups, {
-          typebotVersion: typebot.publishedTypebot.version,
-        }).flatMap((group) =>
-          group.blocks.filter(isInputBlock).map((block) => block.id),
-        ),
-      },
-    },
-    _count: { resultId: true },
-  });
+  const inputBlockIds = parseGroups(typebot.publishedTypebot.groups, {
+    typebotVersion: typebot.publishedTypebot.version,
+  }).flatMap((group) =>
+    group.blocks.filter(isInputBlock).map((block) => block.id),
+  );
 
-  const offDefaultPathVisitedEdges = await prisma.visitedEdge.groupBy({
-    by: ["edgeId"],
-    where: {
-      result: {
-        typebotId,
-        createdAt: fromDate
-          ? {
-              gte: fromDate,
-              lte: toDate ?? undefined,
-            }
-          : undefined,
-      },
-    },
-    _count: { resultId: true },
-  });
+  // The three aggregations are independent, so run them concurrently: the endpoint now
+  // waits for the slowest one rather than the sum of all three.
+  const [totalAnswersPerBlock, totalAnswersV2PerBlock, offDefaultPathVisitedEdges] =
+    await Promise.all([
+      prisma.answer.groupBy({
+        by: ["blockId"],
+        where: {
+          result: resultFilter,
+          blockId: { in: inputBlockIds },
+        },
+        _count: { resultId: true },
+      }),
+      prisma.answerV2.groupBy({
+        by: ["blockId"],
+        where: {
+          result: resultFilter,
+          blockId: { in: inputBlockIds },
+        },
+        _count: { resultId: true },
+      }),
+      prisma.visitedEdge.groupBy({
+        by: ["edgeId"],
+        where: {
+          result: resultFilter,
+        },
+        _count: { resultId: true },
+      }),
+    ]);
 
   const edges = z.array(edgeSchema).parse(typebot.publishedTypebot.edges);
 


### PR DESCRIPTION
## What

`handleGetInDepthAnalyticsData` runs its three aggregations one after another, even though none of them depends on the others:

```ts
const totalAnswersPerBlock      = await prisma.answer.groupBy({ ... })
const totalAnswersV2PerBlock    = await prisma.answerV2.groupBy({ ... })
const offDefaultPathVisitedEdges = await prisma.visitedEdge.groupBy({ ... })
```

All three only need `typebotId`, the parsed time filter, and (for the first two) the input block ids — all computed before the first query. So the endpoint currently waits for the **sum** of three round trips when it could wait for the **slowest one**.

This is the in-depth analytics view in the builder, so the latency is in front of a user waiting for a dashboard, not in a background job.

## How

- Run the three `groupBy` calls in `Promise.all`.
- Hoist two things they were each rebuilding:
  - `resultFilter` — the identical `{ typebotId, createdAt }` filter, written out three times
  - `inputBlockIds` — `parseGroups(...).flatMap(...)` was parsing the published groups **twice**, once for each of the answer queries

Net effect is 44 insertions / 59 deletions: fewer lines, one round trip instead of three, and the group parsing happens once.

No behavioural change — same queries, same filters, same shape of results. The destructuring preserves the original variable names so the code below is untouched.

## Testing

- `tsc --build` on `apps/builder`: **the changed file reports no errors**. The build surfaces 8 pre-existing errors elsewhere (all `Cannot find module '@typebot.io/react'`, from the embed package not being built in my environment) — the count is **identical on a clean `main`**, so nothing new comes from this change.
- I specifically wanted to rule out a Prisma typing regression: extracting `resultFilter` into a variable can lose the literal narrowing Prisma's generated input types rely on. It typechecks fine here, which is why the extraction is safe.
- I did not run the app against a database locally, so I have not exercised the endpoint end to end — the argument for correctness is that the queries and their filters are byte-for-byte the same, just hoisted and awaited together.

## Note on error behaviour

With `Promise.all`, if one aggregation rejects the other two are already in flight rather than never started. The handler surfaces the same rejection either way; the only difference is that a failing request may do a little more database work before returning. Given all three are read-only aggregations scoped to one typebot, that seemed like the right trade for the latency win, but happy to switch to `allSettled` or restructure if you'd prefer.
