### PR TITLE
fix(prisma): honor the DATABASE_URL schema param in the pg driver adapter

### DIFF
--- a/packages/prisma/src/createPrismaAdapter.ts
+++ b/packages/prisma/src/createPrismaAdapter.ts
@@ -1,6 +1,14 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaPlanetScale } from "@prisma/adapter-planetscale";
 
+const getSchemaFromUrl = (url: string): string | undefined => {
+  try {
+    return new URL(url).searchParams.get("schema") ?? undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 export const createPrismaAdapter = (databaseUrl: string | undefined) => {
   if (!databaseUrl) throw new Error("DATABASE_URL is not set");
 
@@ -8,7 +16,14 @@ export const createPrismaAdapter = (databaseUrl: string | undefined) => {
     databaseUrl.startsWith("postgres://") ||
     databaseUrl.startsWith("postgresql://")
   )
-    return new PrismaPg({ connectionString: databaseUrl });
+    // The `?schema=` search param is applied by Prisma Migrate but the driver
+    // adapter does not read it from the connection string, so pass it through
+    // explicitly. Without this, runtime queries default to the `public` schema
+    // even when the tables live in a custom schema.
+    return new PrismaPg(
+      { connectionString: databaseUrl },
+      { schema: getSchemaFromUrl(databaseUrl) },
+    );
 
   if (databaseUrl.startsWith("mysql://"))
     return new PrismaPlanetScale({ url: databaseUrl });


### PR DESCRIPTION
Fixes #2578.

When `DATABASE_URL` points at a custom Postgres schema (`...?schema=chatbot`), Prisma Migrate uses it correctly, but the Prisma Client queries `public` at runtime, so anything that hits the DB through the client fails. The reported symptom is SSO login breaking with:

```
The table `public.Account` does not exist in the current database.
```

even though the table lives at `chatbot.Account`.

The cause is in `createPrismaAdapter`. The pg driver adapter is created from the connection string alone:

```ts
return new PrismaPg({ connectionString: databaseUrl });
```

Unlike the old query engine, `@prisma/adapter-pg` does not read the `schema` search param off the connection string. It takes the schema as a separate option (`PrismaPgOptions.schema`, "the name of the schema to use in generated queries"), which was never passed, so the adapter fell back to `public`.

This parses the `schema` param from the URL and forwards it to the adapter. When there is no `schema` param it passes `undefined`, which is the same as before, so the default `public` setup is unaffected.

I verified against `@prisma/adapter-pg` 7.9.1 (the version resolved by the `^7.4.0` range in `packages/prisma`): the `PrismaPg(config, { schema })` constructor accepts the option, and `new URL(databaseUrl).searchParams.get("schema")` pulls the value out of a real connection string (including ones with encoded passwords and extra params). Malformed URLs fall back to `undefined` via the try/catch. There is no existing test file for this adapter factory, so I kept the change to the fix itself.