### PR TITLE
🐛 Keep unsafe integers as strings when guessing variable types

### DIFF
--- a/packages/variables/src/deepParseVariables.test.ts
+++ b/packages/variables/src/deepParseVariables.test.ts
@@ -13,6 +13,11 @@ const variables = [
     name: "Vector store IDs",
     value: ["vs_123", "vs_456"],
   },
+  {
+    id: "big-integer-id",
+    name: "Big integer ID",
+    value: "12345678901234567",
+  },
 ];
 
 describe("deepParseVariables", () => {
@@ -128,6 +133,25 @@ describe("deepParseVariables", () => {
     ).toEqual({
       values: [42, true, null, { enabled: true }, "text"],
       nested: { value: false },
+    });
+  });
+
+  test("keeps integers above Number.MAX_SAFE_INTEGER as strings when guessing types", () => {
+    expect<unknown>(
+      deepParseVariables(
+        {
+          wabaId: "{{Big integer ID}}",
+          values: ["12345678901234567", "42"],
+        },
+        {
+          variables,
+          guessCorrectTypes: true,
+          sessionStore: new SessionStore(),
+        },
+      ),
+    ).toEqual({
+      wabaId: "12345678901234567",
+      values: ["12345678901234567", 42],
     });
   });
 

--- a/packages/variables/src/parseGuessedTypeFromString.ts
+++ b/packages/variables/src/parseGuessedTypeFromString.ts
@@ -5,7 +5,16 @@ export const parseGuessedTypeFromString = (value: string): unknown => {
 
 const safeJsonParse = (value: string): unknown => {
   try {
-    return JSON.parse(value);
+    const parsedValue = JSON.parse(value);
+    // Integers outside the safe range (e.g. WhatsApp Business Account IDs)
+    // can't be represented exactly as a JS number, keep them as strings
+    if (
+      typeof parsedValue === "number" &&
+      Number.isInteger(parsedValue) &&
+      !Number.isSafeInteger(parsedValue)
+    )
+      return value;
+    return parsedValue;
   } catch {
     return value;
   }

--- a/packages/variables/src/parseGuessedValueType.test.ts
+++ b/packages/variables/src/parseGuessedValueType.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { parseGuessedValueType } from "./parseGuessedValueType";
+
+describe("parseGuessedValueType", () => {
+  test("converts numeric strings within the safe integer range to numbers", () => {
+    expect(parseGuessedValueType("42")).toBe(42);
+    expect(parseGuessedValueType("-42")).toBe(-42);
+    expect(parseGuessedValueType("3.14")).toBe(3.14);
+    expect(parseGuessedValueType(String(Number.MAX_SAFE_INTEGER))).toBe(
+      Number.MAX_SAFE_INTEGER,
+    );
+  });
+
+  test("keeps integers above Number.MAX_SAFE_INTEGER as strings to avoid precision loss", () => {
+    // Number("12345678901234567") === 12345678901234568
+    expect(parseGuessedValueType("12345678901234567")).toBe(
+      "12345678901234567",
+    );
+    expect(parseGuessedValueType("9007199254740992")).toBe("9007199254740992");
+  });
+
+  test("keeps integers below Number.MIN_SAFE_INTEGER as strings to avoid precision loss", () => {
+    expect(parseGuessedValueType("-12345678901234567")).toBe(
+      "-12345678901234567",
+    );
+  });
+
+  test("keeps strings starting with 0 or + untouched", () => {
+    expect(parseGuessedValueType("0123")).toBe("0123");
+    expect(parseGuessedValueType("+5551999999999")).toBe("+5551999999999");
+    expect(parseGuessedValueType("0.5")).toBe(0.5);
+  });
+
+  test("parses boolean, null and undefined literals", () => {
+    expect(parseGuessedValueType("true")).toBe(true);
+    expect(parseGuessedValueType("false")).toBe(false);
+    expect(parseGuessedValueType("null")).toBeNull();
+    expect(parseGuessedValueType("undefined")).toBeUndefined();
+  });
+
+  test("returns non numeric strings and non string values untouched", () => {
+    expect(parseGuessedValueType("hello")).toBe("hello");
+    expect(parseGuessedValueType(["1", "2"])).toEqual(["1", "2"]);
+    expect(parseGuessedValueType(null)).toBeNull();
+    expect(parseGuessedValueType(undefined)).toBeUndefined();
+  });
+});

--- a/packages/variables/src/parseGuessedValueType.ts
+++ b/packages/variables/src/parseGuessedValueType.ts
@@ -18,5 +18,8 @@ export const parseGuessedValueType = (
   if (value === "undefined") return;
   const num = Number(value);
   if (Number.isNaN(num)) return value;
+  // Integers outside the safe range (e.g. WhatsApp Business Account IDs)
+  // can't be represented exactly as a JS number, keep them as strings
+  if (Number.isInteger(num) && !Number.isSafeInteger(num)) return value;
   return num;
 };


### PR DESCRIPTION
## Summary

Variables holding an integer above `Number.MAX_SAFE_INTEGER` (e.g. a WhatsApp Business Account ID like `12345678901234567`) were silently rounded to `12345678901234568` whenever Typebot guessed their type: Script blocks, Set variable "Custom" expressions, inline `{{= =}}` expressions, the Chatwoot block, and blocks using `guessCorrectTypes: true` (Google Analytics, Pixel).

Both `parseGuessedValueType` (`Number(value)`) and `parseGuessedTypeFromString` (`JSON.parse(value)`) now keep the original string when the parsed value is an integer outside the safe range. Everything inside the safe range behaves exactly as before.

Fixes #2589

## Changes

- `parseGuessedValueType`: return the original string when `Number(value)` is an integer that is not a safe integer.
- `parseGuessedTypeFromString`: same guard on the result of `JSON.parse`.
- New `parseGuessedValueType.test.ts` covering the regression plus the existing contract (safe numbers, `0`/`+` prefixes, boolean/null/undefined literals, non-string values).
- New case in `deepParseVariables.test.ts` for `guessCorrectTypes: true` with a big integer.

## Notes

- The HTTP Request block was already safe on its own path through `@typebot.io/lib/JSONParse` (big integers become `BigInt`); this PR only touches the two "guess the type" helpers.
- Trade-off: a script doing arithmetic on such a value (`id + 1`) now concatenates instead of adding. The number was already wrong before the arithmetic, so a correct string seemed preferable to a corrupted number. Returning a `BigInt` instead would be the alternative, happy to switch if you prefer.
- Big integers nested inside a JSON object string (`'{"id": 12345678901234567}'`) passed through `parseGuessedTypeFromString` are out of scope: that would need a BigInt-aware parser like the one the HTTP Request block uses.

## Test plan

- [x] `bun test` in `packages/variables`: 18 pass, 0 fail (2 files)
- [x] `biome check` on the changed files
- [x] `nx run @typebot.io/variables:typecheck`
