### PR TITLE
🐛 Restrict guest access to workspace data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,7 @@ To check the source code and documentation of a dependency, run `bunx opensrc pa
 - To navigate to an authenticated session with Playwright, you need to inject cookies from `apps/viewer/src/test/.auth/user.json`.
 - Do not pass those stored cookie objects directly to `browserContext.addCookies()`. Remap them to a minimal Playwright shape such as `{ name, value, url: "http://localhost:3000", expires, httpOnly, secure, sameSite }`.
 - Prefer `http://localhost:3000` over `127.0.0.1:3000` when reusing that auth file, since the saved session cookies are scoped for `localhost`.
+
+## Authorization regression tests
+
+- With `SKIP_ENV_CHECK=true`, environment transformations are skipped. In isolated Bun tests, supply parsed values such as `ADMIN_EMAIL: ["admin@example.com"]` in the env module mock; setting only `process.env.ADMIN_EMAIL` leaves a string and does not exercise the administrator policy correctly.

--- a/apps/builder/src/features/billing/components/BillingSettingsLayout.tsx
+++ b/apps/builder/src/features/billing/components/BillingSettingsLayout.tsx
@@ -7,12 +7,19 @@ import { UsageProgressBars } from "./UsageProgressBars";
 export const BillingSettingsLayout = () => {
   const { workspace, currentUserMode } = useWorkspace();
 
-  if (!workspace) return null;
+  if (
+    !workspace ||
+    currentUserMode === "guest" ||
+    workspace.stripeId === undefined
+  )
+    return null;
   return (
     <div className="flex flex-col gap-10 w-full">
       <UsageProgressBars workspace={workspace} />
       <div className="flex flex-col gap-4">
-        <CurrentSubscriptionSummary workspace={workspace} />
+        <CurrentSubscriptionSummary
+          workspace={{ ...workspace, stripeId: workspace.stripeId }}
+        />
         <ChangePlanForm
           workspace={workspace}
           currentUserMode={currentUserMode}

--- a/apps/builder/src/features/customDomains/api/handleListCustomDomains.ts
+++ b/apps/builder/src/features/customDomains/api/handleListCustomDomains.ts
@@ -21,6 +21,7 @@ export const handleListCustomDomains = async ({
       members: {
         select: {
           userId: true,
+          role: true,
         },
       },
       customDomains: true,

--- a/apps/builder/src/features/forge/api/fetchSelectItems.ts
+++ b/apps/builder/src/features/forge/api/fetchSelectItems.ts
@@ -57,6 +57,7 @@ export const fetchSelectItems = authenticatedProcedure
           members: {
             select: {
               userId: true,
+              role: true,
             },
           },
           credentials: input.options.credentialsId

--- a/apps/builder/src/features/workspace/WorkspaceProvider.tsx
+++ b/apps/builder/src/features/workspace/WorkspaceProvider.tsx
@@ -8,20 +8,11 @@ import { orpc, queryClient } from "@/lib/queryClient";
 import { toast } from "@/lib/toast";
 import { useTypebot } from "../editor/providers/TypebotProvider";
 import { useUser } from "../user/hooks/useUser";
+import type { InAppWorkspace } from "./api/handleGetWorkspace";
 import { parseNewName } from "./helpers/parseNewName";
 import { setWorkspaceIdInLocalStorage } from "./helpers/setWorkspaceIdInLocalStorage";
 
-export type WorkspaceInApp = Omit<
-  Workspace,
-  | "chatsLimitFirstEmailSentAt"
-  | "chatsLimitSecondEmailSentAt"
-  | "storageLimitFirstEmailSentAt"
-  | "storageLimitSecondEmailSentAt"
-  | "customStorageLimit"
-  | "additionalChatsIndex"
-  | "additionalStorageIndex"
-  | "isQuarantined"
->;
+export type WorkspaceInApp = InAppWorkspace;
 
 type WorkspaceUpdateProps = {
   icon?: string;

--- a/apps/builder/src/features/workspace/api/handleGetWorkspace.ts
+++ b/apps/builder/src/features/workspace/api/handleGetWorkspace.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { getUserModeInWorkspace } from "../helpers/getUserRoleInWorkspace";
 import { isReadWorkspaceFobidden } from "../helpers/isReadWorkspaceFobidden";
 
-export const inAppWorkspaceSchema = workspaceSchema.omit({
+const memberWorkspaceSchema = workspaceSchema.omit({
   chatsLimitFirstEmailSentAt: true,
   chatsLimitSecondEmailSentAt: true,
   storageLimitFirstEmailSentAt: true,
@@ -17,6 +17,25 @@ export const inAppWorkspaceSchema = workspaceSchema.omit({
   additionalStorageIndex: true,
   isQuarantined: true,
 });
+
+// Guests need navigation and bot availability context, not workspace billing data.
+const guestWorkspaceSchema = memberWorkspaceSchema.pick({
+  id: true,
+  name: true,
+  icon: true,
+  plan: true,
+  isSuspended: true,
+  isPastDue: true,
+  isVerified: true,
+});
+
+export const inAppWorkspaceSchema = z.union([
+  memberWorkspaceSchema,
+  guestWorkspaceSchema,
+]);
+
+export type InAppWorkspace = z.infer<typeof guestWorkspaceSchema> &
+  Partial<z.infer<typeof memberWorkspaceSchema>>;
 
 export const getWorkspaceInputSchema = z.object({
   workspaceId: z
@@ -38,8 +57,25 @@ export const handleGetWorkspace = async ({
     include: { members: true },
   });
 
+  if (!workspace)
+    throw new ORPCError("NOT_FOUND", { message: "Workspace not found" });
+
+  if (isReadWorkspaceFobidden(workspace, user)) {
+    if (
+      !workspace.members.some(
+        (member) => member.userId === user.id && member.role === "GUEST",
+      )
+    )
+      throw new ORPCError("NOT_FOUND", { message: "Workspace not found" });
+
+    return {
+      workspace: guestWorkspaceSchema.parse(workspace),
+      currentUserMode: z.literal("guest").parse("guest"),
+    };
+  }
+
   if (
-    !workspace?.lastActivityAt ||
+    !workspace.lastActivityAt ||
     !datesAreOnSameDay(workspace.lastActivityAt, new Date())
   ) {
     await prisma.workspace.updateMany({
@@ -50,13 +86,10 @@ export const handleGetWorkspace = async ({
     });
   }
 
-  if (!workspace || isReadWorkspaceFobidden(workspace, user))
-    throw new ORPCError("NOT_FOUND", { message: "Workspace not found" });
-
   const currentUserMode = getUserModeInWorkspace(user.id, workspace.members);
 
   return {
-    workspace: inAppWorkspaceSchema.parse(workspace),
-    currentUserMode: currentUserMode as "read" | "write" | "guest",
+    workspace: memberWorkspaceSchema.parse(workspace),
+    currentUserMode: z.enum(["read", "write", "guest"]).parse(currentUserMode),
   };
 };

--- a/apps/builder/src/features/workspace/api/workspaceReadAccess.test.ts
+++ b/apps/builder/src/features/workspace/api/workspaceReadAccess.test.ts
@@ -1,0 +1,435 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { call } from "@orpc/server";
+import { WorkspaceRole } from "@typebot.io/prisma/enum";
+
+process.env.SKIP_ENV_CHECK = "true";
+process.env.ENCRYPTION_SECRET = "12345678901234567890123456789012";
+process.env.NEXTAUTH_URL = "https://app.typebot.io";
+process.env.ADMIN_EMAIL = "admin@example.com";
+process.env.STRIPE_SECRET_KEY = "sk_test_local";
+process.env.META_SYSTEM_USER_TOKEN = "local-test-token";
+
+// SKIP_ENV_CHECK bypasses env transformations, including the ADMIN_EMAIL array.
+mock.module("@typebot.io/env", () => ({
+  env: { ...process.env, ADMIN_EMAIL: ["admin@example.com"] },
+}));
+
+const workspaceFindFirst = mock();
+const workspaceFindMany = mock();
+const workspaceUpdateMany = mock();
+const typebotFindFirst = mock();
+const resultCount = mock();
+const userCredentialsFindMany = mock();
+const getGoogleSpreadsheet = mock();
+const decrypt = mock();
+const decryptAndRefreshCredentialsData = mock();
+const downloadMedia = mock();
+const fetchItems = mock();
+
+mock.module("@typebot.io/prisma", () => ({
+  default: {
+    workspace: {
+      findFirst: workspaceFindFirst,
+      findMany: workspaceFindMany,
+      updateMany: workspaceUpdateMany,
+    },
+    typebot: { findFirst: typebotFindFirst },
+    result: { count: resultCount },
+    userCredentials: { findMany: userCredentialsFindMany },
+  },
+}));
+mock.module("@typebot.io/credentials/getGoogleSpreadsheet", () => ({
+  getGoogleSpreadsheet,
+}));
+mock.module("@typebot.io/credentials/decrypt", () => ({ decrypt }));
+mock.module("@typebot.io/credentials/decryptAndRefreshCredentials", () => ({
+  decryptAndRefreshCredentialsData,
+}));
+mock.module("@typebot.io/whatsapp/downloadMedia", () => ({ downloadMedia }));
+mock.module("@typebot.io/forge-repository/definitions", () => ({
+  forgedBlocks: { openai: {} },
+}));
+mock.module("@typebot.io/forge-repository/handlers", () => ({
+  forgedBlockHandlers: {
+    openai: [{ type: "fetcher", id: "test", fetch: fetchItems }],
+  },
+}));
+
+const { isReadWorkspaceFobidden: packageHelper } = await import(
+  "@typebot.io/workspaces/isReadWorkspaceFobidden"
+);
+const { isReadWorkspaceFobidden: builderHelper } = await import(
+  "../helpers/isReadWorkspaceFobidden"
+);
+const { handleGetWorkspace, inAppWorkspaceSchema } = await import(
+  "./handleGetWorkspace"
+);
+const { handleListWorkspaces } = await import("./handleListWorkspaces");
+const { handleListMembersInWorkspace } = await import(
+  "./handleListMembersInWorkspace"
+);
+const { handleListInvitationsInWorkspace } = await import(
+  "./handleListInvitationsInWorkspace"
+);
+const { handleListCredentials } = await import(
+  "../../credentials/api/handleListCredentials"
+);
+const { handleListCustomDomains } = await import(
+  "../../customDomains/api/handleListCustomDomains"
+);
+const { handleGetUsage } = await import(
+  "@typebot.io/billing/api/handleGetUsage"
+);
+const { handleGetSubscription } = await import(
+  "@typebot.io/billing/api/handleGetSubscription"
+);
+const { handleGetSheets } = await import(
+  "../../blocks/integrations/googleSheets/api/handleGetSheets"
+);
+const { handleGetSpreadsheetName } = await import(
+  "../../blocks/integrations/googleSheets/api/handleGetSpreadsheetName"
+);
+const { fetchSelectItems } = await import("../../forge/api/fetchSelectItems");
+const { handleGetWhatsAppMedia } = await import(
+  "@typebot.io/whatsapp/api/handleGetWhatsAppMedia"
+);
+const { handleGetWhatsAppMediaPreview } = await import(
+  "@typebot.io/whatsapp/api/handleGetWhatsAppMediaPreview"
+);
+
+const user = { id: "guest-id", email: "guest@example.com" };
+const context = { user };
+const input = { workspaceId: "workspace-id" };
+const sheetsInput = {
+  ...input,
+  credentialsId: "credential-id",
+  spreadsheetId: "sheet-id",
+};
+const workspace = {
+  id: input.workspaceId,
+  name: "Shared workspace",
+  icon: null,
+  plan: "FREE",
+  isSuspended: false,
+  isPastDue: false,
+  isVerified: true,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+  lastActivityAt: new Date(0),
+  stripeId: "cus_private",
+  settings: {},
+  customChatsLimit: 1234,
+  customSeatsLimit: 12,
+  chatsHardLimit: 4321,
+  members: [{ userId: user.id, role: WorkspaceRole.GUEST }],
+  invitations: [{ email: "private@example.com" }],
+  credentials: [
+    {
+      id: "credential-id",
+      type: "openai",
+      name: "Private credential",
+      data: "encrypted",
+      iv: "iv",
+    },
+  ],
+  customDomains: [{ name: "private.example.com", createdAt: new Date(0) }],
+  typebots: [{ id: "unshared-bot-id" }],
+};
+
+beforeEach(() => {
+  for (const fn of [
+    workspaceFindFirst,
+    workspaceFindMany,
+    workspaceUpdateMany,
+    typebotFindFirst,
+    resultCount,
+    userCredentialsFindMany,
+    getGoogleSpreadsheet,
+    decrypt,
+    decryptAndRefreshCredentialsData,
+    downloadMedia,
+    fetchItems,
+  ])
+    fn.mockReset();
+  workspaceFindFirst.mockResolvedValue(workspace);
+  resultCount.mockResolvedValue(7);
+  getGoogleSpreadsheet.mockResolvedValue({
+    type: "success",
+    spreadsheet: { title: "Test sheet", loadInfo: mock(), sheetCount: 0 },
+  });
+  decryptAndRefreshCredentialsData.mockResolvedValue({});
+  fetchItems.mockResolvedValue({ data: [{ label: "Test", value: "test" }] });
+});
+
+describe.each([
+  ["package", packageHelper],
+  ["builder", builderHelper],
+])("%s workspace read helper", (_name, helper) => {
+  it("rejects guests, outsiders and absent roles, even when another user is admin", () => {
+    expect(helper(workspace, user)).toBe(true);
+    expect(
+      helper(
+        { members: [{ userId: "another-user", role: WorkspaceRole.ADMIN }] },
+        user,
+      ),
+    ).toBe(true);
+    // Runtime callers with incomplete projections must fail closed.
+    // @ts-expect-error role is intentionally missing
+    expect(helper({ members: [{ userId: user.id }] }, user)).toBe(true);
+  });
+  it.each([
+    WorkspaceRole.ADMIN,
+    WorkspaceRole.MEMBER,
+  ])("preserves %s access", (role) => {
+    expect(helper({ members: [{ userId: user.id, role }] }, user)).toBe(false);
+  });
+  it("preserves instance administrator access", () => {
+    expect(
+      helper({ members: [] }, { id: "admin-id", email: "admin@example.com" }),
+    ).toBe(false);
+  });
+});
+
+const workspaceReads = [
+  {
+    name: "members",
+    read: () => handleListMembersInWorkspace({ input, context }),
+  },
+  {
+    name: "invitations",
+    read: () => handleListInvitationsInWorkspace({ input, context }),
+  },
+  {
+    name: "credentials",
+    read: () =>
+      handleListCredentials({
+        input: { ...input, scope: "workspace" },
+        context,
+      }),
+  },
+  { name: "domains", read: () => handleListCustomDomains({ input, context }) },
+  { name: "usage", read: () => handleGetUsage({ input, context }) },
+  {
+    name: "subscription",
+    read: () => handleGetSubscription({ input, context }),
+  },
+  {
+    name: "sheets",
+    read: () => handleGetSheets({ input: sheetsInput, context }),
+  },
+  {
+    name: "spreadsheet name",
+    read: () => handleGetSpreadsheetName({ input: sheetsInput, context }),
+  },
+  {
+    name: "Forge fetcher",
+    read: () =>
+      call(
+        fetchSelectItems,
+        {
+          ...input,
+          scope: "workspace",
+          integrationId: "openai",
+          fetcherId: "test",
+          options: { credentialsId: "credential-id" },
+        },
+        {
+          context: {
+            authenticate: mock(async () => ({
+              ...user,
+              groupTitlesAutoGeneration: null,
+            })),
+          },
+        },
+      ),
+  },
+];
+
+describe.each(workspaceReads)("$name workspace read", ({ read }) => {
+  it("denies guests before downstream data access", async () => {
+    await expect(read()).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(resultCount).not.toHaveBeenCalled();
+    expect(getGoogleSpreadsheet).not.toHaveBeenCalled();
+    expect(decryptAndRefreshCredentialsData).not.toHaveBeenCalled();
+    expect(fetchItems).not.toHaveBeenCalled();
+  });
+  it("denies outsiders", async () => {
+    workspaceFindFirst.mockResolvedValue({
+      ...workspace,
+      members: [{ userId: "other-id", role: WorkspaceRole.ADMIN }],
+    });
+    await expect(read()).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+  it.each([
+    WorkspaceRole.MEMBER,
+    WorkspaceRole.ADMIN,
+  ])("preserves %s access and selects roles", async (role) => {
+    workspaceFindFirst.mockResolvedValue({
+      ...workspace,
+      stripeId: null,
+      members: [{ userId: user.id, role }],
+    });
+    await expect(read()).resolves.toBeDefined();
+    const query = workspaceFindFirst.mock.calls[0]?.[0];
+    const members = query?.select?.members ?? query?.include?.members;
+    if (members !== true && !members?.include)
+      expect(members?.select).toMatchObject({ userId: true, role: true });
+  });
+});
+
+describe("guest workspace context", () => {
+  it("returns exactly the navigation and availability fields and serializes them", async () => {
+    const result = await handleGetWorkspace({ input, context });
+    expect(result).toEqual({
+      currentUserMode: "guest",
+      workspace: {
+        id: workspace.id,
+        name: workspace.name,
+        icon: null,
+        plan: "FREE",
+        isSuspended: false,
+        isPastDue: false,
+        isVerified: true,
+      },
+    });
+    expect(inAppWorkspaceSchema.parse(result.workspace)).toEqual(
+      result.workspace,
+    );
+    expect(workspaceUpdateMany).not.toHaveBeenCalled();
+  });
+  it("preserves full context and activity updates for members", async () => {
+    workspaceFindFirst.mockResolvedValue({
+      ...workspace,
+      members: [{ userId: user.id, role: WorkspaceRole.MEMBER }],
+    });
+    const result = await handleGetWorkspace({ input, context });
+    expect(result.currentUserMode).toBe("read");
+    expect(result.workspace).toMatchObject({
+      stripeId: "cus_private",
+      customSeatsLimit: 12,
+    });
+    expect(inAppWorkspaceSchema.parse(result.workspace)).toEqual(
+      result.workspace,
+    );
+    expect(workspaceUpdateMany).toHaveBeenCalledTimes(1);
+  });
+  it.each([
+    null,
+    { ...workspace, members: [] },
+  ])("does not update activity or return context for an unauthorized workspace", async (record) => {
+    workspaceFindFirst.mockResolvedValue(record);
+    await expect(handleGetWorkspace({ input, context })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+    expect(workspaceUpdateMany).not.toHaveBeenCalled();
+  });
+  it("retains the minimal workspace selector scoped to the caller", async () => {
+    workspaceFindMany.mockResolvedValue([
+      { id: workspace.id, name: workspace.name, icon: null, plan: "FREE" },
+    ]);
+    await expect(handleListWorkspaces({ context })).resolves.toHaveProperty(
+      "workspaces.0.id",
+      workspace.id,
+    );
+    expect(workspaceFindMany).toHaveBeenCalledWith({
+      where: { members: { some: { userId: user.id } } },
+      select: { name: true, id: true, icon: true, plan: true },
+    });
+  });
+  it("retains access to the guest's own credentials", async () => {
+    userCredentialsFindMany.mockResolvedValue([]);
+    await expect(
+      handleListCredentials({ input: { scope: "user" }, context }),
+    ).resolves.toEqual({ credentials: [] });
+    expect(workspaceFindFirst).not.toHaveBeenCalled();
+    expect(userCredentialsFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: user.id, type: undefined } }),
+    );
+  });
+});
+
+describe.each([
+  ["media", handleGetWhatsAppMedia],
+  ["preview", handleGetWhatsAppMediaPreview],
+])("WhatsApp %s", (_name, handle) => {
+  const mediaInput = { typebotId: "shared-bot-id", mediaId: "media-id.png" };
+  beforeEach(() => {
+    typebotFindFirst.mockResolvedValue({
+      whatsAppCredentialsId: "credential-id",
+      collaborators: [],
+      workspace,
+    });
+    decrypt.mockResolvedValue({
+      provider: "meta",
+      systemUserAccessToken: "test",
+      phoneNumberId: "test",
+    });
+    downloadMedia.mockResolvedValue({
+      file: new Uint8Array([1, 2]),
+      mimeType: "image/png",
+    });
+  });
+  it("denies a guest on an unshared bot before decrypting or downloading", async () => {
+    await expect(handle({ input: mediaInput, context })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+    expect(decrypt).not.toHaveBeenCalled();
+    expect(downloadMedia).not.toHaveBeenCalled();
+  });
+  it.each([
+    "READ",
+    "WRITE",
+  ])("preserves an explicitly shared bot (%s)", async (type) => {
+    typebotFindFirst.mockResolvedValue({
+      whatsAppCredentialsId: "credential-id",
+      collaborators: [{ userId: user.id, type }],
+      workspace,
+    });
+    const response = await handle({ input: mediaInput, context });
+    expect(response.body.size).toBe(2);
+    expect(downloadMedia).toHaveBeenCalledTimes(1);
+    expect(typebotFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: mediaInput.typebotId },
+        select: expect.objectContaining({
+          collaborators: {
+            where: { userId: user.id },
+            select: { userId: true },
+          },
+          workspace: {
+            select: expect.objectContaining({
+              isSuspended: true,
+              isPastDue: true,
+              members: { select: { userId: true, role: true } },
+            }),
+          },
+        }),
+      }),
+    );
+  });
+  it.each([
+    WorkspaceRole.MEMBER,
+    WorkspaceRole.ADMIN,
+  ])("preserves %s access", async (role) => {
+    typebotFindFirst.mockResolvedValue({
+      whatsAppCredentialsId: "credential-id",
+      collaborators: [],
+      workspace: { ...workspace, members: [{ userId: user.id, role }] },
+    });
+    await expect(handle({ input: mediaInput, context })).resolves.toBeDefined();
+  });
+  it("does not treat public bot sharing as media authorization", async () => {
+    typebotFindFirst.mockResolvedValue({
+      whatsAppCredentialsId: "credential-id",
+      collaborators: [],
+      workspace,
+    });
+    await expect(
+      handle({
+        input: mediaInput,
+        context: { user: { id: "outsider", email: "outsider@example.com" } },
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(typebotFindFirst.mock.calls[0]?.[0].select.settings).toBeUndefined();
+  });
+});

--- a/apps/builder/src/features/workspace/components/WorkspaceMembersList.tsx
+++ b/apps/builder/src/features/workspace/components/WorkspaceMembersList.tsx
@@ -214,7 +214,13 @@ const useSeatsLimit = () => {
     members.filter((member) => member.role !== WorkspaceRole.GUEST).length +
     invitations.length;
 
-  const seatsLimit = workspace ? getSeatsLimit(workspace) : undefined;
+  const seatsLimit =
+    workspace?.customSeatsLimit !== undefined
+      ? getSeatsLimit({
+          plan: workspace.plan,
+          customSeatsLimit: workspace.customSeatsLimit,
+        })
+      : undefined;
 
   return {
     membersCount,

--- a/apps/builder/src/features/workspace/helpers/isReadWorkspaceFobidden.ts
+++ b/apps/builder/src/features/workspace/helpers/isReadWorkspaceFobidden.ts
@@ -1,16 +1,1 @@
-import { env } from "@typebot.io/env";
-import type { Prisma } from "@typebot.io/prisma/types";
-
-export const isReadWorkspaceFobidden = (
-  workspace: {
-    members: Pick<Prisma.MemberInWorkspace, "userId">[];
-  },
-  user: Pick<Prisma.User, "email" | "id">,
-) => {
-  if (
-    env.ADMIN_EMAIL?.some((email) => email === user.email) ||
-    workspace.members.find((member) => member.userId === user.id)
-  )
-    return false;
-  return true;
-};
+export { isReadWorkspaceFobidden } from "@typebot.io/workspaces/isReadWorkspaceFobidden";

--- a/apps/docs/openapi/builder.json
+++ b/apps/docs/openapi/builder.json
@@ -27113,142 +27113,205 @@
                   "type": "object",
                   "properties": {
                     "workspace": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "createdAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "x-native-type": "date"
-                        },
-                        "updatedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "x-native-type": "date"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "icon": {
-                          "anyOf": [
-                            {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
                               "type": "string"
                             },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "plan": {
-                          "enum": [
-                            "FREE",
-                            "STARTER",
-                            "PRO",
-                            "LIFETIME",
-                            "OFFERED",
-                            "CUSTOM",
-                            "UNLIMITED",
-                            "ENTERPRISE"
-                          ],
-                          "type": "string"
-                        },
-                        "stripeId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "settings": {
-                          "anyOf": [
-                            {
-                              "type": "object"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "customChatsLimit": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "customSeatsLimit": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "isSuspended": {
-                          "type": "boolean"
-                        },
-                        "isPastDue": {
-                          "type": "boolean"
-                        },
-                        "isVerified": {
-                          "anyOf": [
-                            {
-                              "type": "boolean"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "chatsHardLimit": {
-                          "anyOf": [
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "lastActivityAt": {
-                          "anyOf": [
-                            {
+                            "createdAt": {
                               "type": "string",
                               "format": "date-time",
                               "x-native-type": "date"
                             },
-                            {
-                              "type": "null"
+                            "updatedAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "x-native-type": "date"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "icon": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "plan": {
+                              "enum": [
+                                "FREE",
+                                "STARTER",
+                                "PRO",
+                                "LIFETIME",
+                                "OFFERED",
+                                "CUSTOM",
+                                "UNLIMITED",
+                                "ENTERPRISE"
+                              ],
+                              "type": "string"
+                            },
+                            "stripeId": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "settings": {
+                              "anyOf": [
+                                {
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "customChatsLimit": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "customSeatsLimit": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "isSuspended": {
+                              "type": "boolean"
+                            },
+                            "isPastDue": {
+                              "type": "boolean"
+                            },
+                            "isVerified": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "chatsHardLimit": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "lastActivityAt": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "x-native-type": "date"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             }
+                          },
+                          "required": [
+                            "id",
+                            "createdAt",
+                            "updatedAt",
+                            "name",
+                            "icon",
+                            "plan",
+                            "stripeId",
+                            "settings",
+                            "customChatsLimit",
+                            "customSeatsLimit",
+                            "isSuspended",
+                            "isPastDue",
+                            "isVerified",
+                            "chatsHardLimit",
+                            "lastActivityAt"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "icon": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "plan": {
+                              "enum": [
+                                "FREE",
+                                "STARTER",
+                                "PRO",
+                                "LIFETIME",
+                                "OFFERED",
+                                "CUSTOM",
+                                "UNLIMITED",
+                                "ENTERPRISE"
+                              ],
+                              "type": "string"
+                            },
+                            "isSuspended": {
+                              "type": "boolean"
+                            },
+                            "isPastDue": {
+                              "type": "boolean"
+                            },
+                            "isVerified": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name",
+                            "icon",
+                            "plan",
+                            "isSuspended",
+                            "isPastDue",
+                            "isVerified"
                           ]
                         }
-                      },
-                      "required": [
-                        "id",
-                        "createdAt",
-                        "updatedAt",
-                        "name",
-                        "icon",
-                        "plan",
-                        "stripeId",
-                        "settings",
-                        "customChatsLimit",
-                        "customSeatsLimit",
-                        "isSuspended",
-                        "isPastDue",
-                        "isVerified",
-                        "chatsHardLimit",
-                        "lastActivityAt"
                       ]
                     },
                     "currentUserMode": {

--- a/packages/billing/src/api/handleGetSubscription.ts
+++ b/packages/billing/src/api/handleGetSubscription.ts
@@ -33,6 +33,7 @@ export const handleGetSubscription = async ({
       members: {
         select: {
           userId: true,
+          role: true,
         },
       },
     },

--- a/packages/billing/src/api/handleGetUsage.ts
+++ b/packages/billing/src/api/handleGetUsage.ts
@@ -33,6 +33,7 @@ export const handleGetUsage = async ({
       members: {
         select: {
           userId: true,
+          role: true,
         },
       },
       typebots: {

--- a/packages/whatsapp/src/api/handleGetWhatsAppMedia.ts
+++ b/packages/whatsapp/src/api/handleGetWhatsAppMedia.ts
@@ -2,9 +2,9 @@ import { ORPCError } from "@orpc/server";
 import { decrypt } from "@typebot.io/credentials/decrypt";
 import type { WhatsAppCredentials } from "@typebot.io/credentials/schemas";
 import prisma from "@typebot.io/prisma";
+import { isReadTypebotForbidden } from "@typebot.io/typebot/helpers/isReadTypebotForbidden";
 import type { User } from "@typebot.io/user/schemas";
 import { downloadMedia } from "@typebot.io/whatsapp/downloadMedia";
-import { isReadWorkspaceFobidden } from "@typebot.io/workspaces/isReadWorkspaceFobidden";
 import { z } from "zod";
 
 export const getWhatsAppMediaInputSchema = z.object({
@@ -25,8 +25,11 @@ export const handleGetWhatsAppMedia = async ({
     },
     select: {
       whatsAppCredentialsId: true,
+      collaborators: { where: { userId: user.id }, select: { userId: true } },
       workspace: {
         select: {
+          isSuspended: true,
+          isPastDue: true,
           credentials: {
             where: {
               type: "whatsApp",
@@ -35,6 +38,7 @@ export const handleGetWhatsAppMedia = async ({
           members: {
             select: {
               userId: true,
+              role: true,
             },
           },
         },
@@ -42,7 +46,7 @@ export const handleGetWhatsAppMedia = async ({
     },
   });
 
-  if (!typebot?.workspace || isReadWorkspaceFobidden(typebot.workspace, user))
+  if (!typebot || (await isReadTypebotForbidden(typebot, user)))
     throw new ORPCError("NOT_FOUND", { message: "Workspace not found" });
 
   const mediaIdWithoutExtension = mediaId.split(".")[0];

--- a/packages/whatsapp/src/api/handleGetWhatsAppMediaPreview.ts
+++ b/packages/whatsapp/src/api/handleGetWhatsAppMediaPreview.ts
@@ -1,9 +1,9 @@
 import { ORPCError } from "@orpc/server";
 import { env } from "@typebot.io/env";
 import prisma from "@typebot.io/prisma";
+import { isReadTypebotForbidden } from "@typebot.io/typebot/helpers/isReadTypebotForbidden";
 import type { User } from "@typebot.io/user/schemas";
 import { downloadMedia } from "@typebot.io/whatsapp/downloadMedia";
-import { isReadWorkspaceFobidden } from "@typebot.io/workspaces/isReadWorkspaceFobidden";
 import { z } from "zod";
 
 export const getWhatsAppMediaPreviewInputSchema = z.object({
@@ -29,11 +29,15 @@ export const handleGetWhatsAppMediaPreview = async ({
     },
     select: {
       whatsAppCredentialsId: true,
+      collaborators: { where: { userId: user.id }, select: { userId: true } },
       workspace: {
         select: {
+          isSuspended: true,
+          isPastDue: true,
           members: {
             select: {
               userId: true,
+              role: true,
             },
           },
         },
@@ -41,7 +45,7 @@ export const handleGetWhatsAppMediaPreview = async ({
     },
   });
 
-  if (!typebot?.workspace || isReadWorkspaceFobidden(typebot.workspace, user))
+  if (!typebot || (await isReadTypebotForbidden(typebot, user)))
     throw new ORPCError("NOT_FOUND", { message: "Workspace not found" });
 
   const mediaIdWithoutExtension = mediaId.split(".")[0];

--- a/packages/whatsapp/tsconfig.lib.json
+++ b/packages/whatsapp/tsconfig.lib.json
@@ -8,9 +8,6 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../workspaces/tsconfig.lib.json"
-    },
-    {
       "path": "../user/tsconfig.lib.json"
     },
     {

--- a/packages/workspaces/src/isReadWorkspaceFobidden.ts
+++ b/packages/workspaces/src/isReadWorkspaceFobidden.ts
@@ -3,13 +3,17 @@ import type { Prisma } from "@typebot.io/prisma/types";
 
 export const isReadWorkspaceFobidden = (
   workspace: {
-    members: Pick<Prisma.MemberInWorkspace, "userId">[];
+    members: Pick<Prisma.MemberInWorkspace, "userId" | "role">[];
   },
   user: Pick<Prisma.User, "email" | "id">,
 ) => {
   if (
     env.ADMIN_EMAIL?.some((email) => email === user.email) ||
-    workspace.members.find((member) => member.userId === user.id)
+    workspace.members.some(
+      (member) =>
+        member.userId === user.id &&
+        (member.role === "ADMIN" || member.role === "MEMBER"),
+    )
   )
     return false;
   return true;


### PR DESCRIPTION
## Summary

- Deny guest access to workspace members, invitations, credentials, domains, billing data, and integration-backed resources.
- Return only minimal navigation and availability data when loading a guest workspace.
- Preserve access for workspace members, administrators, and explicit typebot collaborators.
- Add authorization regression coverage and update the generated Builder OpenAPI schema.

## Testing

- Not run (test results were not provided).