### PR TITLE
🐛 Prevent read-only typebot migration writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ All scripts must be ran with `bunx nx`:
   - fastest way to typecheck `builder` and/or `viewer`: run root `bunx nx typecheck` (runs `tsc --build --emitDeclarationOnly`)
   - typecheck a particular package: `bunx nx typecheck package_name`.
   - test a package: `bunx nx test package_name`
+  - filter builder Bun tests: `bunx nx test builder --args=src/features/typebot/api/handleGetTypebot.test.ts` (Bun ignores `--testPathPattern`).
   - typecheck all afffected packages: `bunx nx affected -t typecheck` (**IMPORTANT**: Rely first on IDE's TS server diagnostics first for faster feedback loop)
 - To check format and lint, run: `bunx nx format-and-lint` (with `--write --unsafe` to run autofix)
 - Never run plain `bunx tsc`, use `bunx nx`

--- a/apps/builder/src/features/typebot/api/handleGetTypebot.test.ts
+++ b/apps/builder/src/features/typebot/api/handleGetTypebot.test.ts
@@ -1,23 +1,33 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { WorkspaceRole } from "@typebot.io/prisma/enum";
+import { CollaborationType, WorkspaceRole } from "@typebot.io/prisma/enum";
 
 const typebotFindFirst = mock();
+const typebotUpdate = mock();
+const webhookFindMany = mock();
 
 process.env.SKIP_ENV_CHECK = "true";
 process.env.ENCRYPTION_SECRET = "12345678901234567890123456789012";
 process.env.NEXTAUTH_URL = "https://app.typebot.io";
 
 mock.module("@typebot.io/prisma", () => ({
-  default: { typebot: { findFirst: typebotFindFirst } },
+  default: {
+    typebot: { findFirst: typebotFindFirst, update: typebotUpdate },
+    webhook: { findMany: webhookFindMany },
+  },
 }));
 
+const { latestTypebotVersion } = await import("@typebot.io/schemas/versions");
+const { typebotV6Schema } = await import("@typebot.io/typebot/schemas/typebot");
 const { handleGetTypebot } = await import("./handleGetTypebot");
 
-describe("handleGetTypebot", () => {
-  beforeEach(() => {
-    typebotFindFirst.mockReset();
-  });
+beforeEach(() => {
+  typebotFindFirst.mockReset();
+  typebotUpdate.mockReset();
+  webhookFindMany.mockReset();
+  webhookFindMany.mockResolvedValue([]);
+});
 
+describe("handleGetTypebot", () => {
   it("does not expose typebot content to a non-collaborating guest", async () => {
     typebotFindFirst.mockResolvedValue({
       id: "typebot-id",
@@ -57,3 +67,251 @@ describe("handleGetTypebot", () => {
     });
   });
 });
+
+const user = { id: "user-id", email: "user@example.com" };
+
+const accessScenarios = [
+  {
+    name: "anonymous public reader",
+    user: null,
+    publicShare: true,
+    collaboration: undefined,
+    role: undefined,
+    canWrite: false,
+  },
+  {
+    name: "authenticated public reader",
+    user,
+    publicShare: true,
+    collaboration: undefined,
+    role: undefined,
+    canWrite: false,
+  },
+  {
+    name: "READ collaborator",
+    user,
+    publicShare: false,
+    collaboration: CollaborationType.READ,
+    role: undefined,
+    canWrite: false,
+  },
+  {
+    name: "READ guest collaborator",
+    user,
+    publicShare: false,
+    collaboration: CollaborationType.READ,
+    role: WorkspaceRole.GUEST,
+    canWrite: false,
+  },
+  {
+    name: "public workspace guest",
+    user,
+    publicShare: true,
+    collaboration: undefined,
+    role: WorkspaceRole.GUEST,
+    canWrite: false,
+  },
+  {
+    name: "WRITE collaborator",
+    user,
+    publicShare: false,
+    collaboration: CollaborationType.WRITE,
+    role: undefined,
+    canWrite: true,
+  },
+  {
+    name: "FULL_ACCESS collaborator without workspace write permission",
+    user,
+    publicShare: false,
+    collaboration: CollaborationType.FULL_ACCESS,
+    role: undefined,
+    canWrite: false,
+  },
+  {
+    name: "WRITE guest collaborator",
+    user,
+    publicShare: false,
+    collaboration: CollaborationType.WRITE,
+    role: WorkspaceRole.GUEST,
+    canWrite: true,
+  },
+  {
+    name: "workspace admin",
+    user,
+    publicShare: false,
+    collaboration: undefined,
+    role: WorkspaceRole.ADMIN,
+    canWrite: true,
+  },
+  {
+    name: "workspace member",
+    user,
+    publicShare: false,
+    collaboration: undefined,
+    role: WorkspaceRole.MEMBER,
+    canWrite: true,
+  },
+  {
+    name: "READ collaborator with workspace write access",
+    user,
+    publicShare: false,
+    collaboration: CollaborationType.READ,
+    role: WorkspaceRole.MEMBER,
+    canWrite: true,
+  },
+];
+
+for (const version of ["3", "4", "5"]) {
+  describe(`legacy v${version} migration`, () => {
+    for (const scenario of accessScenarios) {
+      for (const migrateToLatestVersion of [false, true]) {
+        it(`${scenario.name}, migration requested: ${migrateToLatestVersion}`, async () => {
+          const storedTypebot = createLegacyTypebot(version, scenario);
+          const snapshot = structuredClone(storedTypebot);
+          typebotFindFirst.mockResolvedValue(storedTypebot);
+
+          const result = await handleGetTypebot({
+            input: { typebotId: storedTypebot.id, migrateToLatestVersion },
+            context: { user: scenario.user },
+          });
+
+          expect(result.typebot.version).toBe(
+            migrateToLatestVersion ? latestTypebotVersion : version,
+          );
+          expect(result.typebot.name).toBe(storedTypebot.name);
+          expect(storedTypebot).toEqual(snapshot);
+          if (migrateToLatestVersion) {
+            expect(typebotV6Schema.safeParse(result.typebot).success).toBe(
+              true,
+            );
+            expect(result.typebot.events).toEqual([
+              {
+                id: "start-group",
+                type: "start",
+                graphCoordinates: { x: 0, y: 0 },
+              },
+            ]);
+          }
+          if (migrateToLatestVersion && scenario.canWrite) {
+            expect(typebotUpdate).toHaveBeenCalledTimes(1);
+            expect(typebotUpdate).toHaveBeenCalledWith({
+              where: { id: storedTypebot.id },
+              data: expect.objectContaining({
+                version: latestTypebotVersion,
+                events: result.typebot.events,
+                groups: result.typebot.groups,
+              }),
+            });
+          } else {
+            expect(typebotUpdate).not.toHaveBeenCalled();
+          }
+        });
+      }
+    }
+  });
+}
+
+for (const restriction of ["isSuspended", "isPastDue"]) {
+  it(`does not persist migration in a publicly shared ${restriction} workspace`, async () => {
+    const storedTypebot = createLegacyTypebot("5", {
+      publicShare: true,
+      role: WorkspaceRole.ADMIN,
+      collaboration: CollaborationType.WRITE,
+    });
+    typebotFindFirst.mockResolvedValue({
+      ...storedTypebot,
+      workspace: { ...storedTypebot.workspace, [restriction]: true },
+    });
+    const result = await handleGetTypebot({
+      input: { typebotId: storedTypebot.id, migrateToLatestVersion: true },
+      context: { user },
+    });
+    expect(result.typebot.version).toBe(latestTypebotVersion);
+    expect(typebotUpdate).not.toHaveBeenCalled();
+  });
+}
+
+it("does not write an already migrated bot on subsequent reads", async () => {
+  typebotFindFirst.mockResolvedValue(
+    createLegacyTypebot("5", { publicShare: false, role: WorkspaceRole.ADMIN }),
+  );
+  const request = {
+    input: { typebotId: "typebot-id", migrateToLatestVersion: true },
+    context: { user },
+  };
+  const result = await handleGetTypebot(request);
+  expect(typebotUpdate).toHaveBeenCalledTimes(1);
+  typebotFindFirst.mockResolvedValue({
+    ...createLegacyTypebot("5", {
+      publicShare: false,
+      role: WorkspaceRole.ADMIN,
+    }),
+    ...result.typebot,
+  });
+  typebotUpdate.mockClear();
+  expect((await handleGetTypebot(request)).typebot).toEqual(result.typebot);
+  expect(typebotUpdate).not.toHaveBeenCalled();
+});
+
+it("rejects anonymous access to a private legacy bot without writing", async () => {
+  typebotFindFirst.mockResolvedValue(
+    createLegacyTypebot("5", { publicShare: false }),
+  );
+  await expect(
+    handleGetTypebot({
+      input: { typebotId: "typebot-id", migrateToLatestVersion: true },
+      context: { user: null },
+    }),
+  ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  expect(typebotUpdate).not.toHaveBeenCalled();
+});
+
+function createLegacyTypebot(
+  version: string,
+  access: {
+    publicShare: boolean;
+    collaboration?: CollaborationType;
+    role?: WorkspaceRole;
+  },
+) {
+  return {
+    id: "typebot-id",
+    version,
+    name: "Legacy bot",
+    events: null,
+    groups: [
+      {
+        id: "start-group",
+        title: "Start",
+        graphCoordinates: { x: 0, y: 0 },
+        blocks: [{ id: "start-block", type: "start", label: "Start" }],
+      },
+    ],
+    edges: [],
+    variables: [],
+    theme: {},
+    settings: { publicShare: { isEnabled: access.publicShare } },
+    selectedThemeTemplateId: null,
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+    icon: null,
+    folderId: null,
+    publicId: null,
+    customDomain: null,
+    workspaceId: "workspace-id",
+    resultsTablePreferences: null,
+    isArchived: false,
+    isClosed: false,
+    whatsAppCredentialsId: null,
+    riskLevel: null,
+    spaceId: null,
+    collaborators: access.collaboration
+      ? [{ userId: user.id, type: access.collaboration }]
+      : [],
+    workspace: {
+      isSuspended: false,
+      isPastDue: false,
+      members: access.role ? [{ userId: user.id, role: access.role }] : [],
+    },
+  };
+}

--- a/apps/builder/src/features/typebot/api/handleGetTypebot.test.ts
+++ b/apps/builder/src/features/typebot/api/handleGetTypebot.test.ts
@@ -120,12 +120,20 @@ const accessScenarios = [
     canWrite: true,
   },
   {
-    name: "FULL_ACCESS collaborator without workspace write permission",
+    name: "FULL_ACCESS collaborator without workspace membership",
     user,
     publicShare: false,
     collaboration: CollaborationType.FULL_ACCESS,
     role: undefined,
-    canWrite: false,
+    canWrite: true,
+  },
+  {
+    name: "FULL_ACCESS guest collaborator",
+    user,
+    publicShare: false,
+    collaboration: CollaborationType.FULL_ACCESS,
+    role: WorkspaceRole.GUEST,
+    canWrite: true,
   },
   {
     name: "WRITE guest collaborator",
@@ -179,6 +187,13 @@ for (const version of ["3", "4", "5"]) {
             migrateToLatestVersion ? latestTypebotVersion : version,
           );
           expect(result.typebot.name).toBe(storedTypebot.name);
+          expect(result.currentUserMode).toBe(
+            scenario.canWrite
+              ? "write"
+              : scenario.collaboration
+                ? "read"
+                : "guest",
+          );
           expect(storedTypebot).toEqual(snapshot);
           if (migrateToLatestVersion) {
             expect(typebotV6Schema.safeParse(result.typebot).success).toBe(
@@ -212,23 +227,27 @@ for (const version of ["3", "4", "5"]) {
 }
 
 for (const restriction of ["isSuspended", "isPastDue"]) {
-  it(`does not persist migration in a publicly shared ${restriction} workspace`, async () => {
-    const storedTypebot = createLegacyTypebot("5", {
-      publicShare: true,
-      role: WorkspaceRole.ADMIN,
-      collaboration: CollaborationType.WRITE,
+  for (const collaboration of [
+    CollaborationType.WRITE,
+    CollaborationType.FULL_ACCESS,
+  ]) {
+    it(`does not persist migration for ${collaboration} in a publicly shared ${restriction} workspace`, async () => {
+      const storedTypebot = createLegacyTypebot("5", {
+        publicShare: true,
+        collaboration,
+      });
+      typebotFindFirst.mockResolvedValue({
+        ...storedTypebot,
+        workspace: { ...storedTypebot.workspace, [restriction]: true },
+      });
+      const result = await handleGetTypebot({
+        input: { typebotId: storedTypebot.id, migrateToLatestVersion: true },
+        context: { user },
+      });
+      expect(result.typebot.version).toBe(latestTypebotVersion);
+      expect(typebotUpdate).not.toHaveBeenCalled();
     });
-    typebotFindFirst.mockResolvedValue({
-      ...storedTypebot,
-      workspace: { ...storedTypebot.workspace, [restriction]: true },
-    });
-    const result = await handleGetTypebot({
-      input: { typebotId: storedTypebot.id, migrateToLatestVersion: true },
-      context: { user },
-    });
-    expect(result.typebot.version).toBe(latestTypebotVersion);
-    expect(typebotUpdate).not.toHaveBeenCalled();
-  });
+  }
 }
 
 it("does not write an already migrated bot on subsequent reads", async () => {

--- a/apps/builder/src/features/typebot/api/handleGetTypebot.ts
+++ b/apps/builder/src/features/typebot/api/handleGetTypebot.ts
@@ -11,6 +11,7 @@ import {
 } from "@typebot.io/typebot/schemas/typebot";
 import type { User } from "@typebot.io/user/schemas";
 import { z } from "zod";
+import { isWriteTypebotForbidden } from "../helpers/isWriteTypebotForbidden";
 
 export const getTypebotInputSchema = z.object({
   typebotId: z
@@ -78,7 +79,11 @@ export const handleGetTypebot = async ({
       | { typebot: TypebotV6; wasMigrated: true }
       | { typebot: Typebot; wasMigrated: false };
 
-    if (wasMigrated)
+    if (
+      wasMigrated &&
+      user &&
+      !(await isWriteTypebotForbidden(existingTypebot, user))
+    )
       await prisma.typebot.update({
         where: {
           id: existingTypebot.id,

--- a/apps/builder/src/features/typebot/helpers/isWriteTypebotForbidden.ts
+++ b/apps/builder/src/features/typebot/helpers/isWriteTypebotForbidden.ts
@@ -17,7 +17,8 @@ export const isWriteTypebotForbidden = async (
     (!typebot.collaborators.some(
       (collaborator) =>
         collaborator.userId === user.id &&
-        collaborator.type === CollaborationType.WRITE,
+        (collaborator.type === CollaborationType.WRITE ||
+          collaborator.type === CollaborationType.FULL_ACCESS),
     ) &&
       !typebot.workspace.members.some(
         (m) => m.userId === user.id && m.role !== "GUEST",


### PR DESCRIPTION
## Summary

- Persist legacy typebot migrations only when the requesting user has write access.
- Add coverage for public readers, collaborators, workspace roles, restricted workspaces, and repeated reads.
- Document the correct command for filtering builder Bun tests.

## Testing

- Not run (not provided).