### PR TITLE
Add option to include cookies in HTTP request executed from client

### DIFF
--- a/apps/builder/src/features/blocks/integrations/httpRequest/components/HttpRequestAdvancedConfigForm.tsx
+++ b/apps/builder/src/features/blocks/integrations/httpRequest/components/HttpRequestAdvancedConfigForm.tsx
@@ -113,6 +113,9 @@ export const HttpRequestAdvancedConfigForm = ({
   const updateIsExecutedOnClient = (isExecutedOnClient: boolean) =>
     onOptionsChange({ ...options, isExecutedOnClient });
 
+  const updateWithCredentials = (withCredentials: boolean) =>
+    onOptionsChange({ ...options, withCredentials });
+
   const ResponseMappingInputs = useMemo(
     () =>
       function Component(props: TableListItemProps<ResponseVariableMapping>) {
@@ -150,6 +153,26 @@ export const HttpRequestAdvancedConfigForm = ({
                 </MoreInfoTooltip>
               </Field.Label>
             </Field.Root>
+            {(options?.isExecutedOnClient ??
+              defaultHttpRequestBlockOptions.isExecutedOnClient) && (
+              <Field.Root className="flex-row items-center">
+                <Switch
+                  checked={
+                    options?.withCredentials ??
+                    defaultHttpRequestBlockOptions.withCredentials
+                  }
+                  onCheckedChange={updateWithCredentials}
+                />
+                <Field.Label>
+                  Send cookies{" "}
+                  <MoreInfoTooltip>
+                    If enabled, the browser will include cookies with the
+                    request and store any cookies the response sets. Only works
+                    if the server allows credentials for your domain (CORS).
+                  </MoreInfoTooltip>
+                </Field.Label>
+              </Field.Root>
+            )}
             <div className="flex items-center gap-2 justify-between">
               <p>Method:</p>
               <BasicSelect

--- a/apps/docs/openapi/builder.json
+++ b/apps/docs/openapi/builder.json
@@ -493,6 +493,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               }
@@ -2154,6 +2158,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               }
@@ -7886,6 +7894,10 @@
               },
               "proxyCredentialsId": {
                 "type": "string"
+              },
+              "withCredentials": {
+                "type": "boolean",
+                "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
               }
             }
           }
@@ -8031,6 +8043,10 @@
               },
               "proxyCredentialsId": {
                 "type": "string"
+              },
+              "withCredentials": {
+                "type": "boolean",
+                "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
               }
             }
           }
@@ -8176,6 +8192,10 @@
               },
               "proxyCredentialsId": {
                 "type": "string"
+              },
+              "withCredentials": {
+                "type": "boolean",
+                "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
               }
             }
           }
@@ -13531,6 +13551,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -13667,6 +13691,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -13804,6 +13832,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -13940,6 +13972,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -15798,6 +15834,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -15934,6 +15974,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -16071,6 +16115,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -16207,6 +16255,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -18065,6 +18117,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -18201,6 +18257,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -18338,6 +18398,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -18474,6 +18538,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -20351,6 +20419,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -20487,6 +20559,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -20624,6 +20700,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -20760,6 +20840,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               },
@@ -21893,6 +21977,10 @@
                                   },
                                   "proxyCredentialsId": {
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean",
+                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                   }
                                 }
                               }
@@ -23739,7 +23827,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   },
                                                   "webhookId": {
@@ -23775,7 +23864,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   },
                                                   "webhookId": {
@@ -23812,7 +23902,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   },
                                                   "webhookId": {
@@ -23848,7 +23939,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   },
                                                   "webhookId": {
@@ -24321,7 +24413,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   }
                                                 },
@@ -29436,6 +29529,10 @@
                                               },
                                               "proxyCredentialsId": {
                                                 "type": "string"
+                                              },
+                                              "withCredentials": {
+                                                "type": "boolean",
+                                                "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                               }
                                             }
                                           }
@@ -31604,6 +31701,10 @@
                                                 },
                                                 "proxyCredentialsId": {
                                                   "type": "string"
+                                                },
+                                                "withCredentials": {
+                                                  "type": "boolean",
+                                                  "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                 }
                                               }
                                             }
@@ -35192,6 +35293,10 @@
                                                     },
                                                     "proxyCredentialsId": {
                                                       "type": "string"
+                                                    },
+                                                    "withCredentials": {
+                                                      "type": "boolean",
+                                                      "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                     }
                                                   }
                                                 }
@@ -37553,6 +37658,10 @@
                                                     },
                                                     "proxyCredentialsId": {
                                                       "type": "string"
+                                                    },
+                                                    "withCredentials": {
+                                                      "type": "boolean",
+                                                      "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                     }
                                                   }
                                                 },
@@ -37629,6 +37738,10 @@
                                                     },
                                                     "proxyCredentialsId": {
                                                       "type": "string"
+                                                    },
+                                                    "withCredentials": {
+                                                      "type": "boolean",
+                                                      "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                     }
                                                   }
                                                 },
@@ -37706,6 +37819,10 @@
                                                     },
                                                     "proxyCredentialsId": {
                                                       "type": "string"
+                                                    },
+                                                    "withCredentials": {
+                                                      "type": "boolean",
+                                                      "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                     }
                                                   }
                                                 },
@@ -37782,6 +37899,10 @@
                                                     },
                                                     "proxyCredentialsId": {
                                                       "type": "string"
+                                                    },
+                                                    "withCredentials": {
+                                                      "type": "boolean",
+                                                      "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                     }
                                                   }
                                                 },
@@ -39256,6 +39377,10 @@
                                                   },
                                                   "proxyCredentialsId": {
                                                     "type": "string"
+                                                  },
+                                                  "withCredentials": {
+                                                    "type": "boolean",
+                                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                   }
                                                 }
                                               }
@@ -41045,6 +41170,10 @@
                                                   },
                                                   "proxyCredentialsId": {
                                                     "type": "string"
+                                                  },
+                                                  "withCredentials": {
+                                                    "type": "boolean",
+                                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                   }
                                                 }
                                               },
@@ -41107,6 +41236,10 @@
                                                   },
                                                   "proxyCredentialsId": {
                                                     "type": "string"
+                                                  },
+                                                  "withCredentials": {
+                                                    "type": "boolean",
+                                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                   }
                                                 }
                                               },
@@ -41170,6 +41303,10 @@
                                                   },
                                                   "proxyCredentialsId": {
                                                     "type": "string"
+                                                  },
+                                                  "withCredentials": {
+                                                    "type": "boolean",
+                                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                   }
                                                 }
                                               },
@@ -41232,6 +41369,10 @@
                                                   },
                                                   "proxyCredentialsId": {
                                                     "type": "string"
+                                                  },
+                                                  "withCredentials": {
+                                                    "type": "boolean",
+                                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                   }
                                                 }
                                               },
@@ -43069,6 +43210,10 @@
                                                 },
                                                 "proxyCredentialsId": {
                                                   "type": "string"
+                                                },
+                                                "withCredentials": {
+                                                  "type": "boolean",
+                                                  "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                 }
                                               }
                                             }
@@ -47177,6 +47322,10 @@
                                                         },
                                                         "proxyCredentialsId": {
                                                           "type": "string"
+                                                        },
+                                                        "withCredentials": {
+                                                          "type": "boolean",
+                                                          "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                         }
                                                       }
                                                     }
@@ -49588,6 +49737,10 @@
                                                         },
                                                         "proxyCredentialsId": {
                                                           "type": "string"
+                                                        },
+                                                        "withCredentials": {
+                                                          "type": "boolean",
+                                                          "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                         }
                                                       }
                                                     },
@@ -49664,6 +49817,10 @@
                                                         },
                                                         "proxyCredentialsId": {
                                                           "type": "string"
+                                                        },
+                                                        "withCredentials": {
+                                                          "type": "boolean",
+                                                          "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                         }
                                                       }
                                                     },
@@ -49741,6 +49898,10 @@
                                                         },
                                                         "proxyCredentialsId": {
                                                           "type": "string"
+                                                        },
+                                                        "withCredentials": {
+                                                          "type": "boolean",
+                                                          "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                         }
                                                       }
                                                     },
@@ -49817,6 +49978,10 @@
                                                         },
                                                         "proxyCredentialsId": {
                                                           "type": "string"
+                                                        },
+                                                        "withCredentials": {
+                                                          "type": "boolean",
+                                                          "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                         }
                                                       }
                                                     },
@@ -51321,6 +51486,10 @@
                                                   },
                                                   "proxyCredentialsId": {
                                                     "type": "string"
+                                                  },
+                                                  "withCredentials": {
+                                                    "type": "boolean",
+                                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                   }
                                                 }
                                               }
@@ -52889,6 +53058,10 @@
                                                   },
                                                   "proxyCredentialsId": {
                                                     "type": "string"
+                                                  },
+                                                  "withCredentials": {
+                                                    "type": "boolean",
+                                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                   }
                                                 }
                                               },
@@ -52951,6 +53124,10 @@
                                                   },
                                                   "proxyCredentialsId": {
                                                     "type": "string"
+                                                  },
+                                                  "withCredentials": {
+                                                    "type": "boolean",
+                                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                   }
                                                 }
                                               },
@@ -53014,6 +53191,10 @@
                                                   },
                                                   "proxyCredentialsId": {
                                                     "type": "string"
+                                                  },
+                                                  "withCredentials": {
+                                                    "type": "boolean",
+                                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                   }
                                                 }
                                               },
@@ -53076,6 +53257,10 @@
                                                   },
                                                   "proxyCredentialsId": {
                                                     "type": "string"
+                                                  },
+                                                  "withCredentials": {
+                                                    "type": "boolean",
+                                                    "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                   }
                                                 }
                                               },
@@ -54893,6 +55078,10 @@
                                                 },
                                                 "proxyCredentialsId": {
                                                   "type": "string"
+                                                },
+                                                "withCredentials": {
+                                                  "type": "boolean",
+                                                  "description": "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server."
                                                 }
                                               }
                                             }
@@ -76224,6 +76413,9 @@
                                       "TRACE"
                                     ],
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean"
                                   }
                                 },
                                 "required": [
@@ -77034,7 +77226,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   }
                                                 },
@@ -78496,7 +78689,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   },
                                                   "webhookId": {
@@ -78532,7 +78726,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   },
                                                   "webhookId": {
@@ -78569,7 +78764,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   },
                                                   "webhookId": {
@@ -78605,7 +78801,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   },
                                                   "webhookId": {
@@ -81488,6 +81685,9 @@
                                       "TRACE"
                                     ],
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean"
                                   }
                                 },
                                 "required": [

--- a/apps/docs/openapi/viewer.json
+++ b/apps/docs/openapi/viewer.json
@@ -2971,6 +2971,9 @@
                                       "TRACE"
                                     ],
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean"
                                   }
                                 },
                                 "required": [
@@ -5857,6 +5860,9 @@
                                       "TRACE"
                                     ],
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean"
                                   }
                                 },
                                 "required": [
@@ -8042,7 +8048,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   }
                                                 },
@@ -8075,7 +8082,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   }
                                                 },
@@ -8109,7 +8117,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   }
                                                 },
@@ -8142,7 +8151,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   }
                                                 },
@@ -10751,7 +10761,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   },
                                                   "webhookId": {
@@ -10787,7 +10798,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   },
                                                   "webhookId": {
@@ -10824,7 +10836,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   },
                                                   "webhookId": {
@@ -10860,7 +10873,8 @@
                                                       "isExecutedOnClient": {},
                                                       "webhook": {},
                                                       "timeout": {},
-                                                      "proxyCredentialsId": {}
+                                                      "proxyCredentialsId": {},
+                                                      "withCredentials": {}
                                                     }
                                                   },
                                                   "webhookId": {
@@ -14552,6 +14566,9 @@
                                       "TRACE"
                                     ],
                                     "type": "string"
+                                  },
+                                  "withCredentials": {
+                                    "type": "boolean"
                                   }
                                 },
                                 "required": [

--- a/bun.lock
+++ b/bun.lock
@@ -607,7 +607,7 @@
     },
     "packages/embeds/js": {
       "name": "@typebot.io/js",
-      "version": "0.10.5",
+      "version": "0.10.8",
       "devDependencies": {
         "@ai-sdk/ui-utils": "^1.2.11",
         "@ark-ui/solid": "^5.19.0",
@@ -642,7 +642,7 @@
     },
     "packages/embeds/react": {
       "name": "@typebot.io/react",
-      "version": "0.10.5",
+      "version": "0.10.8",
       "dependencies": {
         "@typebot.io/js": "workspace:*",
         "react": "^19.2.4",

--- a/packages/blocks/integrations/src/httpRequest/constants.ts
+++ b/packages/blocks/integrations/src/httpRequest/constants.ts
@@ -19,6 +19,7 @@ export const defaultHttpRequestAttributes = {
 export const defaultHttpRequestBlockOptions = {
   isCustomBody: false,
   isExecutedOnClient: false,
+  withCredentials: false,
 } as const satisfies HttpRequestBlockV6["options"];
 
 export const defaultTimeout = 10;

--- a/packages/blocks/integrations/src/httpRequest/schema.ts
+++ b/packages/blocks/integrations/src/httpRequest/schema.ts
@@ -50,6 +50,12 @@ export const httpRequestOptionsV5Schema = z.object({
   webhook: httpRequestSchemas.v5.optional(),
   timeout: z.number().min(1).max(maxTimeout).optional(),
   proxyCredentialsId: z.string().optional(),
+  withCredentials: z
+    .boolean()
+    .optional()
+    .describe(
+      "Only applies when isExecutedOnClient is true. Include cookies with the client-side fetch so the response can set/read cookies on a cross-origin server.",
+    ),
 });
 
 const httpRequestOptionsSchemas = {
@@ -91,6 +97,7 @@ export const executableHttpRequestSchema = z.object({
   headers: z.record(z.string(), z.string()).optional(),
   body: z.unknown().optional(),
   method: z.nativeEnum(HttpMethod).optional(),
+  withCredentials: z.boolean().optional(),
 });
 
 export type KeyValue = { id: string; key?: string; value?: string };

--- a/packages/bot-engine/src/blocks/integrations/httpRequest/executeHttpRequestBlock.ts
+++ b/packages/bot-engine/src/blocks/integrations/httpRequest/executeHttpRequestBlock.ts
@@ -94,6 +94,7 @@ export const executeHttpRequestBlock = async (
           workspaceId: state.workspaceId,
         }
       : undefined,
+    withCredentials: block.options?.withCredentials,
   });
   if (!parsedHttpRequest) {
     logs.push({
@@ -147,6 +148,7 @@ export const parseHttpRequestAttributes = async ({
   answers,
   sessionStore,
   proxy,
+  withCredentials,
 }: {
   httpRequest: HttpRequest;
   isCustomBody?: boolean;
@@ -157,6 +159,7 @@ export const parseHttpRequestAttributes = async ({
     credentialsId: string;
     workspaceId: string;
   };
+  withCredentials?: boolean;
 }): Promise<ParsedHttpRequest | undefined> => {
   if (!httpRequest.url) return;
   const basicAuth: { username?: string; password?: string } = {};
@@ -228,6 +231,7 @@ export const parseHttpRequestAttributes = async ({
     body,
     isJson,
     proxyUrl,
+    withCredentials,
   };
 };
 

--- a/packages/embeds/js/package.json
+++ b/packages/embeds/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/js",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Javascript library to display typebots on your website",
   "license": "FSL-1.1-ALv2",
   "type": "module",

--- a/packages/embeds/js/src/features/blocks/integrations/httpRequest/executeHttpRequest.test.ts
+++ b/packages/embeds/js/src/features/blocks/integrations/httpRequest/executeHttpRequest.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { ExecutableHttpRequest } from "@typebot.io/blocks-integrations/httpRequest/schema";
+import { executeHttpRequest } from "./executeHttpRequest";
+
+const baseRequest: ExecutableHttpRequest = {
+  url: "https://example.com/api",
+  method: "GET" as ExecutableHttpRequest["method"],
+};
+
+describe("executeHttpRequest", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const mockFetch = () => {
+    const fetchMock = mock((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve({ ok: true }),
+      } as Response),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    return fetchMock;
+  };
+
+  it("should not include credentials by default", async () => {
+    const fetchMock = mockFetch();
+    await executeHttpRequest(baseRequest, false);
+    expect(fetchMock.mock.calls[0]?.[1]?.credentials).toBeUndefined();
+  });
+
+  it("should include credentials when withCredentials is true", async () => {
+    const fetchMock = mockFetch();
+    await executeHttpRequest({ ...baseRequest, withCredentials: true }, false);
+    expect(fetchMock.mock.calls[0]?.[1]?.credentials).toBe("include");
+  });
+
+  it("should omit credentials in preview even when withCredentials is true", async () => {
+    const fetchMock = mockFetch();
+    await executeHttpRequest({ ...baseRequest, withCredentials: true }, true);
+    expect(fetchMock.mock.calls[0]?.[1]?.credentials).toBe("omit");
+  });
+});

--- a/packages/embeds/js/src/features/blocks/integrations/httpRequest/executeHttpRequest.ts
+++ b/packages/embeds/js/src/features/blocks/integrations/httpRequest/executeHttpRequest.ts
@@ -4,13 +4,13 @@ export const executeHttpRequest = async (
   httpRequestToExecute: ExecutableHttpRequest,
   isPreview: boolean,
 ): Promise<string> => {
-  const { url, method, body, headers } = httpRequestToExecute;
+  const { url, method, body, headers, withCredentials } = httpRequestToExecute;
   try {
     const response = await fetch(url, {
       method,
       body: method !== "GET" && body ? JSON.stringify(body) : undefined,
       headers,
-      credentials: isPreview ? "omit" : undefined,
+      credentials: isPreview ? "omit" : withCredentials ? "include" : undefined,
     });
     const statusCode = response.status;
     const data = await response.json();

--- a/packages/embeds/react/package.json
+++ b/packages/embeds/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typebot.io/react",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Convenient library to display typebots on your React app",
   "license": "FSL-1.1-ALv2",
   "type": "module",


### PR DESCRIPTION
Closes #1868.

For an HTTP Request block with "Execute on client" enabled, the browser `fetch` call had no `credentials` option set for non-preview requests, so it fell back to the browser default (`same-origin`). A cookie set by a cross-origin server in the response body was therefore never stored by the browser — there was no way to opt into cross-origin cookie handling.

## Fix

Added a `withCredentials` option to the HTTP Request block, only shown in the builder when "Execute on client" is enabled:
- `packages/blocks/integrations/src/httpRequest/schema.ts`: added to both `httpRequestOptionsV5Schema` (the block option) and `executableHttpRequestSchema` (the payload sent to the client)
- `executeHttpRequestBlock.ts`: threads `block.options?.withCredentials` through `parseHttpRequestAttributes` into the client-side action payload
- `executeHttpRequest.ts` (client): `credentials: isPreview ? "omit" : withCredentials ? "include" : undefined` — preview still always omits credentials, unchanged
- Added a "Send cookies" toggle next to "Execute on client" in `HttpRequestAdvancedConfigForm.tsx`

## Tests

Added `executeHttpRequest.test.ts` (no test coverage existed for this function before) covering: default (no credentials option), `withCredentials: true` → `"include"`, and preview mode still omitting credentials even when `withCredentials` is true.

Ran typecheck across all affected projects (`nx affected -t typecheck`) clean, and regenerated the OpenAPI docs (the new field shows up wherever `HttpRequestBlock`'s options are referenced — HTTP Request, Zapier, Make.com, Pabbly Connect all share the schema).