### PR TITLE
Fix custom head code execution on page refresh (#2472)

### DIFF
--- a/apps/viewer/src/test/settings.spec.ts
+++ b/apps/viewer/src/test/settings.spec.ts
@@ -173,4 +173,18 @@ test("Should correctly parse metadata", async ({ page }) => {
           .content,
     ),
   ).toBe("John Doe");
+
+  await page.reload();
+  await expect(
+    page.locator(
+      `input[placeholder="${defaultTextInputOptions.labels.placeholder}"]`,
+    ),
+  ).toBeVisible();
+  expect(
+    await page.evaluate(
+      () =>
+        (document.querySelector('meta[name="author"]') as HTMLMetaElement)
+          .content,
+    ),
+  ).toBe("John Doe");
 });

--- a/packages/embeds/js/src/components/ConversationContainer/ChatContainer.tsx
+++ b/packages/embeds/js/src/components/ConversationContainer/ChatContainer.tsx
@@ -41,6 +41,7 @@ import { mergeThemes } from "../../utils/dynamicTheme";
 import { isNetworkError } from "../../utils/error";
 import { executeClientSideAction } from "../../utils/executeClientSideActions";
 import { getAnswerContent } from "../../utils/getAnswerContent";
+import { injectStartProps } from "../../utils/injectStartProps";
 import { migrateLegacyChatChunks } from "../../utils/migrateLegacyChatChunks";
 import { persist } from "../../utils/persist";
 import { setGeneralBackground } from "../../utils/setCssVariablesValue";
@@ -102,6 +103,19 @@ export const ChatContainer = (props: Props) => {
   onMount(() => {
     window.addEventListener("message", processIncomingEvent);
     (async () => {
+      const initialStartPropsAction =
+        props.initialChatReply.clientSideActions?.find(
+          (action) => "startPropsToInject" in action,
+        );
+      if (
+        initialStartPropsAction &&
+        "startPropsToInject" in initialStartPropsAction
+      )
+        await injectStartProps(
+          initialStartPropsAction.startPropsToInject,
+          props.context.typebot.id,
+        );
+
       const isRecoveredFromStorage = chatChunks().length > 1;
       if (isRecoveredFromStorage) {
         cleanupRecoveredChatChunks();

--- a/packages/embeds/js/src/utils/injectStartProps.ts
+++ b/packages/embeds/js/src/utils/injectStartProps.ts
@@ -8,9 +8,16 @@ import { initGoogleAnalytics } from "../lib/gtag";
 import { gtmBodyElement } from "../lib/gtm";
 import { initPixel } from "../lib/pixel";
 
+let hasInjectedPropsForTypebotId: string | boolean | undefined;
+
 export const injectStartProps = async (
   startPropsToInject: StartPropsToInject,
+  typebotId?: string,
 ) => {
+  const currentKey = typebotId ?? true;
+  if (hasInjectedPropsForTypebotId === currentKey) return;
+  hasInjectedPropsForTypebotId = currentKey;
+
   const customHeadCode = startPropsToInject.customHeadCode;
   if (isNotEmpty(customHeadCode)) injectCustomHeadCode(customHeadCode);
   const gtmId = startPropsToInject.gtmId;


### PR DESCRIPTION
Fixes #2472

### Bug Description
When `customHeadCode` was configured in bot settings, it executed on initial clean load, but failed to execute when a user refreshed the page with an active session stored in `localStorage`. 

### Cause
On initial session start, `startPropsToInject` was executed and subsequently popped/removed from `chatChunks`. When the page was refreshed, the browser loaded a clean DOM, but `chatChunks` restored from `localStorage` no longer contained `startPropsToInject`, preventing `injectCustomHeadCode` from firing on page reload.

### Solution
1. **Idempotency Guard**: Updated `injectStartProps` with an in-memory guard (`hasInjectedPropsForTypebotId`) to prevent duplicate script injections on the same page load.
2. **Mount Injection**: Updated `ChatContainer.tsx` `onMount` to inspect `props.initialChatReply.clientSideActions` for `startPropsToInject` and trigger `injectStartProps`. This guarantees custom head scripts and analytics are injected into the fresh page DOM whenever a session is restored on page refresh.
3. **Automated Test**: Added an e2e test assertion in `settings.spec.ts` reloading the page (`page.reload()`) and verifying `customHeadCode` elements persist across reloads.