### PR TITLE
🐛 Enforce ownership of legacy webhooks

### DIFF
--- a/apps/builder/src/features/blocks/integrations/httpRequest/api/handleSubscribeHttpRequest.ts
+++ b/apps/builder/src/features/blocks/integrations/httpRequest/api/handleSubscribeHttpRequest.ts
@@ -79,9 +79,9 @@ export const handleSubscribeHttpRequest = async ({
       },
     });
   } else {
-    if ("webhookId" in httpRequestBlock)
+    if ("webhookId" in httpRequestBlock && httpRequestBlock.webhookId)
       await prisma.webhook.update({
-        where: { id: httpRequestBlock.webhookId },
+        where: { id: httpRequestBlock.webhookId, typebotId },
         data: { url },
       });
     else

--- a/apps/builder/src/features/blocks/integrations/httpRequest/api/handleUnsubscribeHttpRequest.ts
+++ b/apps/builder/src/features/blocks/integrations/httpRequest/api/handleUnsubscribeHttpRequest.ts
@@ -78,9 +78,9 @@ export const handleUnsubscribeHttpRequest = async ({
       },
     });
   } else {
-    if ("webhookId" in httpRequestBlock)
+    if ("webhookId" in httpRequestBlock && httpRequestBlock.webhookId)
       await prisma.webhook.update({
-        where: { id: httpRequestBlock.webhookId },
+        where: { id: httpRequestBlock.webhookId, typebotId },
         data: { url: null },
       });
     else

--- a/apps/builder/src/features/typebot/api/handleImportTypebot.ts
+++ b/apps/builder/src/features/typebot/api/handleImportTypebot.ts
@@ -63,10 +63,11 @@ type ImportingTypebot = z.infer<typeof importingTypebotSchema>;
 
 const migrateImportingTypebot = async (
   typebot: ImportingTypebot,
+  newTypebotId: string,
 ): Promise<TypebotV6> => {
   const fullTypebot = {
     ...typebot,
-    id: "dummy id",
+    id: newTypebotId,
     workspaceId: "dummy workspace id",
     resultsTablePreferences: typebot.resultsTablePreferences ?? null,
     selectedThemeTemplateId: typebot.selectedThemeTemplateId ?? null,
@@ -159,6 +160,7 @@ export const handleImportTypebot = async ({
 
   const duplicatingBot = await migrateImportingTypebot(
     newUploadUrlsResponse.typebot,
+    newBotId,
   );
 
   const groups = (

--- a/apps/builder/src/features/typebot/api/handleUpdateTypebot.ts
+++ b/apps/builder/src/features/typebot/api/handleUpdateTypebot.ts
@@ -1,4 +1,5 @@
 import { ORPCError } from "@orpc/server";
+import { parseGroups } from "@typebot.io/groups/helpers/parseGroups";
 import prisma from "@typebot.io/prisma";
 import { DbNull } from "@typebot.io/prisma/enum";
 import { settingsSchema } from "@typebot.io/settings/schemas";
@@ -75,6 +76,7 @@ export const handleUpdateTypebot = async ({
     },
     select: {
       version: true,
+      groups: true,
       id: true,
       customDomain: true,
       publicId: true,
@@ -147,11 +149,20 @@ export const handleUpdateTypebot = async ({
       });
   }
 
-  const groups = typebot.groups
-    ? await sanitizeGroups(typebot.groups, {
-        workspace: existingTypebot.workspace,
-      })
-    : undefined;
+  // A version-only downgrade can reactivate persisted legacy references.
+  const groups =
+    typebot.groups || typebot.version !== undefined
+      ? await sanitizeGroups(
+          typebot.groups ??
+            parseGroups(existingTypebot.groups, {
+              typebotVersion: existingTypebot.version,
+            }),
+          {
+            workspace: existingTypebot.workspace,
+            typebotId: existingTypebot.id,
+          },
+        )
+      : undefined;
 
   const newTypebot = await prisma.typebot.update({
     where: {

--- a/apps/builder/src/features/typebot/helpers/sanitizers.ts
+++ b/apps/builder/src/features/typebot/helpers/sanitizers.ts
@@ -1,3 +1,4 @@
+import { ORPCError } from "@orpc/server";
 import { isInputBlock } from "@typebot.io/blocks-core/helpers";
 import type { Block } from "@typebot.io/blocks-core/schemas/schema";
 import { IntegrationBlockType } from "@typebot.io/blocks-integrations/constants";
@@ -44,12 +45,36 @@ export const sanitizeGroups = async (
   {
     enableSafetyFlags,
     workspace,
+    typebotId,
   }: {
     enableSafetyFlags?: boolean;
+    // The authorized existing bot ID; new bots cannot reuse legacy rows.
+    typebotId?: string;
     workspace: Pick<Workspace, "id" | "plan">;
   },
-): Promise<Typebot["groups"]> =>
-  Promise.all(
+): Promise<Typebot["groups"]> => {
+  const webhookIds = groups.flatMap((group) =>
+    group.blocks.flatMap((block) =>
+      "webhookId" in block && block.webhookId ? [block.webhookId] : [],
+    ),
+  );
+  if (webhookIds.length > 0) {
+    const ownedWebhooks = typebotId
+      ? await prisma.webhook.findMany({
+          where: { id: { in: webhookIds }, typebotId },
+          select: { id: true },
+        })
+      : [];
+    if (
+      webhookIds.some(
+        (id) => !ownedWebhooks.some((webhook) => webhook.id === id),
+      )
+    )
+      throw new ORPCError("BAD_REQUEST", {
+        message: "Invalid legacy webhook reference",
+      });
+  }
+  return Promise.all(
     groups.map(async (group) => ({
       ...group,
       blocks: await Promise.all(
@@ -59,6 +84,7 @@ export const sanitizeGroups = async (
       ),
     })),
   ) as Promise<Typebot["groups"]>;
+};
 
 const sanitizeBlock = async (
   block: Block,

--- a/bun.lock
+++ b/bun.lock
@@ -7282,8 +7282,6 @@
 
     "@module-federation/dts-plugin/adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
 
-    "@module-federation/dts-plugin/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
-
     "@module-federation/dts-plugin/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "@module-federation/enhanced/@module-federation/sdk": ["@module-federation/sdk@2.8.2", "", {}, "sha512-OPS/lbQjraLXoWniQpCwQ/vqgURHTrhsackSNcOPmcJHM3LyR+DabxUc0pl8jAqExsW2l+uepQq7+/Gkei871w=="],

--- a/packages/blocks/core/src/migrations/migrateWebhookBlock.ts
+++ b/packages/blocks/core/src/migrations/migrateWebhookBlock.ts
@@ -11,6 +11,7 @@ export const migrateWebhookBlock =
   (webhooks: Prisma.Webhook[]) =>
   (block: BlockV5): BlockV5 => {
     if (!isHttpRequestBlock(block)) return block;
+    if (block.options?.webhook) return { ...block, webhookId: undefined };
     const webhook = webhooks.find(
       (webhook) => "webhookId" in block && webhook.id === block.webhookId,
     );

--- a/packages/bot-engine/src/blocks/integrations/httpRequest/executeHttpRequestBlock.ts
+++ b/packages/bot-engine/src/blocks/integrations/httpRequest/executeHttpRequestBlock.ts
@@ -92,9 +92,12 @@ export const executeHttpRequestBlock = async (
   const logs: LogInSession[] = [];
   const httpRequest =
     block.options?.webhook ??
-    ("webhookId" in block
+    ("webhookId" in block && block.webhookId
       ? ((await prisma.webhook.findUnique({
-          where: { id: block.webhookId },
+          where: {
+            id: block.webhookId,
+            typebotId: state.typebotsQueue[0].typebot.id,
+          },
         })) as HttpRequest | null)
       : null);
   if (!httpRequest) return { outgoingEdgeId: block.outgoingEdgeId };

--- a/packages/typebot/src/migrations/migrateTypebotFromV3ToV4.ts
+++ b/packages/typebot/src/migrations/migrateTypebotFromV3ToV4.ts
@@ -15,6 +15,7 @@ export const migrateTypebotFromV3ToV4 = async (
     .filter(isHttpRequestBlock);
   const webhooks = await prisma.webhook.findMany({
     where: {
+      typebotId: "typebotId" in typebot ? typebot.typebotId : typebot.id,
       id: {
         in: webhookBlocks
           .map((block) => ("webhookId" in block ? block.webhookId : undefined))


### PR DESCRIPTION
## Summary

- Reject legacy webhook references that do not belong to the current typebot.
- Scope webhook updates, execution, and migrations to the owning typebot.
- Revalidate persisted webhook references during version changes and prevent imports from reusing existing webhook rows.

## Testing

- Not run.