### PR TITLE
Allow any file type in Embed bubble to be sent as a WhatsApp document

### DIFF
--- a/packages/whatsapp/src/convertMessageToWhatsAppMessage.test.ts
+++ b/packages/whatsapp/src/convertMessageToWhatsAppMessage.test.ts
@@ -1,0 +1,99 @@
+import { BubbleBlockType } from "@typebot.io/blocks-bubbles/constants";
+import type { ContinueChatResponse } from "@typebot.io/chat-api/schemas";
+import { describe, expect, it } from "vitest";
+import { convertMessageToWhatsAppMessage } from "./convertMessageToWhatsAppMessage";
+
+const embedMessage = (url: string): ContinueChatResponse["messages"][number] =>
+  ({
+    type: BubbleBlockType.EMBED,
+    content: { url },
+  }) as ContinueChatResponse["messages"][number];
+
+describe("convertMessageToWhatsAppMessage - Embed", () => {
+  it("should send a known document extension as a downloadable document", async () => {
+    const result = await convertMessageToWhatsAppMessage({
+      message: embedMessage("https://example.com/files/report.pdf"),
+    });
+    expect(result).toEqual({
+      type: "document",
+      document: {
+        link: "https://example.com/files/report.pdf",
+        filename: "report.pdf",
+      },
+    });
+  });
+
+  it("should send an unlisted file extension as a downloadable document", async () => {
+    const result = await convertMessageToWhatsAppMessage({
+      message: embedMessage("https://example.com/files/data.csv"),
+    });
+    expect(result).toEqual({
+      type: "document",
+      document: {
+        link: "https://example.com/files/data.csv",
+        filename: "data.csv",
+      },
+    });
+  });
+
+  it("should strip query params before extracting the extension", async () => {
+    const result = await convertMessageToWhatsAppMessage({
+      message: embedMessage(
+        "https://example.com/files/data.csv?token=abc&expires=123",
+      ),
+    });
+    expect(result).toEqual({
+      type: "document",
+      document: {
+        link: "https://example.com/files/data.csv?token=abc&expires=123",
+        filename: "data.csv",
+      },
+    });
+  });
+
+  it("should not treat an image extension as a document", async () => {
+    const result = await convertMessageToWhatsAppMessage({
+      message: embedMessage("https://example.com/files/photo.png"),
+    });
+    expect(result).toEqual({
+      type: "text",
+      text: {
+        body: "https://example.com/files/photo.png",
+        preview_url: true,
+      },
+    });
+  });
+
+  it("should not mistake a bare domain for a filename", async () => {
+    const result = await convertMessageToWhatsAppMessage({
+      message: embedMessage("https://example.com"),
+    });
+    expect(result).toEqual({
+      type: "text",
+      text: {
+        body: "https://example.com",
+        preview_url: true,
+      },
+    });
+  });
+
+  it("should treat a path with no dot as a plain link", async () => {
+    const result = await convertMessageToWhatsAppMessage({
+      message: embedMessage("https://example.com/some/page"),
+    });
+    expect(result).toEqual({
+      type: "text",
+      text: {
+        body: "https://example.com/some/page",
+        preview_url: true,
+      },
+    });
+  });
+
+  it("should return null when there is no url", async () => {
+    const result = await convertMessageToWhatsAppMessage({
+      message: embedMessage(""),
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/whatsapp/src/convertMessageToWhatsAppMessage.ts
+++ b/packages/whatsapp/src/convertMessageToWhatsAppMessage.ts
@@ -12,6 +12,20 @@ import { convertRichTextToMarkdown } from "@typebot.io/rich-text/convertRichText
 import { getOrUploadMedia, type UploadMediaCache } from "./getOrUploadMedia";
 import type { WhatsAppSendingMessage } from "./schemas";
 
+// Any file extension not in this set is sent as a downloadable "document" —
+// WhatsApp's Cloud API doesn't restrict document mime types the way it does
+// image/audio/video, so we don't need to whitelist known document extensions.
+const mediaFileExtensions = new Set(
+  Object.entries(extensionFromMimeType)
+    .filter(
+      ([mimeType]) =>
+        mimeType.startsWith("audio/") ||
+        mimeType.startsWith("video/") ||
+        mimeType.startsWith("image/"),
+    )
+    .map(([, extension]) => extension),
+);
+
 type Props = {
   message: ContinueChatResponse["messages"][number];
   mediaCache?: UploadMediaCache;
@@ -132,18 +146,23 @@ export const convertMessageToWhatsAppMessage = async ({
       return null;
     case BubbleBlockType.EMBED: {
       if (!message.content.url) return null;
-      const fileExtension = message.content.url.split(".").pop();
-      const filename = message.content.url.split("/").pop();
-      if (
-        fileExtension &&
-        Object.entries(extensionFromMimeType).some(
-          ([mimeType, extension]) =>
-            !mimeType.includes("audio") &&
-            !mimeType.includes("video") &&
-            !mimeType.includes("image") &&
-            extension === fileExtension,
-        )
-      ) {
+      // Derived from the URL's pathname rather than the raw string so a
+      // bare domain (e.g. "https://example.com") isn't mistaken for a
+      // filename with a "com" extension.
+      let filename: string | undefined;
+      let fileExtension: string | undefined;
+      try {
+        const pathSegment = new URL(message.content.url).pathname
+          .split("/")
+          .pop();
+        if (pathSegment?.includes(".")) {
+          filename = pathSegment;
+          fileExtension = pathSegment.split(".").pop()?.toLowerCase();
+        }
+      } catch {
+        // Not an absolute URL, treat as a plain link below.
+      }
+      if (fileExtension && !mediaFileExtensions.has(fileExtension)) {
         if (mediaCache) {
           const mediaId = await getOrUploadMedia({
             url: message.content.url,


### PR DESCRIPTION
Closes #240.

`convertMessageToWhatsAppMessage` only sends an Embed bubble as a downloadable WhatsApp "document" when its URL's extension exactly matches one of the ~15 non-media entries in `extensionFromMimeType` (pdf, doc/docx, xls/xlsx, ppt/pptx, zip, rar, 7z, json, xml, js, tar, gz, apk, exe, mpkg, rtf, sh, ttf, odt/ods/odp). Anything else — .csv, .txt, .epub, or any format not on that list — fell through to a plain text link instead.

## Fix

Flipped the check: instead of requiring the extension to be in that whitelist, it now only excludes known image/audio/video extensions (derived from the same `extensionFromMimeType` map) — any other file extension is sent as a document, matching the ask ("any file type").

While in there, I also fixed how the extension/filename get derived: the old code did `url.split(".").pop()`, which for a bare domain like `https://example.com` (no path) would grab "com" as a fake extension. Parsing with `new URL(...)` and reading the pathname's last segment avoids that, and also naturally strips query params/hash (a signed URL like `file.pdf?token=...` now correctly extracts `.pdf`, which the old code didn't handle either).

## Tests

Added `convertMessageToWhatsAppMessage.test.ts` (this function had no test coverage before) covering:
- a known document extension (.pdf) → document
- an extension not in the whitelist (.csv) → now also a document
- query params stripped before extracting the extension
- an image extension (.png) → still a plain text link, not a document
- a bare domain isn't mistaken for a filename
- a path with no dot → plain text link
- no url → null

All 53 existing + new tests in the whatsapp package pass.