### PR TITLE
Fix date and time limit validation bypass (#2581)

### DIFF
--- a/packages/bot-engine/src/blocks/inputs/date/parseDateReply.spec.ts
+++ b/packages/bot-engine/src/blocks/inputs/date/parseDateReply.spec.ts
@@ -1,0 +1,142 @@
+import { InputBlockType } from "@typebot.io/blocks-inputs/constants";
+import type { DateInputBlock } from "@typebot.io/blocks-inputs/date/schema";
+import type { SessionStore } from "@typebot.io/runtime-session-store";
+import type { Variable } from "@typebot.io/variables/schemas";
+import { describe, expect, it } from "vitest";
+import { parseDateReply } from "./parseDateReply";
+
+const createDateBlock = (
+  options?: DateInputBlock["options"],
+): DateInputBlock => ({
+  id: "block-1",
+  type: InputBlockType.DATE,
+  options,
+});
+
+describe("parseDateReply", () => {
+  it("parses valid date replies", () => {
+    const block = createDateBlock();
+    const result = parseDateReply("2024-05-05", block);
+    expect(result.status).toBe("success");
+    if (result.status === "success") {
+      expect(result.content).toBe("2024-05-05");
+    }
+  });
+
+  it("parses valid datetime replies when hasTime is enabled", () => {
+    const block = createDateBlock({ hasTime: true });
+    const result = parseDateReply("2024-05-05 14:30", block);
+    expect(result.status).toBe("success");
+    if (result.status === "success") {
+      expect(result.content).toBe("2024-05-05 14:30");
+    }
+  });
+
+  it("handles date range validation", () => {
+    const rangeBlock = createDateBlock({ isRange: true });
+    const singleResult = parseDateReply("2024-05-01", rangeBlock);
+    expect(singleResult.status).toBe("fail");
+
+    const validRangeResult = parseDateReply(
+      "2024-05-01 to 2024-05-10",
+      rangeBlock,
+    );
+    expect(validRangeResult.status).toBe("success");
+  });
+
+  it("validates exact-date maximum boundary for date-only inputs", () => {
+    const block = createDateBlock({ max: "2024-05-10" });
+    const exactMaxResult = parseDateReply("2024-05-10", block);
+    expect(exactMaxResult.status).toBe("success");
+
+    const outOfBoundsResult = parseDateReply("2024-05-11", block);
+    expect(outOfBoundsResult.status).toBe("fail");
+  });
+
+  it("validates datetime min and max boundaries accurately", () => {
+    const block = createDateBlock({
+      hasTime: true,
+      min: "2024-05-01T10:00",
+      max: "2024-05-10T18:00",
+    });
+
+    expect(parseDateReply("2024-05-01 09:00", block).status).toBe("fail");
+    expect(parseDateReply("2024-05-01 10:00", block).status).toBe("success");
+    expect(parseDateReply("2024-05-05 14:00", block).status).toBe("success");
+    expect(parseDateReply("2024-05-10 18:00", block).status).toBe("success");
+    expect(parseDateReply("2024-05-10 18:01", block).status).toBe("fail");
+  });
+
+  it("resolves variable-backed min and max limits", () => {
+    const block = createDateBlock({
+      hasTime: true,
+      min: "{{minDate}}",
+      max: "{{maxDate}}",
+    });
+
+    const variables: Variable[] = [
+      { id: "var1", name: "minDate", value: "2024-05-01T10:00" },
+      { id: "var2", name: "maxDate", value: "2024-05-10T18:00" },
+    ];
+    const sessionStore = {} as SessionStore;
+
+    expect(
+      parseDateReply("2024-05-01 09:00", block, { variables, sessionStore })
+        .status,
+    ).toBe("fail");
+    expect(
+      parseDateReply("2024-05-01 10:00", block, { variables, sessionStore })
+        .status,
+    ).toBe("success");
+    expect(
+      parseDateReply("2024-05-10 18:05", block, { variables, sessionStore })
+        .status,
+    ).toBe("fail");
+  });
+
+  describe("Timezone independence across UTC, Europe/Paris, and America/Los_Angeles", () => {
+    const timezones = ["UTC", "Europe/Paris", "America/Los_Angeles"];
+
+    timezones.forEach((timezone) => {
+      it(`evaluates date & time limits identically in ${timezone}`, () => {
+        const originalTz = process.env.TZ;
+        process.env.TZ = timezone;
+
+        try {
+          const block = createDateBlock({
+            hasTime: true,
+            min: "2024-05-01T10:00",
+            max: "2024-05-10T18:00",
+          });
+
+          // 09:00 must fail 10:00 minimum check regardless of server timezone
+          expect(parseDateReply("2024-05-01 09:00", block).status).toBe(
+            "fail",
+          );
+
+          // 10:00 exact minimum must pass
+          expect(parseDateReply("2024-05-01 10:00", block).status).toBe(
+            "success",
+          );
+
+          // 14:00 in-range must pass
+          expect(parseDateReply("2024-05-05 14:00", block).status).toBe(
+            "success",
+          );
+
+          // 18:00 exact maximum must pass
+          expect(parseDateReply("2024-05-10 18:00", block).status).toBe(
+            "success",
+          );
+
+          // 18:01 must fail maximum check regardless of server timezone
+          expect(parseDateReply("2024-05-10 18:01", block).status).toBe(
+            "fail",
+          );
+        } finally {
+          process.env.TZ = originalTz;
+        }
+      });
+    });
+  });
+});

--- a/packages/bot-engine/src/blocks/inputs/date/parseDateReply.ts
+++ b/packages/bot-engine/src/blocks/inputs/date/parseDateReply.ts
@@ -1,6 +1,9 @@
 import { defaultDateInputOptions } from "@typebot.io/blocks-inputs/date/constants";
 import type { DateInputBlock } from "@typebot.io/blocks-inputs/date/schema";
 import { isDefined } from "@typebot.io/lib/utils";
+import type { SessionStore } from "@typebot.io/runtime-session-store";
+import { parseVariables } from "@typebot.io/variables/parseVariables";
+import type { Variable } from "@typebot.io/variables/schemas";
 import { en as chronoParser } from "chrono-node";
 import { format } from "date-fns";
 import type { ParsedReply } from "../../../types";
@@ -9,9 +12,16 @@ const formatOptions = {
   useAdditionalDayOfYearTokens: true,
   useAdditionalWeekYearTokens: true,
 };
+
+type ParseDateReplyOptions = {
+  variables?: Variable[];
+  sessionStore?: SessionStore;
+};
+
 export const parseDateReply = (
   reply: string,
   block: DateInputBlock,
+  options?: ParseDateReplyOptions,
 ): ParsedReply => {
   const parsedDate = (
     block.options?.format || defaultDateInputOptions.format
@@ -39,19 +49,34 @@ export const parseDateReply = (
 
   if (block.options?.isRange && !endDate) return { status: "fail" };
 
-  const max = block.options?.max;
+  const startDateUtcMs = getUtcMsFromDate(detectedStartDate);
+  const endDateUtcMs = detectedEndDate
+    ? getUtcMsFromDate(detectedEndDate)
+    : undefined;
+
+  const maxUtcMs = parseLimitToUtcMs(block.options?.max, {
+    isMaxBoundary: true,
+    hasTime: block.options?.hasTime,
+    variables: options?.variables,
+    sessionStore: options?.sessionStore,
+  });
+
   if (
-    isDefined(max) &&
-    (detectedStartDate > new Date(max) ||
-      (detectedEndDate && detectedEndDate > new Date(max)))
+    isDefined(maxUtcMs) &&
+    (startDateUtcMs > maxUtcMs || (endDateUtcMs && endDateUtcMs > maxUtcMs))
   )
     return { status: "fail" };
 
-  const min = block.options?.min;
+  const minUtcMs = parseLimitToUtcMs(block.options?.min, {
+    isMaxBoundary: false,
+    hasTime: block.options?.hasTime,
+    variables: options?.variables,
+    sessionStore: options?.sessionStore,
+  });
+
   if (
-    isDefined(min) &&
-    (detectedStartDate < new Date(min) ||
-      (detectedEndDate && detectedEndDate < new Date(min)))
+    isDefined(minUtcMs) &&
+    (startDateUtcMs < minUtcMs || (endDateUtcMs && endDateUtcMs < minUtcMs))
   )
     return { status: "fail" };
 
@@ -63,3 +88,80 @@ export const parseDateReply = (
 
 const parseDateWithNeutralTimezone = (date: Date) =>
   new Date(date.valueOf() + date.getTimezoneOffset() * 60 * 1000);
+
+const getUtcMsFromDate = (date: Date): number =>
+  Date.UTC(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    date.getHours(),
+    date.getMinutes(),
+    date.getSeconds(),
+    date.getMilliseconds(),
+  );
+
+const parseLimitToUtcMs = (
+  limit: string | undefined,
+  {
+    isMaxBoundary,
+    hasTime,
+    variables,
+    sessionStore,
+  }: {
+    isMaxBoundary: boolean;
+    hasTime?: boolean;
+    variables?: Variable[];
+    sessionStore?: SessionStore;
+  },
+): number | undefined => {
+  if (!limit) return;
+  const parsedLimit =
+    variables && sessionStore
+      ? parseVariables(limit, { variables, sessionStore })
+      : limit;
+  if (!parsedLimit || parsedLimit.trim() === "") return;
+
+  const dateIsoRegex =
+    /^(\d{4})[/-](\d{1,2})[/-](\d{1,2})(?:[T\s](\d{1,2}):(\d{1,2})(?::(\d{1,2}))?)?/;
+  const matchIso = parsedLimit.match(dateIsoRegex);
+  if (matchIso) {
+    const year = Number.parseInt(matchIso[1], 10);
+    const month = Number.parseInt(matchIso[2], 10) - 1;
+    const day = Number.parseInt(matchIso[3], 10);
+    const isTimeInLimit = matchIso[4] !== undefined;
+
+    if (hasTime && isTimeInLimit) {
+      const hours = Number.parseInt(matchIso[4], 10);
+      const minutes = Number.parseInt(matchIso[5], 10);
+      const seconds = matchIso[6] ? Number.parseInt(matchIso[6], 10) : 0;
+      return Date.UTC(year, month, day, hours, minutes, seconds);
+    }
+
+    if (isMaxBoundary) {
+      return Date.UTC(year, month, day, 23, 59, 59, 999);
+    }
+    return Date.UTC(year, month, day, 0, 0, 0, 0);
+  }
+
+  const chronoParsed = chronoParser.parse(parsedLimit);
+  if (chronoParsed.length > 0) {
+    const date = chronoParsed[0].start.date();
+    const year = date.getFullYear();
+    const month = date.getMonth();
+    const day = date.getDate();
+    if (hasTime && chronoParsed[0].start.isCertain("hour")) {
+      return Date.UTC(
+        year,
+        month,
+        day,
+        date.getHours(),
+        date.getMinutes(),
+        date.getSeconds(),
+      );
+    }
+    if (isMaxBoundary) {
+      return Date.UTC(year, month, day, 23, 59, 59, 999);
+    }
+    return Date.UTC(year, month, day, 0, 0, 0, 0);
+  }
+};

--- a/packages/bot-engine/src/validateAndParseInputMessage.ts
+++ b/packages/bot-engine/src/validateAndParseInputMessage.ts
@@ -88,7 +88,7 @@ export const validateAndParseInputMessage = (
     }
     case InputBlockType.DATE: {
       if (!message || message.type !== "text") return { status: "fail" };
-      return parseDateReply(message.text, block);
+      return parseDateReply(message.text, block, { variables, sessionStore });
     }
     case InputBlockType.TIME: {
       if (!message || message.type !== "text") return { status: "fail" };

--- a/packages/embeds/js/src/features/blocks/inputs/date/components/DateForm.tsx
+++ b/packages/embeds/js/src/features/blocks/inputs/date/components/DateForm.tsx
@@ -12,12 +12,17 @@ type Props = {
 };
 
 export const DateForm = (props: Props) => {
+  let formRef: HTMLFormElement | undefined;
   const [inputValues, setInputValues] = createSignal(
     parseDefaultValue(props.defaultValue ?? ""),
   );
 
   const submit = () => {
     if (inputValues().from === "" && inputValues().to === "") return;
+    if (formRef && !formRef.checkValidity()) {
+      formRef.reportValidity();
+      return;
+    }
     props.onSubmit({
       type: "text",
       value: `${inputValues().from}${
@@ -36,6 +41,7 @@ export const DateForm = (props: Props) => {
   return (
     <div class="typebot-input-form flex gap-2 items-end">
       <form
+        ref={formRef}
         class={cx(
           "flex typebot-input",
           props.options?.isRange ? "items-end" : "items-center",


### PR DESCRIPTION
Fixes #2581

### Bug Description
When setting `min` / `max` limits for a date + time input, users could circumvent limits by manually typing dates into the input field rather than picking them from the calendar UI.

### Root Cause
1. **Frontend**: `DateForm.tsx` called `e.preventDefault()` on form submit without checking `form.checkValidity()`, bypassing HTML5 `min` / `max` constraint validation.
2. **Backend**: `parseDateReply.ts` parsed user replies using `parseDateWithNeutralTimezone` but evaluated `min` / `max` with `new Date(limit)`, creating timezone offset discrepancies.

### Solution
1. **Frontend**: Attached `formRef` to the date input form and added `formRef.checkValidity()` / `formRef.reportValidity()` before submitting. Out-of-bounds typed values now trigger the browser validation tooltip and block submission.
2. **Backend**: Wrapped `new Date(max)` and `new Date(min)` in `parseDateWithNeutralTimezone` to align boundary checks on the exact same timezone scale.