### PR TITLE
🐛 Generate WhatsApp credentials id per dialog instance

### DIFF
--- a/apps/builder/src/features/publish/components/deploy/dialogs/whatsApp/WhatsAppCredentialsDialog.tsx
+++ b/apps/builder/src/features/publish/components/deploy/dialogs/whatsApp/WhatsAppCredentialsDialog.tsx
@@ -42,8 +42,6 @@ type Props = {
   onNewCredentials: (id: string) => void;
 };
 
-const credentialsId = createId();
-
 export const WhatsAppCredentialsDialog = ({
   isOpen,
   onClose,
@@ -82,6 +80,8 @@ export const WhatsAppCreateDialogBody = ({
   const [systemUserAccessToken, setSystemUserAccessToken] = useState("");
   const [appSecret, setAppSecret] = useState("");
   const [apiKey, setApiKey] = useState("");
+  // Generated client-side because the webhook URL shown in the wizard needs it before the credentials exist
+  const [credentialsId, setCredentialsId] = useState(createId);
   const [webhookSecret, setWebhookSecret] = useState(createId);
   const [wabaId, setWabaId] = useState("");
   const [phoneNumberId, setPhoneNumberId] = useState("");
@@ -124,6 +124,7 @@ export const WhatsAppCreateDialogBody = ({
     setActiveStep(0);
     setSystemUserAccessToken("");
     setAppSecret("");
+    setCredentialsId(createId());
     setWebhookSecret(createId());
     setWabaId("");
     setPhoneNumberId("");


### PR DESCRIPTION
## Summary

Creating a second WhatsApp credentials in the same builder session failed with `Unique constraint failed on the fields: (id)`. The credentials id was generated once at module scope in `WhatsAppCredentialsDialog.tsx`, so every `WhatsAppCreateDialogBody` instance (deploy dialog and workspace credentials page) reused the same id after the first successful creation.

The id is now component state, generated per dialog instance and regenerated in `resetForm()` after a successful creation, the same way `webhookSecret` already is. It stays stable during the wizard so the webhook URL shown to the user keeps matching the credentials being created.

Fixes #2591

## Changes

- `WhatsAppCredentialsDialog.tsx`: remove the module scope `const credentialsId = createId()`, add `const [credentialsId, setCredentialsId] = useState(createId)` in `WhatsAppCreateDialogBody`, and call `setCredentialsId(createId())` in `resetForm()`.

## Notes

- No automated test: the builder has no component test setup (no `.test.tsx` files, no testing-library), and the change is a 3 line state move. Happy to add one if you have a preferred harness.

## Test plan

- [x] `biome check` on the changed file
- [x] `nx run builder:typecheck` (after `nx build @typebot.io/react`)
- [ ] Manual: create two WhatsApp credentials in a row without reloading, both succeed, each gets its own id in the webhook URL
