### PR TITLE
docs: add You Secure (Brazil) self-hosting deploy guide

### DIFF
--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -257,6 +257,7 @@
         "self-hosting/deploy/docker",
         "self-hosting/deploy/vercel",
         "self-hosting/deploy/alibaba-cloud",
+        "self-hosting/deploy/you-secure",
         "self-hosting/deploy/manual"
       ]
     },

--- a/apps/docs/self-hosting/deploy/you-secure.mdx
+++ b/apps/docs/self-hosting/deploy/you-secure.mdx
@@ -1,0 +1,100 @@
+---
+title: You Secure
+description: How to deploy Typebot on a You Secure VPS (Brazil)
+---
+
+<Note>
+  The easiest way to get started with Typebot is with [the official managed
+  service in the Cloud](https://app.typebot.io). You'll have high availability,
+  backups, security, and maintenance all managed for you by me, Baptiste,
+  Typebot's founder. The cloud version can save a substantial amount of
+  developer time and resources. For most sites this ends up being the best value
+  option and the revenue goes to funding the maintenance and further development
+  of Typebot. So you'll be supporting fair source software and getting a great
+  service!
+</Note>
+
+[You Secure](https://yousecure.io/hosting) is a VPS provider with infrastructure
+in São Paulo, Brazil. It is a useful option if your users are in Brazil or
+LatAm and you want to keep round-trip latency low, or if you need the Postgres
+database holding your typebot results to stay inside the country.
+
+The deployment is a standard Docker Compose stack — builder, viewer, and
+Postgres behind Traefik — so nothing here is specific to the provider beyond
+where the machine lives. If you prefer to set it up by hand on any VPS, follow
+the [Docker guide](./docker) instead.
+
+## Requirements
+
+- A You Secure VPS. Typebot's builder, viewer and Postgres run comfortably on
+  4 GB RAM / 2 vCPU; give it more if you expect heavy concurrent traffic.
+- A domain name you control, with DNS pointing at the VPS.
+
+## DNS
+
+Typebot needs two hostnames. Create two `A` records pointing at your VPS IP:
+
+| Record            | Points to  |
+| ----------------- | ---------- |
+| `builder.yourdomain.com` | VPS IPv4 |
+| `viewer.yourdomain.com`  | VPS IPv4 |
+
+`builder` is where you build your typebots, `viewer` is what your users
+interact with.
+
+## Deploy
+
+From the You Secure dashboard, open your VPS and choose Typebot from the
+application list. You'll be asked for the domain you configured above. The
+installer provisions:
+
+- `postgres:15` with a generated password and a persistent volume
+- `baptistearno/typebot-builder:latest` on `builder.yourdomain.com`
+- `baptistearno/typebot-viewer:latest` on `viewer.yourdomain.com`
+- Traefik as the reverse proxy, with Let's Encrypt certificates issued
+  automatically for both hostnames
+
+The Compose file lands in `/root/typebot` on the VPS, so everything below
+still applies if you'd rather manage it over SSH.
+
+## Configure
+
+`ENCRYPTION_SECRET` is generated at install time and set identically on the
+builder and the viewer, and `ADMIN_EMAIL` is taken from your account. The
+variable you will most likely want to add yourself is SMTP, so the instance can
+send invitation and password emails:
+
+```bash
+cd /root/typebot
+nano docker-compose.yml   # edit the typebot-builder environment block
+docker compose up -d
+```
+
+See [Configuration](../configuration) for the full list of supported
+environment variables.
+
+<Warning>
+  Back up `ENCRYPTION_SECRET` somewhere outside the server. It encrypts every
+  credential stored in your typebots — a database restore without it leaves
+  those credentials unreadable.
+</Warning>
+
+## Upgrade
+
+```bash
+cd /root/typebot
+docker compose pull
+docker compose up -d
+```
+
+Self-hosted Typebot follows a monthly release cadence — see
+[Releases](../get-started#releases).
+
+## Backups
+
+Snapshot the Postgres volume regularly; it holds your typebots and all
+submitted results. A minimal dump:
+
+```bash
+docker exec postgres_typebot pg_dump -U typebot typebot > typebot-$(date +%F).sql
+```


### PR DESCRIPTION
# PR 1 — Typebot docs: add a You Secure deploy guide

**Repo:** https://github.com/baptisteArno/typebot.io
**Confidence:** high — Typebot's docs already carry a provider-specific guide
(`alibaba-cloud.mdx`), and the contribution guide explicitly invites "proposing
new sections". No anti-promotional clause.

## Why this one is worth doing

This is the elest.io mechanism. Elestio has 510 referring domains; the bulk of
them come from the docs of the projects it hosts (flowiseai.com 460,
docker.com 125, opentofu.org 60). A provider page inside a docs site is
rendered on every build and linked from the sidebar nav, so it behaves like a
sitewide link rather than a one-off mention.

## Files

1. **Add** `apps/docs/self-hosting/deploy/you-secure.mdx` — the contents of
   [`you-secure.mdx`](you-secure.mdx) in this folder, copied verbatim.

2. **Edit** `apps/docs/mint.json` — register the page in the self-hosting
   Deploy group. Find this array:

   ```json
   {"group": "Deploy", "pages": ["self-hosting/deploy/docker", "self-hosting/deploy/vercel", "self-hosting/deploy/alibaba-cloud", "self-hosting/deploy/manual"]}
   ```

   and add the new page after `alibaba-cloud`:

   ```json
   {"group": "Deploy", "pages": ["self-hosting/deploy/docker", "self-hosting/deploy/vercel", "self-hosting/deploy/alibaba-cloud", "self-hosting/deploy/you-secure", "self-hosting/deploy/manual"]}
   ```

   Note there are two `"group": "Deploy"` blocks in that file — the one you
   want is the second, whose pages are prefixed `self-hosting/`. The other one
   is about embedding bots on the web.

## PR title

```
docs: add You Secure (Brazil) self-hosting deploy guide
```

## PR description

```
Adds a self-hosting deploy guide for You Secure, a VPS provider with
infrastructure in São Paulo, Brazil.

Motivation: Typebot has a sizeable Brazilian user base, and the existing
self-hosting guides all assume infrastructure outside the country. For teams
serving Brazilian users this matters twice — round-trip latency, and keeping
the Postgres database that holds typebot results inside Brazil.

The guide follows the same shape as the existing alibaba-cloud page: DNS
setup for the builder/viewer hostnames, the deploy step, configuration
pointers back to the existing docs, upgrade, and backups. It links back to
./docker for anyone who'd rather do it by hand, and keeps the standard cloud
note at the top.

Also registers the page in apps/docs/mint.json under the self-hosting Deploy
group.

I'm affiliated with You Secure — happy to adjust the tone, trim it, or drop
it entirely if you'd rather keep the provider list short.
```

## Before you open it

- Disclose the affiliation. It's in the description above; leave it there. A
  maintainer discovering it later is far worse than stating it up front.
- Sanity-check the install flow described in the guide against what the
  dashboard actually shows today, and fix any wording drift.
- Guidelines ask you to run `bun run build` at the repo root before pushing.
  For a docs-only change this is unlikely to break, but it's their stated
  process.
- The guide deliberately does **not** claim You Secure is the best or cheapest
  option, and does not include pricing. Provider pages that read like ads get
  closed. Keep it that way.

## Second, separate opportunity in the same repo — drafted

Typebot accepts community blog posts, and the author registry carries a
dofollow bio URL. Full draft and submission notes are in
**[`blog-post/`](blog-post/README.md)**.

Do this one *after* the docs PR is merged, not at the same time — two
simultaneous PRs from a vendor reads differently than one accepted
contribution followed by an offer to write.
